### PR TITLE
sort mariadb gtid set

### DIFF
--- a/mysql/mariadb_gtid.go
+++ b/mysql/mariadb_gtid.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/siddontang/go-log/log"
-	"github.com/siddontang/go/hack"
 )
 
 // MariadbGTID represent mariadb gtid, [domain ID]-[server-id]-[sequence]
@@ -158,26 +157,13 @@ func (s *MariadbGTIDSet) Update(GTIDStr string) error {
 }
 
 func (s *MariadbGTIDSet) String() string {
-	if len(s.Sets) == 1 {
-		for _, set := range s.Sets {
-			return set.String()
-		}
-	}
-
-	var buf bytes.Buffer
 	sets := make([]string, 0, len(s.Sets))
 	for _, set := range s.Sets {
 		sets = append(sets, set.String())
 	}
 	sort.Strings(sets)
 
-	sep := ""
-	for _, set := range sets {
-		buf.WriteString(sep)
-		buf.WriteString(set)
-		sep = ","
-	}
-	return hack.String(buf.Bytes())
+	return strings.Join(sets, ",")
 }
 
 // Encode encodes mariadb gtid set

--- a/mysql/mariadb_gtid.go
+++ b/mysql/mariadb_gtid.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -157,7 +158,26 @@ func (s *MariadbGTIDSet) Update(GTIDStr string) error {
 }
 
 func (s *MariadbGTIDSet) String() string {
-	return hack.String(s.Encode())
+	if len(s.Sets) == 1 {
+		for _, set := range s.Sets {
+			return set.String()
+		}
+	}
+
+	var buf bytes.Buffer
+	sets := make([]string, 0, len(s.Sets))
+	for _, set := range s.Sets {
+		sets = append(sets, set.String())
+	}
+	sort.Strings(sets)
+
+	sep := ""
+	for _, set := range sets {
+		buf.WriteString(sep)
+		buf.WriteString(set)
+		sep = ","
+	}
+	return hack.String(buf.Bytes())
 }
 
 // Encode encodes mariadb gtid set

--- a/mysql/mariadb_gtid_test.go
+++ b/mysql/mariadb_gtid_test.go
@@ -234,10 +234,12 @@ func (t *mariaDBTestSuite) TestMariaDBGTIDSetClone(c *check.C) {
 }
 
 func (t *mariaDBTestSuite) TestMariaDBGTIDSetSortedString(c *check.C) {
-	gtidSetStr := "2-2-2,1-1-1,3-2-1"
-	sorted := "1-1-1,2-2-2,3-2-1"
+	cases := [][]string{{"", ""}, {"1-1-1", "1-1-1"},
+		{"2-2-2,1-1-1,3-2-1", "1-1-1,2-2-2,3-2-1"}}
 
-	gtidSet, err := ParseMariadbGTIDSet(gtidSetStr)
-	c.Assert(err, check.IsNil)
-	c.Assert(gtidSet.String(), check.Equals, sorted)
+	for _, strs := range cases {
+		gtidSet, err := ParseMariadbGTIDSet(strs[0])
+		c.Assert(err, check.IsNil)
+		c.Assert(gtidSet.String(), check.Equals, strs[1])
+	}
 }

--- a/mysql/mariadb_gtid_test.go
+++ b/mysql/mariadb_gtid_test.go
@@ -232,3 +232,12 @@ func (t *mariaDBTestSuite) TestMariaDBGTIDSetClone(c *check.C) {
 		c.Assert(gtidSet.Clone(), check.DeepEquals, gtidSet)
 	}
 }
+
+func (t *mariaDBTestSuite) TestMariaDBGTIDSetSortedString(c *check.C) {
+	gtidSetStr := "2-2-2,1-1-1,3-2-1"
+	sorted := "1-1-1,2-2-2,3-2-1"
+
+	gtidSet, err := ParseMariadbGTIDSet(gtidSetStr)
+	c.Assert(err, check.IsNil)
+	c.Assert(gtidSet.String(), check.Equals, sorted)
+}


### PR DESCRIPTION
当 mariadb gtid中包含多个 server id时，由于 Sets是一个map结构，输出 set的顺序随机，导致最终输出的 gtid字符串内容不同。本 PR，在输出前对内容进行排序后输出，保证输出结果的一致。