### PR TITLE
fix: init Resultset in Result when handling ddl statement

### DIFF
--- a/client/resp.go
+++ b/client/resp.go
@@ -39,7 +39,7 @@ func (c *Conn) handleOKPacket(data []byte) (*Result, error) {
 	var n int
 	var pos = 1
 
-	r := new(Result)
+	r := &Result{Resultset: &Resultset{}}
 
 	r.AffectedRows, _, n = LengthEncodedInt(data[pos:])
 	pos += n


### PR DESCRIPTION
this PR is to fix issue #577 
as I only use client module of this repository and didn't use other modules like replication, server...etc, I'm not sure if this fix may impact the behavior of those modules, need some to review this.