### PR TITLE
expose capability and charset of connections to server

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -17,6 +17,7 @@ type Conn struct {
 
 	serverConf     *Server
 	capability     uint32
+	charset        uint8
 	authPluginName string
 	connectionID   uint32
 	status         uint16
@@ -131,6 +132,14 @@ func (c *Conn) Closed() bool {
 
 func (c *Conn) GetUser() string {
 	return c.user
+}
+
+func (c *Conn) Capability() uint32 {
+	return c.capability
+}
+
+func (c *Conn) Charset() uint8 {
+	return c.charset
 }
 
 func (c *Conn) ConnectionID() uint32 {

--- a/server/handshake_resp.go
+++ b/server/handshake_resp.go
@@ -50,6 +50,10 @@ func (c *Conn) readFirstPart() ([]byte, int, error) {
 		return nil, 0, err
 	}
 
+	return c.decodeFirstPart(data)
+}
+
+func (c *Conn) decodeFirstPart(data []byte) ([]byte, int, error) {
 	pos := 0
 
 	// check CLIENT_PROTOCOL_41
@@ -67,8 +71,8 @@ func (c *Conn) readFirstPart() ([]byte, int, error) {
 	//skip max packet size
 	pos += 4
 
-	//charset, skip, if you want to use another charset, use set names
-	//c.collation = CollationId(data[pos])
+	// connection's default character set as defined
+	c.charset = data[pos]
 	pos++
 
 	//skip reserved 23[00]

--- a/server/handshake_resp_test.go
+++ b/server/handshake_resp_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
@@ -26,5 +27,28 @@ func TestReadAuthData(t *testing.T) {
 	}
 	if readBytes != len(data)-1 {
 		t.Fatalf("expected %d read bytes, got %d", len(data)-1, readBytes)
+	}
+}
+
+func TestDecodeFirstPart(t *testing.T) {
+	data := []byte{141, 174, 255, 1, 0, 0, 0, 1, 8}
+
+	c := &Conn{}
+
+	result, pos, err := c.decodeFirstPart(data)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if !bytes.Equal(result, data) {
+		t.Fatal("expected same data, got something else")
+	}
+	if pos != 32 {
+		t.Fatalf("unexpected pos, got %d", pos)
+	}
+	if c.capability != 33533581 {
+		t.Fatalf("unexpected capability, got %d", c.capability)
+	}
+	if c.charset != 8 {
+		t.Fatalf("unexpected capability, got %d", c.capability)
 	}
 }


### PR DESCRIPTION
For a project of mine I need to be able to read the capabilities and default charset of a client connecting to my server. This PR exposes those 2 properties. Charset perhaps used to be decoded before into a type called `CollationId` but this doesn't exist (anymore) and I'm perfectly fine with the collation ID as an uint8.

I also took the liberty to refactor `readFirstPacket` a bit so it is easier to test its behaviour