### PR TITLE
return EOF response on COM_SET_OPTION commands

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -125,6 +125,12 @@ func (c *Conn) dispatch(data []byte) interface{} {
 		} else {
 			return r
 		}
+	case COM_SET_OPTION:
+		if err := c.h.HandleOtherCommand(cmd, data); err != nil {
+			return err
+		}
+
+		return eofResponse{}
 	default:
 		return c.h.HandleOtherCommand(cmd, data)
 	}

--- a/server/resp.go
+++ b/server/resp.go
@@ -170,11 +170,14 @@ func (c *Conn) writeFieldList(fs []*Field) error {
 }
 
 type noResponse struct{}
+type eofResponse struct{}
 
 func (c *Conn) writeValue(value interface{}) error {
 	switch v := value.(type) {
 	case noResponse:
 		return nil
+	case eofResponse:
+		return c.writeEOF()
 	case error:
 		return c.writeError(v)
 	case nil:


### PR DESCRIPTION
I'm implementing a server that needs to respect the `CLIENT_MULTI_STATEMENTS` capability and the `MYSQL_OPTION_MULTI_STATEMENTS_ON` and `_OFF` options that can be set through `COM_SET_OPTION`. According to the [docs](https://dev.mysql.com/doc/internals/en/com-set-option.html) it is supposed to return EOF on success so I added a backwards compatible way of handling these commands properly.