### PR TITLE
chain results when server indicates more results are coming

### DIFF
--- a/mysql/result.go
+++ b/mysql/result.go
@@ -7,6 +7,8 @@ type Result struct {
 	AffectedRows uint64
 
 	*Resultset
+
+	Next *Result
 }
 
 type Executer interface {
@@ -18,4 +20,24 @@ func (r *Result) Close() {
 		r.Resultset.returnToPool()
 		r.Resultset = nil
 	}
+}
+
+func (r *Result) lastChained() (int, *Result) {
+	count := 1
+	var lastRes *Result
+	for lastRes = r; lastRes.Next != nil; lastRes = lastRes.Next {
+		count++
+	}
+
+	return count, lastRes
+}
+
+func (r *Result) ChainResult(cr *Result) {
+	_, lastRes := r.lastChained()
+	lastRes.Next = cr
+}
+
+func (r *Result) Length() int {
+	n, _ := r.lastChained()
+	return n
 }

--- a/mysql/result_test.go
+++ b/mysql/result_test.go
@@ -1,0 +1,30 @@
+package mysql
+
+import (
+	"github.com/pingcap/check"
+)
+
+type resultTestSuite struct {
+}
+
+var _ = check.Suite(&resultTestSuite{})
+
+func (t *resultTestSuite) TestLastChained(c *check.C) {
+	r1 := &Result{}
+	n, last := r1.lastChained()
+	c.Assert(last == r1, check.IsTrue)
+	c.Assert(n, check.Equals, 1)
+
+	r2 := &Result{}
+	r1.ChainResult(r2)
+	n, last = r1.lastChained()
+	c.Assert(last == r2, check.IsTrue)
+	c.Assert(n, check.Equals, 2)
+
+	n, last = r2.lastChained()
+	c.Assert(last == r2, check.IsTrue)
+	c.Assert(n, check.Equals, 1)
+
+	c.Assert(r1.Length(), check.Equals, 2)
+	c.Assert(r2.Length(), check.Equals, 1)
+}

--- a/server/caching_sha2_cache_test.go
+++ b/server/caching_sha2_cache_test.go
@@ -192,16 +192,16 @@ func (h *testCacheHandler) handleQuery(query string, binary bool) (*mysql.Result
 		if err != nil {
 			return nil, errors.Trace(err)
 		} else {
-			return &mysql.Result{0, 0, 0, r}, nil
+			return &mysql.Result{0, 0, 0, r, nil}, nil
 		}
 	case "insert":
-		return &mysql.Result{0, 1, 0, nil}, nil
+		return &mysql.Result{0, 1, 0, nil, nil}, nil
 	case "delete":
-		return &mysql.Result{0, 0, 1, nil}, nil
+		return &mysql.Result{0, 0, 1, nil, nil}, nil
 	case "update":
-		return &mysql.Result{0, 0, 1, nil}, nil
+		return &mysql.Result{0, 0, 1, nil, nil}, nil
 	case "replace":
-		return &mysql.Result{0, 0, 1, nil}, nil
+		return &mysql.Result{0, 0, 1, nil, nil}, nil
 	default:
 		return nil, fmt.Errorf("invalid query %s", query)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -239,16 +239,16 @@ func (h *testHandler) handleQuery(query string, binary bool) (*mysql.Result, err
 		if err != nil {
 			return nil, errors.Trace(err)
 		} else {
-			return &mysql.Result{0, 0, 0, r}, nil
+			return &mysql.Result{0, 0, 0, r, nil}, nil
 		}
 	case "insert":
-		return &mysql.Result{0, 1, 0, nil}, nil
+		return &mysql.Result{0, 1, 0, nil, nil}, nil
 	case "delete":
-		return &mysql.Result{0, 0, 1, nil}, nil
+		return &mysql.Result{0, 0, 1, nil, nil}, nil
 	case "update":
-		return &mysql.Result{0, 0, 1, nil}, nil
+		return &mysql.Result{0, 0, 1, nil, nil}, nil
 	case "replace":
-		return &mysql.Result{0, 0, 1, nil}, nil
+		return &mysql.Result{0, 0, 1, nil, nil}, nil
 	default:
 		return nil, fmt.Errorf("invalid query %s", query)
 	}


### PR DESCRIPTION
This is my implementation of what https://github.com/go-mysql-org/go-mysql/pull/524 initially tries to accomplish, but in this case it actually chains the results (not resultsets) recursively when it reads them in the client code.