### PR TITLE
fixed access denied error messages

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -107,11 +107,11 @@ func (c *Conn) handshake() error {
 
 	if err := c.readHandshakeResponse(); err != nil {
 		if errors.Is(err, ErrAccessDenied) {
-			usingPasswd := ER_YES
+			var usingPasswd uint16 = ER_YES
 			if errors.Is(err, ErrAccessDeniedNoPassword) {
 				usingPasswd = ER_NO
 			}
-			err = NewDefaultError(ER_ACCESS_DENIED_ERROR, c.user, c.RemoteAddr().String(), usingPasswd)
+			err = NewDefaultError(ER_ACCESS_DENIED_ERROR, c.user, c.RemoteAddr().String(), MySQLErrName[usingPasswd])
 		}
 		_ = c.writeError(err)
 		return err

--- a/server/handshake_resp.go
+++ b/server/handshake_resp.go
@@ -148,7 +148,7 @@ func (c *Conn) readAuthData(data []byte, pos int) (auth []byte, authLen int, new
 		}
 		if isNULL {
 			// no auth length and no auth data, just \NUL, considered invalid auth data, and reject connection as MySQL does
-			return nil, 0, 0, NewDefaultError(ER_ACCESS_DENIED_ERROR, c.RemoteAddr().String(), c.user, MySQLErrName[ER_NO])
+			return nil, 0, 0, NewDefaultError(ER_ACCESS_DENIED_ERROR, c.user, c.RemoteAddr().String(), MySQLErrName[ER_NO])
 		}
 		auth = authData
 		authLen = readBytes

--- a/server/handshake_resp.go
+++ b/server/handshake_resp.go
@@ -148,7 +148,7 @@ func (c *Conn) readAuthData(data []byte, pos int) (auth []byte, authLen int, new
 		}
 		if isNULL {
 			// no auth length and no auth data, just \NUL, considered invalid auth data, and reject connection as MySQL does
-			return nil, 0, 0, NewDefaultError(ER_ACCESS_DENIED_ERROR, c.RemoteAddr().String(), c.user, ER_NO)
+			return nil, 0, 0, NewDefaultError(ER_ACCESS_DENIED_ERROR, c.RemoteAddr().String(), c.user, MySQLErrName[ER_NO])
 		}
 		auth = authData
 		authLen = readBytes


### PR DESCRIPTION
Not sure what went wrong trying to rebase #592 so here is a new attempt:

---

When trying to reproduce my issue as I describe in #578 I came across an omission I made in #589: I directly pass the error code to `NewDefaultError` instead of the error message corresponding to that code. My apologies for the poor testing.

Also, I noticed that in a different case, the formatting of the user/address was the wrong way around in the access denied error. This gave 
```
ERROR 1045 (28000): Access denied for user '127.0.0.1:51221'@'root' (using password: NO)
```
and now it correctly gives:
```
ERROR 1045 (28000): Access denied for user 'root'@'127.0.0.1:51259' (using password: NO)
```