### PR TITLE
Fix error when trying to check binlog settings

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -386,7 +386,7 @@ func (c *Canal) CheckBinlogRowImage(image string) error {
 	// need to check MySQL binlog row image? full, minimal or noblob?
 	// now only log
 	if c.cfg.Flavor == mysql.MySQLFlavor {
-		if res, err := c.Execute(`SHOW GLOBAL VARIABLES LIKE "binlog_row_image"`); err != nil {
+		if res, err := c.Execute(`SHOW GLOBAL VARIABLES LIKE 'binlog_row_image'`); err != nil {
 			return errors.Trace(err)
 		} else {
 			// MySQL has binlog row image from 5.6, so older will return empty
@@ -401,7 +401,7 @@ func (c *Canal) CheckBinlogRowImage(image string) error {
 }
 
 func (c *Canal) checkBinlogRowFormat() error {
-	res, err := c.Execute(`SHOW GLOBAL VARIABLES LIKE "binlog_format";`)
+	res, err := c.Execute(`SHOW GLOBAL VARIABLES LIKE 'binlog_format';`)
 	if err != nil {
 		return errors.Trace(err)
 	} else if f, _ := res.GetString(0, 1); f != "ROW" {


### PR DESCRIPTION
When sql_mode contains ANSI_QUOTES mode the " character can be used to enclose identifiers just like `, causing the error below when queries in lines 389 and 404 run.

```
Error Code: 1064. You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '"binlog_format"' at line 1
```