### PR TITLE
Fix ast.TruncateTableStmt node name assignment

### DIFF
--- a/canal/sync.go
+++ b/canal/sync.go
@@ -223,7 +223,7 @@ func parseStmt(stmt ast.StmtNode) (ns []*node) {
 	case *ast.TruncateTableStmt:
 		n := &node{
 			db:    t.Table.Schema.String(),
-			table: t.Table.Schema.String(),
+			table: t.Table.Name.String(),
 		}
 		ns = []*node{n}
 	}


### PR DESCRIPTION
Fix case for ast.TruncateTableStmt to assign Name instead of Schema to node.table otherwise OnTableChanged will be passed empty table value.