### PR TITLE
fix(server):java jdbc connect "Access denied for user 'root'@'127.0.0…

### DIFF
--- a/mysql/util.go
+++ b/mysql/util.go
@@ -8,8 +8,10 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	mrand "math/rand"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/siddontang/go/hack"
@@ -107,18 +109,11 @@ func AppendLengthEncodedInteger(b []byte, n uint64) []byte {
 
 func RandomBuf(size int) ([]byte, error) {
 	buf := make([]byte, size)
-
-	if _, err := io.ReadFull(rand.Reader, buf); err != nil {
-		return nil, errors.Trace(err)
+	mrand.Seed(time.Now().UTC().UnixNano())
+	min, max := 30, 127
+	for i := 0; i < size; i++ {
+		buf[i] = byte(min + mrand.Intn(max-min))
 	}
-
-	// avoid to generate '\0'
-	for i, b := range buf {
-		if b == 0 {
-			buf[i] = '0'
-		}
-	}
-
 	return buf, nil
 }
 


### PR DESCRIPTION
Fixes #531 

I found that when java connects to the server through the jdbc library, there will be:
`error: Access denied for user'root'@'127.0.0.1:3306' (using password: Yes` 

After capturing the packet and comparing it with kingshard, I found that salt must be in the range of ascii