### PR TITLE
packet: memory optimization for reading network packet

### DIFF
--- a/packet/conn.go
+++ b/packet/conn.go
@@ -3,15 +3,14 @@ package packet
 import (
 	"bufio"
 	"bytes"
-	"io"
-	"net"
-	"sync"
-
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
 	"crypto/x509"
 	"encoding/pem"
+	"io"
+	"net"
+	"sync"
 
 	. "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/utils"
@@ -97,10 +96,25 @@ func (c *Conn) ReadPacketReuseMem(dst []byte) ([]byte, error) {
 
 	if err := c.ReadPacketTo(buf); err != nil {
 		return nil, errors.Trace(err)
-	} else {
-		result := append(dst, buf.Bytes()...)
-		return result, nil
 	}
+
+	readBytes := buf.Bytes()
+	readSize := len(readBytes) + len(dst)
+	result := make([]byte, 0, readSize)
+	if len(dst) > 0 {
+		result = append(result, dst...)
+		result = append(result, readBytes...)
+
+	} else {
+		if readSize <= utils.TooBigBlockSize {
+			result = append(result, readBytes...)
+		} else {
+			// if read block is big, use read block as result and do not cache buf any more
+			result = readBytes
+			buf = nil
+		}
+	}
+	return result, nil
 }
 
 func (c *Conn) copyN(dst io.Writer, src io.Reader, n int64) (written int64, err error) {

--- a/packet/conn.go
+++ b/packet/conn.go
@@ -107,13 +107,11 @@ func (c *Conn) ReadPacketReuseMem(dst []byte) ([]byte, error) {
 		if readSize > utils.TooBigBlockSize {
 			buf = nil
 		}
-
 	} else {
 		if readSize > utils.TooBigBlockSize {
 			// if read block is big, use read block as result and do not cache buf any more
 			result = readBytes
 			buf = nil
-
 		} else {
 			result = append(dst, readBytes...)
 		}

--- a/utils/bytes_buffer_pool.go
+++ b/utils/bytes_buffer_pool.go
@@ -5,6 +5,10 @@ import (
 	"sync"
 )
 
+const (
+	TooBigBlockSize = 1024 * 1024 * 4
+)
+
 var (
 	bytesBufferPool = sync.Pool{
 		New: func() interface{} {
@@ -27,6 +31,10 @@ func BytesBufferGet() (data *bytes.Buffer) {
 }
 
 func BytesBufferPut(data *bytes.Buffer) {
+	if data == nil || len(data.Bytes()) > TooBigBlockSize {
+		return
+	}
+
 	select {
 	case bytesBufferChan <- data:
 	default:


### PR DESCRIPTION
### What problem does this PR solve?
读取网络包遇到大的 event之后，会导致 buffer冲的很大，之后一直没法释放。从而导致整个程序的内存占用居高不下。

### What is changed and how it works?
这个PR对这块逻辑做了优化，只缓存比较小的缓存块，避免了这种情况。

--
The buffer will be increased and can't be released when the packet is very big, thus the memory consumption keeps high. 
This PR tries to avoid it.
