### PR TITLE
Set slave_uuid and replica_uuid

### DIFF
--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -10,11 +10,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-mysql-org/go-mysql/client"
-	. "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/errors"
 	uuid "github.com/satori/go.uuid"
 	"github.com/siddontang/go-log/log"
+
+	"github.com/go-mysql-org/go-mysql/client"
+	. "github.com/go-mysql-org/go-mysql/mysql"
 )
 
 var (
@@ -308,6 +309,12 @@ func (b *BinlogSyncer) registerSlave() error {
 	}
 
 	if _, err = b.c.ReadOKPacket(); err != nil {
+		return errors.Trace(err)
+	}
+
+	serverUUID := uuid.NewV1()
+	if _, err = b.c.Execute(fmt.Sprintf("SET @slave_uuid = '%s', @replica_uuid = '%s'", serverUUID, serverUUID)); err != nil {
+		log.Errorf("failed to set @slave_uuid = '%s', err: %v", serverUUID, err)
 		return errors.Trace(err)
 	}
 

--- a/replication/replication_test.go
+++ b/replication/replication_test.go
@@ -10,10 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-mysql-org/go-mysql/client"
-	"github.com/go-mysql-org/go-mysql/mysql"
 	. "github.com/pingcap/check"
 	uuid "github.com/satori/go.uuid"
+
+	"github.com/go-mysql-org/go-mysql/client"
+	"github.com/go-mysql-org/go-mysql/mysql"
 )
 
 // Use docker mysql to test, mysql is 3306, mariadb is 3316
@@ -37,7 +38,6 @@ type testSyncerSuite struct {
 var _ = Suite(&testSyncerSuite{})
 
 func (t *testSyncerSuite) SetUpSuite(c *C) {
-
 }
 
 func (t *testSyncerSuite) TearDownSuite(c *C) {
@@ -274,8 +274,8 @@ func (t *testSyncerSuite) setupTest(c *C, flavor string) {
 		c.Skip(err.Error())
 	}
 
-	// _, err = t.c.Execute("CREATE DATABASE IF NOT EXISTS test")
-	// c.Assert(err, IsNil)
+	_, err = t.c.Execute("CREATE DATABASE IF NOT EXISTS test")
+	c.Assert(err, IsNil)
 
 	_, err = t.c.Execute("USE test")
 	c.Assert(err, IsNil)
@@ -306,6 +306,12 @@ func (t *testSyncerSuite) testPositionSync(c *C) {
 
 	s, err := t.b.StartSync(mysql.Position{Name: binFile, Pos: uint32(binPos)})
 	c.Assert(err, IsNil)
+
+	// check we have set Slave_UUID
+	r, err = t.c.Execute("SHOW SLAVE HOSTS")
+	c.Assert(err, IsNil)
+	slaveUUID, _ := r.GetString(0, 4)
+	c.Assert(slaveUUID, HasLen, 36)
 
 	// Test re-sync.
 	time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
close https://github.com/go-mysql-org/go-mysql/issues/618

~I'll see how to add a test in this repo soon.~ For now the manually test result is 

with this PR
```
MySQL [(none)]> show slave hosts;
+-----------+----------------------+------+-----------+--------------------------------------+
| Server_id | Host                 | Port | Master_id | Slave_UUID                           |
+-----------+----------------------+------+-----------+--------------------------------------+
|       101 | lance6716-nuc10i7fnh | 3306 |         1 | 53cd72fc-5efc-11ec-b783-1c697a65dfdc |
+-----------+----------------------+------+-----------+--------------------------------------+
```

without this PR
```
MySQL [(none)]> show slave hosts;
ERROR 2027 (HY000): Malformed packet
```