### PR TITLE
Add MysqlGTIDSet.Add() and Minus() methods

### DIFF
--- a/mysql/mysql_gtid.go
+++ b/mysql/mysql_gtid.go
@@ -275,8 +275,7 @@ func (s *UUIDSet) MinusInterval(in IntervalSlice) {
 		}
 	}
 
-	s.Intervals = n
-	s.Intervals = s.Intervals.Normalize()
+	s.Intervals = n.Normalize()
 }
 
 func (s *UUIDSet) String() string {

--- a/mysql/mysql_gtid.go
+++ b/mysql/mysql_gtid.go
@@ -227,6 +227,58 @@ func (s *UUIDSet) AddInterval(in IntervalSlice) {
 	s.Intervals = s.Intervals.Normalize()
 }
 
+func (s *UUIDSet) MinusInterval(in IntervalSlice) {
+	var n IntervalSlice
+	in = in.Normalize()
+
+	i, j := 0, 0
+	var minuend Interval
+	var subtrahend Interval
+	for j < len(in) && i < len(s.Intervals) {
+		if minuend.Stop != s.Intervals[i].Stop { // `i` changed?
+			minuend = s.Intervals[i]
+		}
+		subtrahend = in[j]
+
+		if minuend.Stop <= subtrahend.Start {
+			// no overlapping
+			n = append(n, minuend)
+			i++
+		} else if minuend.Start >= subtrahend.Stop {
+			// no overlapping
+			j++
+		} else {
+			if minuend.Start < subtrahend.Start && minuend.Stop < subtrahend.Stop {
+				n = append(n, Interval{minuend.Start, subtrahend.Start})
+				i++
+			} else if minuend.Start > subtrahend.Start && minuend.Stop > subtrahend.Stop {
+				minuend = Interval{subtrahend.Stop, minuend.Stop}
+				j++
+			} else if minuend.Start >= subtrahend.Start && minuend.Stop <= subtrahend.Stop {
+				// minuend is completely removed
+				i++
+			} else {
+				n = append(n, Interval{minuend.Start, subtrahend.Start})
+				minuend = Interval{subtrahend.Stop, minuend.Stop}
+				j++
+			}
+		}
+	}
+
+	lastSub := in[len(in)-1]
+	for ; i < len(s.Intervals); i++ {
+		minuend = s.Intervals[i]
+		if minuend.Start < lastSub.Stop {
+			n = append(n, Interval{lastSub.Stop, minuend.Stop})
+		} else {
+			n = append(n, s.Intervals[i])
+		}
+	}
+
+	s.Intervals = n
+	s.Intervals = s.Intervals.Normalize()
+}
+
 func (s *UUIDSet) String() string {
 	return hack.String(s.Bytes())
 }
@@ -304,6 +356,8 @@ type MysqlGTIDSet struct {
 	Sets map[string]*UUIDSet
 }
 
+var _ GTIDSet = &MysqlGTIDSet{}
+
 func ParseMysqlGTIDSet(str string) (GTIDSet, error) {
 	s := new(MysqlGTIDSet)
 	s.Sets = make(map[string]*UUIDSet)
@@ -362,6 +416,20 @@ func (s *MysqlGTIDSet) AddSet(set *UUIDSet) {
 	}
 }
 
+func (s *MysqlGTIDSet) MinusSet(set *UUIDSet) {
+	if set == nil {
+		return
+	}
+	sid := set.SID.String()
+	uuidSet, ok := s.Sets[sid]
+	if ok {
+		uuidSet.MinusInterval(set.Intervals)
+		if uuidSet.Intervals == nil {
+			delete(s.Sets, sid)
+		}
+	}
+}
+
 func (s *MysqlGTIDSet) Update(GTIDStr string) error {
 	gtidSet, err := ParseMysqlGTIDSet(GTIDStr)
 	if err != nil {
@@ -369,6 +437,20 @@ func (s *MysqlGTIDSet) Update(GTIDStr string) error {
 	}
 	for _, uuidSet := range gtidSet.(*MysqlGTIDSet).Sets {
 		s.AddSet(uuidSet)
+	}
+	return nil
+}
+
+func (s *MysqlGTIDSet) Add(addend MysqlGTIDSet) error {
+	for _, uuidSet := range addend.Sets {
+		s.AddSet(uuidSet)
+	}
+	return nil
+}
+
+func (s *MysqlGTIDSet) Minus(subtrahend MysqlGTIDSet) error {
+	for _, uuidSet := range subtrahend.Sets {
+		s.MinusSet(uuidSet)
 	}
 	return nil
 }

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -150,13 +150,16 @@ func (t *mysqlTestSuite) TestMysqlGTIDAdd(c *check.C) {
 		// simple cases works:
 		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:23", "3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23:28-57"},
 		// summ is associative operation
-		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:23", "3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23:28-57"},
+		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23:28-57"},
+		// merge intervals:
+		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:23-27", "3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23-57"},
 	}
 
 	for _, tc := range testCases {
 		m1 := t.mysqlGTIDfromString(c, tc.left)
 		m2 := t.mysqlGTIDfromString(c, tc.right)
-		m1.Add(m2)
+		err := m1.Add(m2)
+		c.Assert(err, check.IsNil)
 		c.Assert(
 			fmt.Sprintf("%s + %s = %s", tc.left, tc.right, strings.ToUpper(m1.String())),
 			check.Equals,
@@ -182,7 +185,8 @@ func (t *mysqlTestSuite) TestMysqlGTIDMinus(c *check.C) {
 	for _, tc := range testCases {
 		m1 := t.mysqlGTIDfromString(c, tc.left)
 		m2 := t.mysqlGTIDfromString(c, tc.right)
-		m1.Minus(m2)
+		err := m1.Minus(m2)
+		c.Assert(err, check.IsNil)
 		c.Assert(
 			fmt.Sprintf("%s - %s = %s", tc.left, tc.right, strings.ToUpper(m1.String())),
 			check.Equals,


### PR DESCRIPTION
Add MysqlGTIDSet.Add() and Minus() methods, so it will help users to estimate GTID sets that are stored in binlog file.