### PR TITLE
enabled govet

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,9 +15,9 @@ linters:
     - nakedret
     - unconvert
     - whitespace
+    - govet
     # ToDo:
     #- gosimple
-    #- govet
     #- ineffassign
     #- gocritic
     #- golint
@@ -26,3 +26,10 @@ linters-settings:
     allow-unused: false
     allow-leading-space: false
     require-specific: true
+
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment
+      - lostcancel
+      - shadow

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -181,8 +181,6 @@ func (c *Canal) runSyncBinlog() error {
 			}
 		}
 	}
-
-	return nil
 }
 
 type node struct {
@@ -298,8 +296,6 @@ func (c *Canal) WaitUntilPos(pos mysql.Position, timeout time.Duration) error {
 			}
 		}
 	}
-
-	return nil
 }
 
 func (c *Canal) GetMasterPos() (mysql.Position, error) {

--- a/client/conn.go
+++ b/client/conn.go
@@ -263,24 +263,23 @@ func (c *Conn) FieldList(table string, wildcard string) ([]*Field, error) {
 	var f *Field
 	if data[0] == ERR_HEADER {
 		return nil, c.handleErrorPacket(data)
-	} else {
-		for {
-			if data, err = c.ReadPacket(); err != nil {
-				return nil, errors.Trace(err)
-			}
-
-			// EOF Packet
-			if c.isEOFPacket(data) {
-				return fs, nil
-			}
-
-			if f, err = FieldData(data).Parse(); err != nil {
-				return nil, errors.Trace(err)
-			}
-			fs = append(fs, f)
-		}
 	}
-	return nil, fmt.Errorf("field list error")
+
+	for {
+		if data, err = c.ReadPacket(); err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		// EOF Packet
+		if c.isEOFPacket(data) {
+			return fs, nil
+		}
+
+		if f, err = FieldData(data).Parse(); err != nil {
+			return nil, errors.Trace(err)
+		}
+		fs = append(fs, f)
+	}
 }
 
 func (c *Conn) SetAutoCommit() error {

--- a/client/resp.go
+++ b/client/resp.go
@@ -29,7 +29,6 @@ func (c *Conn) readUntilEOF() (err error) {
 			return
 		}
 	}
-	return
 }
 
 func (c *Conn) isEOFPacket(data []byte) bool {

--- a/replication/backup.go
+++ b/replication/backup.go
@@ -92,6 +92,4 @@ func (b *BinlogSyncer) StartBackup(backupDir string, p Position, timeout time.Du
 			return errors.Trace(io.ErrShortWrite)
 		}
 	}
-
-	return nil
 }

--- a/replication/json_binary.go
+++ b/replication/json_binary.go
@@ -391,8 +391,6 @@ func (d *jsonBinaryDecoder) decodeOpaque(data []byte) interface{} {
 	default:
 		return hack.String(data)
 	}
-
-	return nil
 }
 
 func (d *jsonBinaryDecoder) decodeDecimal(data []byte) interface{} {

--- a/server/caching_sha2_cache_test.go
+++ b/server/caching_sha2_cache_test.go
@@ -205,8 +205,6 @@ func (h *testCacheHandler) handleQuery(query string, binary bool) (*mysql.Result
 	default:
 		return nil, fmt.Errorf("invalid query %s", query)
 	}
-
-	return nil, nil
 }
 
 func (h *testCacheHandler) HandleQuery(query string) (*mysql.Result, error) {

--- a/server/caching_sha2_cache_test.go
+++ b/server/caching_sha2_cache_test.go
@@ -192,16 +192,30 @@ func (h *testCacheHandler) handleQuery(query string, binary bool) (*mysql.Result
 		if err != nil {
 			return nil, errors.Trace(err)
 		} else {
-			return &mysql.Result{0, 0, 0, 0, r}, nil
+			return &mysql.Result{
+				Status:       0,
+				Warnings:     0,
+				InsertId:     0,
+				AffectedRows: 0,
+				Resultset:    r,
+			}, nil
 		}
 	case "insert":
-		return &mysql.Result{0, 0, 1, 0, nil}, nil
-	case "delete":
-		return &mysql.Result{0, 0, 0, 1, nil}, nil
-	case "update":
-		return &mysql.Result{0, 0, 0, 1, nil}, nil
-	case "replace":
-		return &mysql.Result{0, 0, 0, 1, nil}, nil
+		return &mysql.Result{
+			Status:       0,
+			Warnings:     0,
+			InsertId:     1,
+			AffectedRows: 0,
+			Resultset:    nil,
+		}, nil
+	case "delete", "update", "replace":
+		return &mysql.Result{
+			Status:       0,
+			Warnings:     0,
+			InsertId:     0,
+			AffectedRows: 1,
+			Resultset:    nil,
+		}, nil
 	default:
 		return nil, fmt.Errorf("invalid query %s", query)
 	}

--- a/server/command.go
+++ b/server/command.go
@@ -134,8 +134,6 @@ func (c *Conn) dispatch(data []byte) interface{} {
 	default:
 		return c.h.HandleOtherCommand(cmd, data)
 	}
-
-	return fmt.Errorf("command %d is not handled correctly", cmd)
 }
 
 type EmptyHandler struct {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -239,16 +239,30 @@ func (h *testHandler) handleQuery(query string, binary bool) (*mysql.Result, err
 		if err != nil {
 			return nil, errors.Trace(err)
 		} else {
-			return &mysql.Result{0, 0, 0, 0, r}, nil
+			return &mysql.Result{
+				Status:       0,
+				Warnings:     0,
+				InsertId:     0,
+				AffectedRows: 0,
+				Resultset:    r,
+			}, nil
 		}
 	case "insert":
-		return &mysql.Result{0, 0, 1, 0, nil}, nil
-	case "delete":
-		return &mysql.Result{0, 0, 0, 1, nil}, nil
-	case "update":
-		return &mysql.Result{0, 0, 0, 1, nil}, nil
-	case "replace":
-		return &mysql.Result{0, 0, 0, 1, nil}, nil
+		return &mysql.Result{
+			Status:       0,
+			Warnings:     0,
+			InsertId:     1,
+			AffectedRows: 0,
+			Resultset:    nil,
+		}, nil
+	case "delete", "update", "replace":
+		return &mysql.Result{
+			Status:       0,
+			Warnings:     0,
+			InsertId:     0,
+			AffectedRows: 1,
+			Resultset:    nil,
+		}, nil
 	default:
 		return nil, fmt.Errorf("invalid query %s", query)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -252,8 +252,6 @@ func (h *testHandler) handleQuery(query string, binary bool) (*mysql.Result, err
 	default:
 		return nil, fmt.Errorf("invalid query %s", query)
 	}
-
-	return nil, nil
 }
 
 func (h *testHandler) HandleQuery(query string) (*mysql.Result, error) {


### PR DESCRIPTION
Enabled govet in golangci config and fixed some low-hanging fruit code issues.

The reason I ended up enabling govet is that I eventually want to enable govet's `fieldalignment` linter to lower the memory footprint of this library. To make the changes more readable, I will do that in a follow up PR later.