### PR TITLE
enabled gosimple in golangci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,8 +16,8 @@ linters:
     - unconvert
     - whitespace
     - govet
+    - gosimple
     # ToDo:
-    #- gosimple
     #- ineffassign
     #- gocritic
     #- golint

--- a/canal/canal.go
+++ b/canal/canal.go
@@ -316,7 +316,7 @@ func (c *Canal) GetTable(db string, table string) (*schema.Table, error) {
 		c.tableLock.RLock()
 		lastTime, ok := c.errorTablesGetTime[key]
 		c.tableLock.RUnlock()
-		if ok && time.Now().Sub(lastTime) < UnknownTableRetryPeriod {
+		if ok && time.Since(lastTime) < UnknownTableRetryPeriod {
 			return nil, schema.ErrMissingTableMeta
 		}
 	}

--- a/canal/dump.go
+++ b/canal/dump.go
@@ -186,7 +186,7 @@ func (c *Canal) dump() error {
 		startPos = h.gset
 	}
 	log.Infof("dump MySQL and parse OK, use %0.2f seconds, start binlog replication at %s",
-		time.Now().Sub(start).Seconds(), startPos)
+		time.Since(start).Seconds(), startPos)
 	return nil
 }
 

--- a/dump/dumper.go
+++ b/dump/dumper.go
@@ -136,7 +136,7 @@ func (d *Dumper) AddTables(db string, tables ...string) {
 }
 
 func (d *Dumper) AddIgnoreTables(db string, tables ...string) {
-	t, _ := d.IgnoreTables[db]
+	t := d.IgnoreTables[db]
 	t = append(t, tables...)
 	d.IgnoreTables[db] = t
 }

--- a/dump/parser.go
+++ b/dump/parser.go
@@ -29,7 +29,7 @@ var valuesExp *regexp.Regexp
 var gtidExp *regexp.Regexp
 
 func init() {
-	binlogExp = regexp.MustCompile("^CHANGE MASTER TO MASTER_LOG_FILE='(.+)', MASTER_LOG_POS=(\\d+);")
+	binlogExp = regexp.MustCompile(`^CHANGE MASTER TO MASTER_LOG_FILE='(.+)', MASTER_LOG_POS=(\d+);`)
 	useExp = regexp.MustCompile("^USE `(.+)`;")
 	valuesExp = regexp.MustCompile("^INSERT INTO `(.+?)` VALUES \\((.+)\\);$")
 	// The pattern will only match MySQL GTID, as you know SET GLOBAL gtid_slave_pos='0-1-4' is used for MariaDB.

--- a/replication/event.go
+++ b/replication/event.go
@@ -251,7 +251,7 @@ func (e *PreviousGTIDsEvent) Decode(data []byte) error {
 		}
 		previousGTIDSets = append(previousGTIDSets, fmt.Sprintf("%s:%s", uuid, strings.Join(intervals, ":")))
 	}
-	e.GTIDSets = fmt.Sprintf("%s", strings.Join(previousGTIDSets, ","))
+	e.GTIDSets = strings.Join(previousGTIDSets, ",")
 	return nil
 }
 


### PR DESCRIPTION
In line with #663 and #664, I enabled the `gosimple` linter and fixed some small issues that came from it.