### PR TITLE
enabled ineffassign in golangci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,9 +16,9 @@ linters:
     - unconvert
     - whitespace
     - govet
+    - ineffassign
     # ToDo:
     #- gosimple
-    #- ineffassign
     #- gocritic
     #- golint
 linters-settings:

--- a/client/resp.go
+++ b/client/resp.go
@@ -53,11 +53,11 @@ func (c *Conn) handleOKPacket(data []byte) (*Result, error) {
 
 		//todo:strict_mode, check warnings as error
 		r.Warnings = binary.LittleEndian.Uint16(data[pos:])
-		pos += 2
+		// pos += 2
 	} else if c.capability&CLIENT_TRANSACTIONS > 0 {
 		r.Status = binary.LittleEndian.Uint16(data[pos:])
 		c.status = r.Status
-		pos += 2
+		// pos += 2
 	}
 
 	//new ok package will check CLIENT_SESSION_TRACK too, but I don't support it now.

--- a/client/stmt.go
+++ b/client/stmt.go
@@ -214,7 +214,7 @@ func (c *Conn) Prepare(query string) (*Stmt, error) {
 
 	//warnings
 	s.warnings = int(binary.LittleEndian.Uint16(data[pos:]))
-	pos += 2
+	// pos += 2
 
 	if s.params > 0 {
 		if err := s.conn.readUntilEOF(); err != nil {

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -37,9 +37,6 @@ func (t *mysqlTestSuite) TestMysqlGTIDInterval(c *check.C) {
 	i, err = parseInterval("1-1")
 	c.Assert(err, check.IsNil)
 	c.Assert(i, check.DeepEquals, Interval{1, 2})
-
-	i, err = parseInterval("1-2")
-	c.Assert(err, check.IsNil)
 }
 
 func (t *mysqlTestSuite) TestMysqlGTIDIntervalSlice(c *check.C) {

--- a/mysql/rowdata.go
+++ b/mysql/rowdata.go
@@ -26,8 +26,7 @@ func (p RowData) ParseText(f []*Field, dst []FieldValue) ([]FieldValue, error) {
 	var err error
 	var v []byte
 	var isNull bool
-	var pos int = 0
-	var n int = 0
+	var pos, n int
 
 	for i := range f {
 		v, isNull, n, err = LengthEncodedString(p[pos:])

--- a/replication/event.go
+++ b/replication/event.go
@@ -91,7 +91,7 @@ func (h *EventHeader) Decode(data []byte) error {
 	pos += 4
 
 	h.Flags = binary.LittleEndian.Uint16(data[pos:])
-	pos += 2
+	// pos += 2
 
 	if h.EventSize < uint32(EventHeaderSize) {
 		return errors.Errorf("invalid event size %d, must >= 19", h.EventSize)
@@ -420,7 +420,7 @@ func (e *GTIDEvent) Decode(data []byte) error {
 				// If the most significant bit set, another 4 byte follows representing OriginalServerVersion
 				e.ImmediateServerVersion &= ^(uint32(1) << 31)
 				e.OriginalServerVersion = binary.LittleEndian.Uint32(data[pos:])
-				pos += 4
+				// pos += 4
 			} else {
 				// Otherwise OriginalServerVersion == ImmediateServerVersion
 				e.OriginalServerVersion = e.ImmediateServerVersion

--- a/replication/replication_test.go
+++ b/replication/replication_test.go
@@ -72,14 +72,12 @@ func (t *testSyncerSuite) testSync(c *C, s *BinlogStreamer) {
 			return
 		}
 
-		eventCount := 0
 		for {
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			e, err := s.GetEvent(ctx)
 			cancel()
 
 			if err == context.DeadlineExceeded {
-				eventCount += 1
 				return
 			}
 

--- a/server/stmt.go
+++ b/server/stmt.go
@@ -170,7 +170,7 @@ func (c *Conn) bindStmtArgs(s *Stmt, nullBitmap, paramTypes, paramValues []byte)
 	pos := 0
 
 	var v []byte
-	var n int = 0
+	var n int
 	var isNull bool
 	var err error
 


### PR DESCRIPTION
In line with #663, #664 and #665, I enabled the ineffassign linter and fixed some small issues that came from it.