### PR TITLE
added constants for COM_SET_OPTION

### DIFF
--- a/mysql/const.go
+++ b/mysql/const.go
@@ -167,3 +167,8 @@ const (
 	MySQLFlavor   = "mysql"
 	MariaDBFlavor = "mariadb"
 )
+
+const (
+	MYSQL_OPTION_MULTI_STATEMENTS_ON = iota
+	MYSQL_OPTION_MULTI_STATEMENTS_OFF
+)


### PR DESCRIPTION
In my server implementation, I'm using these constants and felt like they belonged in the library. They're described at:

https://dev.mysql.com/doc/internals/en/com-set-option.html#packet-COM_SET_OPTION