### PR TITLE
添加rowEvent当前的position字段和fakeRotate也会调用onRotate

### DIFF
--- a/canal/dump.go
+++ b/canal/dump.go
@@ -110,7 +110,7 @@ func (h *dumpParseHandler) Data(db string, table string, values []string) error 
 		}
 	}
 
-	events := newRowsEvent(tableInfo, InsertAction, [][]interface{}{vs}, nil)
+	events := newRowsEvent(tableInfo, InsertAction, [][]interface{}{vs}, nil, mysql.Position{})
 	return h.c.eventHandler.OnRow(events)
 }
 

--- a/canal/rows.go
+++ b/canal/rows.go
@@ -3,6 +3,8 @@ package canal
 import (
 	"fmt"
 
+	"github.com/go-mysql-org/go-mysql/mysql"
+
 	"github.com/go-mysql-org/go-mysql/replication"
 	"github.com/go-mysql-org/go-mysql/schema"
 )
@@ -16,6 +18,8 @@ const (
 
 // RowsEvent is the event for row replication.
 type RowsEvent struct {
+	// the position in this event
+	CurPos mysql.Position
 	Table  *schema.Table
 	Action string
 	// changed row list
@@ -28,14 +32,14 @@ type RowsEvent struct {
 	Header *replication.EventHeader
 }
 
-func newRowsEvent(table *schema.Table, action string, rows [][]interface{}, header *replication.EventHeader) *RowsEvent {
+func newRowsEvent(table *schema.Table, action string, rows [][]interface{}, header *replication.EventHeader, curPos mysql.Position) *RowsEvent {
 	e := new(RowsEvent)
 
 	e.Table = table
 	e.Action = action
 	e.Rows = rows
 	e.Header = header
-
+	e.CurPos = curPos
 	e.handleUnsigned()
 
 	return e


### PR DESCRIPTION
主要是两个修改
rowEvent添加CurPos 表示当前event的position 
fakeRotate也会调用onRotate 而不是直接continue 目的是同步一开始是有时候需要记录当前的log文件名