### PR TITLE
Add go1.18 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [ 1.17, 1.16, 1.15 ]
+        go: [ 1.18, 1.17, 1.16, 1.15 ]
     name: Tests Go ${{ matrix.go }}
     runs-on: ubuntu-18.04
 


### PR DESCRIPTION
Github actions support go1.18 as well