### PR TITLE
Replacing github.com/satori/go.uuid with github.com/google/uuid

### DIFF
--- a/canal/sync.go
+++ b/canal/sync.go
@@ -8,9 +8,9 @@ import (
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/replication"
 	"github.com/go-mysql-org/go-mysql/schema"
+	"github.com/google/uuid"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
-	uuid "github.com/satori/go.uuid"
 	"github.com/siddontang/go-log/log"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,12 @@ go 1.16
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/go-sql-driver/mysql v1.5.0
+	github.com/google/uuid v1.3.0
 	github.com/jmoiron/sqlx v1.3.3
 	github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8
 	github.com/pingcap/errors v0.11.5-0.20201126102027-b0a155152ca3
 	github.com/pingcap/log v0.0.0-20210317133921-96f4fcab92a4 // indirect
 	github.com/pingcap/parser v0.0.0-20210415081931-48e7f467fd74
-	github.com/satori/go.uuid v1.2.0
 	github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24
 	github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726
 	github.com/siddontang/go-log v0.0.0-20180807004314-8d05993dda07

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/go-sql-driver/mysql v1.3.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jmoiron/sqlx v1.3.3 h1:j82X0bf7oQ27XeqxicSZsTU5suPwKElg3oyxNn43iTk=
 github.com/jmoiron/sqlx v1.3.3/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/mysql/mysql_gtid.go
+++ b/mysql/mysql_gtid.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/pingcap/errors"
-	uuid "github.com/satori/go.uuid"
 	"github.com/siddontang/go/hack"
 )
 
@@ -174,7 +174,7 @@ func ParseUUIDSet(str string) (*UUIDSet, error) {
 
 	var err error
 	s := new(UUIDSet)
-	if s.SID, err = uuid.FromString(sep[0]); err != nil {
+	if s.SID, err = uuid.Parse(sep[0]); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -203,7 +203,7 @@ func NewUUIDSet(sid uuid.UUID, in ...Interval) *UUIDSet {
 }
 
 func (s *UUIDSet) Contain(sub *UUIDSet) bool {
-	if !bytes.Equal(s.SID.Bytes(), sub.SID.Bytes()) {
+	if s.SID != sub.SID {
 		return false
 	}
 
@@ -280,7 +280,9 @@ func (s *UUIDSet) String() string {
 }
 
 func (s *UUIDSet) encode(w io.Writer) {
-	_, _ = w.Write(s.SID.Bytes())
+	b, _ := s.SID.MarshalBinary()
+
+	_, _ = w.Write(b)
 	n := int64(len(s.Intervals))
 
 	_ = binary.Write(w, binary.LittleEndian, n)

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -313,6 +313,10 @@ func (b *BinlogSyncer) registerSlave() error {
 	}
 
 	serverUUID, err := uuid.NewUUID()
+	if err != nil {
+		log.Errorf("failed to get new uud %v", err)
+		return errors.Trace(err)
+	}
 	if _, err = b.c.Execute(fmt.Sprintf("SET @slave_uuid = '%s', @replica_uuid = '%s'", serverUUID, serverUUID)); err != nil {
 		log.Errorf("failed to set @slave_uuid = '%s', err: %v", serverUUID, err)
 		return errors.Trace(err)

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pingcap/errors"
-	uuid "github.com/satori/go.uuid"
 	"github.com/siddontang/go-log/log"
 
 	"github.com/go-mysql-org/go-mysql/client"
@@ -312,7 +312,7 @@ func (b *BinlogSyncer) registerSlave() error {
 		return errors.Trace(err)
 	}
 
-	serverUUID := uuid.NewV1()
+	serverUUID, err := uuid.NewUUID()
 	if _, err = b.c.Execute(fmt.Sprintf("SET @slave_uuid = '%s', @replica_uuid = '%s'", serverUUID, serverUUID)); err != nil {
 		log.Errorf("failed to set @slave_uuid = '%s', err: %v", serverUUID, err)
 		return errors.Trace(err)

--- a/replication/event.go
+++ b/replication/event.go
@@ -10,8 +10,8 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/google/uuid"
 	"github.com/pingcap/errors"
-	uuid "github.com/satori/go.uuid"
 
 	. "github.com/go-mysql-org/go-mysql/mysql"
 )

--- a/replication/replication_test.go
+++ b/replication/replication_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	. "github.com/pingcap/check"
-	uuid "github.com/satori/go.uuid"
 
 	"github.com/go-mysql-org/go-mysql/client"
 	"github.com/go-mysql-org/go-mysql/mysql"
@@ -339,7 +339,7 @@ func (t *testSyncerSuite) TestMysqlGTIDSync(c *C) {
 
 	var masterUuid uuid.UUID
 	if s, _ := r.GetString(0, 1); len(s) > 0 && s != "NONE" {
-		masterUuid, err = uuid.FromString(s)
+		masterUuid, err = uuid.Parse(s)
 		c.Assert(err, IsNil)
 	}
 


### PR DESCRIPTION
Library github.com/satori/go.uuid didn't release new version in 4 years and there is CVE-2021-3538 vulnerability.

This PR replaces github.com/satori/go.uuid dependency with github.com/google/uuid