### PR TITLE
Allow logger override

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -71,7 +71,7 @@ func NewCanal(cfg *Config) (*Canal, error) {
 	if c.cfg.DiscardNoMetaRowEvent {
 		c.errorTablesGetTime = make(map[string]time.Time)
 	}
-	c.master = &masterInfo{}
+	c.master = &masterInfo{logger: c.cfg.Logger}
 
 	c.delay = new(uint32)
 

--- a/canal/config.go
+++ b/canal/config.go
@@ -4,11 +4,13 @@ import (
 	"crypto/tls"
 	"io/ioutil"
 	"math/rand"
+	"os"
 	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/errors"
+	"github.com/siddontang/go-log/log"
 )
 
 type DumpConfig struct {
@@ -86,6 +88,9 @@ type Config struct {
 
 	// Set TLS config
 	TLSConfig *tls.Config
+
+	//Set Logger
+	Logger *log.Logger
 }
 
 func NewConfigWithFile(name string) (*Config, error) {
@@ -123,6 +128,9 @@ func NewDefaultConfig() *Config {
 	c.Dump.ExecutionPath = "mysqldump"
 	c.Dump.DiscardErr = true
 	c.Dump.SkipMasterData = false
+
+	streamHandler, _ := log.NewStreamHandler(os.Stdout)
+	c.Logger = log.NewDefault(streamHandler)
 
 	return c
 }

--- a/canal/master.go
+++ b/canal/master.go
@@ -15,10 +15,12 @@ type masterInfo struct {
 	gset mysql.GTIDSet
 
 	timestamp uint32
+
+	logger *log.Logger
 }
 
 func (m *masterInfo) Update(pos mysql.Position) {
-	log.Debugf("update master position %s", pos)
+	m.logger.Debugf("update master position %s", pos)
 
 	m.Lock()
 	m.pos = pos
@@ -26,7 +28,7 @@ func (m *masterInfo) Update(pos mysql.Position) {
 }
 
 func (m *masterInfo) UpdateTimestamp(ts uint32) {
-	log.Debugf("update master timestamp %d", ts)
+	m.logger.Debugf("update master timestamp %d", ts)
 
 	m.Lock()
 	m.timestamp = ts
@@ -34,7 +36,7 @@ func (m *masterInfo) UpdateTimestamp(ts uint32) {
 }
 
 func (m *masterInfo) UpdateGTIDSet(gset mysql.GTIDSet) {
-	log.Debugf("update master gtid set %s", gset)
+	m.logger.Debugf("update master gtid set %s", gset)
 
 	m.Lock()
 	m.gset = gset


### PR DESCRIPTION
## Problem

Ideally libraries don't have a logger at all. But this is a smaller change by allowing a user to set the Logger. This will allow the previous behaviour if needed.

Closes: https://github.com/go-mysql-org/go-mysql/issues/698 and maybe others

## Feedback?

Should errors ever log or just return?