### PR TITLE
use existing function for comparing auth data

### DIFF
--- a/server/auth_switch_response.go
+++ b/server/auth_switch_response.go
@@ -24,10 +24,7 @@ func (c *Conn) handleAuthSwitchResponse() error {
 		if err := c.acquirePassword(); err != nil {
 			return err
 		}
-		if !bytes.Equal(CalcPassword(c.salt, []byte(c.password)), authData) {
-			return errAccessDenied(c.password)
-		}
-		return nil
+		return c.compareNativePasswordAuthData(authData, c.password)
 
 	case AUTH_CACHING_SHA2_PASSWORD:
 		if !c.cachingSha2FullAuth {


### PR DESCRIPTION
Through time, I made a couple of changes to a local branch of go-mysql I'm using. While I was casually going over the diffs between my branch and the upstream master, I noticed that I could optimise something: comparing the client's authentication data during the handshake is abstracted to `compareNativePasswordAuthData` for `mysql_native_password` while this is not the case during auth switching. So I think this is duplicate code and can be simplified like this!