### PR TITLE
Add support for custom dialer in canal and binlog syncer

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -481,17 +481,17 @@ func (c *Canal) Execute(cmd string, args ...interface{}) (rr *mysql.Result, err 
 		}
 
 		rr, err = c.conn.Execute(cmd, args...)
-		if err != nil && !mysql.ErrorEqual(err, mysql.ErrBadConn) {
-			return
-		} else if mysql.ErrorEqual(err, mysql.ErrBadConn) {
-			c.conn.Close()
-			c.conn = nil
-			continue
-		} else {
-			return
+		if err != nil {
+			if mysql.ErrorEqual(err, mysql.ErrBadConn) {
+				c.conn.Close()
+				c.conn = nil
+				continue
+			}
+			return nil, err
 		}
+		break
 	}
-	return
+	return rr, err
 }
 
 func (c *Canal) SyncedPosition() mysql.Position {

--- a/canal/config.go
+++ b/canal/config.go
@@ -4,10 +4,12 @@ import (
 	"crypto/tls"
 	"io/ioutil"
 	"math/rand"
+	"net"
 	"os"
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/go-mysql-org/go-mysql/client"
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/errors"
 	"github.com/siddontang/go-log/log"
@@ -91,6 +93,9 @@ type Config struct {
 
 	//Set Logger
 	Logger *log.Logger
+
+	//Set Dialer
+	Dialer client.Dialer
 }
 
 func NewConfigWithFile(name string) (*Config, error) {
@@ -131,6 +136,9 @@ func NewDefaultConfig() *Config {
 
 	streamHandler, _ := log.NewStreamHandler(os.Stdout)
 	c.Logger = log.NewDefault(streamHandler)
+
+	dialer := &net.Dialer{}
+	c.Dialer = dialer.DialContext
 
 	return c
 }

--- a/client/conn.go
+++ b/client/conn.go
@@ -61,14 +61,12 @@ func getNetProto(addr string) string {
 // Connect to a MySQL server, addr can be ip:port, or a unix socket domain like /var/sock.
 // Accepts a series of configuration functions as a variadic argument.
 func Connect(addr string, user string, password string, dbName string, options ...func(*Conn)) (*Conn, error) {
-	proto := getNetProto(addr)
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
 	dialer := &net.Dialer{}
 
-	return ConnectWithDialer(ctx, proto, addr, user, password, dbName, dialer.DialContext, options...)
+	return ConnectWithDialer(ctx, "", addr, user, password, dbName, dialer.DialContext, options...)
 }
 
 // Dialer connects to the address on the named network using the provided context.

--- a/client/conn.go
+++ b/client/conn.go
@@ -78,6 +78,10 @@ type Dialer func(ctx context.Context, network, address string) (net.Conn, error)
 func ConnectWithDialer(ctx context.Context, network string, addr string, user string, password string, dbName string, dialer Dialer, options ...func(*Conn)) (*Conn, error) {
 	c := new(Conn)
 
+	if network == "" {
+		network = getNetProto(addr)
+	}
+
 	var err error
 	conn, err := dialer(ctx, network, addr)
 	if err != nil {


### PR DESCRIPTION
Allow custom dialers in canal in binlog syncer. This change introduces some minor copy&paste code mainly in order to set the timeout context at 10 seconds to mimic the behavior of client.Connect