### PR TITLE
use net.JoinHostPort to join host and port

### DIFF
--- a/cmd/go-canal/main.go
+++ b/cmd/go-canal/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -38,7 +40,7 @@ func main() {
 	flag.Parse()
 
 	cfg := canal.NewDefaultConfig()
-	cfg.Addr = fmt.Sprintf("%s:%d", *host, *port)
+	cfg.Addr = net.JoinHostPort(*host, strconv.Itoa(*port))
 	cfg.User = *user
 	cfg.Password = *password
 	cfg.Flavor = *flavor

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -866,7 +867,7 @@ func (b *BinlogSyncer) LastConnectionID() uint32 {
 func (b *BinlogSyncer) newConnection() (*client.Conn, error) {
 	var addr string
 	if b.cfg.Port != 0 {
-		addr = fmt.Sprintf("%s:%d", b.cfg.Host, b.cfg.Port)
+		addr = net.JoinHostPort(b.cfg.Host, strconv.Itoa(int(b.cfg.Port)))
 	} else {
 		addr = b.cfg.Host
 	}


### PR DESCRIPTION
as title, so we can use ipv6 address more naturally(not workaround with explicit square brackets)