### PR TITLE
Added SetTableCache method to set new schema for a table without load…

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -380,6 +380,18 @@ func (c *Canal) ClearTableCache(db []byte, table []byte) {
 	c.tableLock.Unlock()
 }
 
+// SetTableCache sets table cache value for the given key
+func (c *Canal) SetTableCache(db []byte, table []byte, schema *schema.Table) {
+	key := fmt.Sprintf("%s.%s", db, table)
+	c.tableLock.Lock()
+	c.tables[key] = schema
+	if c.cfg.DiscardNoMetaRowEvent {
+		// if get table info success, delete this key from errorTablesGetTime
+		delete(c.errorTablesGetTime, key)
+	}
+	c.tableLock.Unlock()
+}
+
 // CheckBinlogRowImage checks MySQL binlog row image, must be in FULL, MINIMAL, NOBLOB
 func (c *Canal) CheckBinlogRowImage(image string) error {
 	// need to check MySQL binlog row image? full, minimal or noblob?

--- a/canal/canal.go
+++ b/canal/canal.go
@@ -380,7 +380,7 @@ func (c *Canal) ClearTableCache(db []byte, table []byte) {
 	c.tableLock.Unlock()
 }
 
-// SetTableCache sets table cache value for the given key
+// SetTableCache sets table cache value for the given table
 func (c *Canal) SetTableCache(db []byte, table []byte, schema *schema.Table) {
 	key := fmt.Sprintf("%s.%s", db, table)
 	c.tableLock.Lock()


### PR DESCRIPTION
## Problem
Canal lacks ability to set table schema cache bypassing the schema reload from the replicated source database. This makes it impossible to replay the binlog with several table schema changes in the sequence even when you have history of table schemas for every change at your hand.
## Solution
This PR adds SetTableCache method for canal users to be able to directly set table schema whenever a user sees fit, for example, when detecting schema change (through a table rename statement e.x. RENAME _temp_migration_123 to my_table) while replaying binlog history.