### PR TITLE
removed use of deprecated ioutil

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [ 1.18, 1.17, 1.16, 1.15 ]
+        go: [ 1.18, 1.17, 1.16 ]
     name: Tests Go ${{ matrix.go }}
     runs-on: ubuntu-18.04
 

--- a/canal/canal.go
+++ b/canal/canal.go
@@ -3,7 +3,7 @@ package canal
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"strconv"
@@ -165,7 +165,7 @@ func (c *Canal) prepareDumper() error {
 	}
 
 	if c.cfg.Dump.DiscardErr {
-		c.dumper.SetErrOut(ioutil.Discard)
+		c.dumper.SetErrOut(io.Discard)
 	} else {
 		c.dumper.SetErrOut(os.Stderr)
 	}

--- a/canal/config.go
+++ b/canal/config.go
@@ -2,7 +2,6 @@ package canal
 
 import (
 	"crypto/tls"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -99,7 +98,7 @@ type Config struct {
 }
 
 func NewConfigWithFile(name string) (*Config, error) {
-	data, err := ioutil.ReadFile(name)
+	data, err := os.ReadFile(name)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/client/auth.go
+++ b/client/auth.go
@@ -110,9 +110,9 @@ func (c *Conn) readInitialHandshake() error {
 // generate auth response data according to auth plugin
 //
 // NOTE: the returned boolean value indicates whether to add a \NUL to the end of data.
-//       it is quite tricky because MySQL server expects different formats of responses in different auth situations.
-//       here the \NUL needs to be added when sending back the empty password or cleartext password in 'sha256_password'
-//       authentication.
+// it is quite tricky because MySQL server expects different formats of responses in different auth situations.
+// here the \NUL needs to be added when sending back the empty password or cleartext password in 'sha256_password'
+// authentication.
 func (c *Conn) genAuthResponse(authData []byte) ([]byte, bool, error) {
 	// password hashing
 	switch c.authPluginName {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -112,8 +112,8 @@ func (s *clientTestSuite) TestConn_SetCapability(c *C) {
 }
 
 // NOTE for MySQL 5.5 and 5.6, server side has to config SSL to pass the TLS test, otherwise, it will throw error that
-//      MySQL server does not support TLS required by the client. However, for MySQL 5.7 and above, auto generated certificates
-//      are used by default so that manual config is no longer necessary.
+// MySQL server does not support TLS required by the client. However, for MySQL 5.7 and above, auto generated certificates
+// are used by default so that manual config is no longer necessary.
 func (s *clientTestSuite) TestConn_TLS_Verify(c *C) {
 	// Verify that the provided tls.Config is used when attempting to connect to mysql.
 	// An empty tls.Config will result in a connection error.

--- a/client/conn.go
+++ b/client/conn.go
@@ -217,11 +217,10 @@ func (c *Conn) Execute(command string, args ...interface{}) (*Result, error) {
 //
 // Example:
 //
-//      queries := "SELECT 1; SELECT NOW();"
-//      conn.ExecuteMultiple(queries, func(result *mysql.Result, err error) {
-//          // Use the result as you want
-//      })
-//
+// queries := "SELECT 1; SELECT NOW();"
+// conn.ExecuteMultiple(queries, func(result *mysql.Result, err error) {
+// // Use the result as you want
+// })
 func (c *Conn) ExecuteMultiple(query string, perResultCallback ExecPerResultCallback) (*Result, error) {
 	if err := c.writeCommandStr(COM_QUERY, query); err != nil {
 		return nil, errors.Trace(err)
@@ -271,20 +270,19 @@ func (c *Conn) ExecuteMultiple(query string, perResultCallback ExecPerResultCall
 }
 
 // ExecuteSelectStreaming will call perRowCallback for every row in resultset
-//   WITHOUT saving any row data to Result.{Values/RawPkg/RowDatas} fields.
+// WITHOUT saving any row data to Result.{Values/RawPkg/RowDatas} fields.
 // When given, perResultCallback will be called once per result
 //
 // ExecuteSelectStreaming should be used only for SELECT queries with a large response resultset for memory preserving.
 //
 // Example:
 //
-// 		var result mysql.Result
-// 		conn.ExecuteSelectStreaming(`SELECT ... LIMIT 100500`, &result, func(row []mysql.FieldValue) error {
-//   		// Use the row as you want.
-//   		// You must not save FieldValue.AsString() value after this callback is done. Copy it if you need.
-//   		return nil
-// 		}, nil)
-//
+// var result mysql.Result
+// conn.ExecuteSelectStreaming(`SELECT ... LIMIT 100500`, &result, func(row []mysql.FieldValue) error {
+// // Use the row as you want.
+// // You must not save FieldValue.AsString() value after this callback is done. Copy it if you need.
+// return nil
+// }, nil)
 func (c *Conn) ExecuteSelectStreaming(command string, result *Result, perRowCallback SelectPerRowCallback, perResultCallback SelectPerResultCallback) error {
 	if err := c.writeCommandStr(COM_QUERY, command); err != nil {
 		return errors.Trace(err)

--- a/client/pool.go
+++ b/client/pool.go
@@ -75,10 +75,10 @@ var (
 )
 
 // NewPool initializes new connection pool and uses params: addr, user, password, dbName and options.
-//     minAlive specifies the minimum number of open connections that the pool will try to maintain.
-//     maxAlive specifies the maximum number of open connections
-//       (for internal reasons, may be greater by 1 inside newConnectionProducer).
-//     maxIdle specifies the maximum number of idle connections (see DefaultIdleTimeout).
+// minAlive specifies the minimum number of open connections that the pool will try to maintain.
+// maxAlive specifies the maximum number of open connections (for internal reasons,
+// may be greater by 1 inside newConnectionProducer).
+// maxIdle specifies the maximum number of idle connections (see DefaultIdleTimeout).
 func NewPool(
 	logFunc LogFunc,
 	minAlive int,

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -304,8 +304,7 @@ func init() {
 // Example of supplying a custom CA, no client cert, no key, validating the
 // certificate, and supplying a serverName for the validation:
 //
-//     driver.SetCustomTLSConfig(CaPem, make([]byte, 0), make([]byte, 0), false, "my.domain.name")
-//
+// driver.SetCustomTLSConfig(CaPem, make([]byte, 0), make([]byte, 0), false, "my.domain.name")
 func SetCustomTLSConfig(dsn string, caPem []byte, certPem []byte, keyPem []byte, insecureSkipVerify bool, serverName string) error {
 	// Extract addr from dsn
 	parsed, err := url.Parse(dsn)

--- a/dump/schema_test.go
+++ b/dump/schema_test.go
@@ -3,7 +3,7 @@ package dump
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/go-mysql-org/go-mysql/client"
@@ -83,19 +83,19 @@ func (s *schemaTestSuite) TestDump(c *C) {
 	// Using mysql 5.7 can't work, error:
 	// 	mysqldump: Error 1412: Table definition has changed,
 	// 	please retry transaction when dumping table `test_replication` at row: 0
-	// err := s.d.Dump(ioutil.Discard)
+	// err := s.d.Dump(io.Discard)
 	// c.Assert(err, IsNil)
 
 	s.d.AddDatabases("test1", "test2")
 
 	s.d.AddIgnoreTables("test1", "t2")
 
-	err := s.d.Dump(ioutil.Discard)
+	err := s.d.Dump(io.Discard)
 	c.Assert(err, IsNil)
 
 	s.d.AddTables("test1", "t1")
 
-	err = s.d.Dump(ioutil.Discard)
+	err = s.d.Dump(io.Discard)
 	c.Assert(err, IsNil)
 }
 

--- a/failover/failover.go
+++ b/failover/failover.go
@@ -6,15 +6,14 @@ import (
 )
 
 // Failover will do below things after the master down
-//  1. Elect a slave which has the most up-to-date data with old master
-//  2. Promote the slave to new master
-//  3. Change other slaves to the new master
+// 1. Elect a slave which has the most up-to-date data with old master
+// 2. Promote the slave to new master
+// 3. Change other slaves to the new master
 //
 // Limitation:
-//  1, All slaves must have the same master before, Failover will check using master server id or uuid
-//  2, If the failover error, the whole topology may be wrong, we must handle this error manually
-//  3, Slaves must have same replication mode, all use GTID or not
-//
+// 1, All slaves must have the same master before, Failover will check using master server id or uuid
+// 2, If the failover error, the whole topology may be wrong, we must handle this error manually
+// 3, Slaves must have same replication mode, all use GTID or not
 func Failover(flavor string, slaves []*Server) ([]*Server, error) {
 	var h Handler
 	var err error

--- a/packet/conn.go
+++ b/packet/conn.go
@@ -40,9 +40,7 @@ func (b *BufPool) Return(buf *bytes.Buffer) {
 	b.pool.Put(buf)
 }
 
-/*
-	Conn is the base class to handle MySQL protocol.
-*/
+// Conn is the base class to handle MySQL protocol.
 type Conn struct {
 	net.Conn
 

--- a/server/caching_sha2_cache_test.go
+++ b/server/caching_sha2_cache_test.go
@@ -21,7 +21,7 @@ var delay = 50
 
 // test caching for 'caching_sha2_password'
 // NOTE the idea here is to plugin a throttled credential provider so that the first connection (cache miss) will take longer time
-//      than the second connection (cache hit). Remember to set the password for MySQL user otherwise it won't cache empty password.
+// than the second connection (cache hit). Remember to set the password for MySQL user otherwise it won't cache empty password.
 func TestCachingSha2Cache(t *testing.T) {
 	log.SetLevel(log.LevelDebug)
 

--- a/server/conn.go
+++ b/server/conn.go
@@ -11,9 +11,7 @@ import (
 	"github.com/go-mysql-org/go-mysql/packet"
 )
 
-/*
-   Conn acts like a MySQL server connection, you can use MySQL client to communicate with it.
-*/
+// Conn acts like a MySQL server connection, you can use MySQL client to communicate with it.
 type Conn struct {
 	*packet.Conn
 


### PR DESCRIPTION
The package `io/ioutil` has been deprecated since Go 1.16