### PR TITLE
fix: fix client field list

### DIFF
--- a/client/conn.go
+++ b/client/conn.go
@@ -328,20 +328,17 @@ func (c *Conn) FieldList(table string, wildcard string) ([]*Field, error) {
 		return nil, errors.Trace(err)
 	}
 
-	data, err := c.ReadPacket()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	fs := make([]*Field, 0, 4)
 	var f *Field
-	if data[0] == ERR_HEADER {
-		return nil, c.handleErrorPacket(data)
-	}
-
 	for {
-		if data, err = c.ReadPacket(); err != nil {
+		data, err := c.ReadPacket()
+		if err != nil {
 			return nil, errors.Trace(err)
+		}
+
+		// ERR Packet
+		if data[0] == ERR_HEADER {
+			return nil, c.handleErrorPacket(data)
 		}
 
 		// EOF Packet

--- a/client/conn_test.go
+++ b/client/conn_test.go
@@ -82,7 +82,7 @@ func (s *connTestSuite) testExecute_DropTable(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *clientTestSuite) TestFieldList(c *C) {
+func (s *connTestSuite) TestFieldList(c *C) {
 	fields, err := s.c.FieldList(testExecuteSelectStreamingTablename, "")
 	c.Assert(err, IsNil)
 	c.Assert(fields, HasLen, 2)

--- a/client/conn_test.go
+++ b/client/conn_test.go
@@ -82,6 +82,12 @@ func (s *connTestSuite) testExecute_DropTable(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (s *clientTestSuite) TestFieldList(c *C) {
+	fields, err := s.c.FieldList(testExecuteSelectStreamingTablename, "")
+	c.Assert(err, IsNil)
+	c.Assert(fields, HasLen, 2)
+}
+
 func (s *connTestSuite) TestExecuteMultiple(c *C) {
 	queries := []string{
 		`INSERT INTO ` + testExecuteSelectStreamingTablename + ` (id, str) VALUES (999, "executemultiple")`,


### PR DESCRIPTION
### What bug does this MR fix?
Client FieldList is missing the first field because check ERR Packet.
### How is the bug fixed?
Check ERR Packet in loop, in this way we can parse the first packet into FieldData