### PR TITLE
packet: fix misusing of defer

### DIFF
--- a/packet/conn.go
+++ b/packet/conn.go
@@ -90,7 +90,9 @@ func (c *Conn) ReadPacket() ([]byte, error) {
 func (c *Conn) ReadPacketReuseMem(dst []byte) ([]byte, error) {
 	// Here we use `sync.Pool` to avoid allocate/destroy buffers frequently.
 	buf := utils.BytesBufferGet()
-	defer utils.BytesBufferPut(buf)
+	defer func() {
+		utils.BytesBufferPut(buf)
+	}()
 
 	if err := c.ReadPacketTo(buf); err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
defer capture arguments at once, so modify arguments after defer line not works
Closes #728 