### PR TITLE
Make logger require an interface instead of a concrete implementation

### DIFF
--- a/canal/config.go
+++ b/canal/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/errors"
 	"github.com/siddontang/go-log/log"
+	"github.com/siddontang/go-log/loggers"
 )
 
 type DumpConfig struct {
@@ -91,7 +92,7 @@ type Config struct {
 	TLSConfig *tls.Config
 
 	//Set Logger
-	Logger *log.Logger
+	Logger loggers.Advanced
 
 	//Set Dialer
 	Dialer client.Dialer

--- a/canal/master.go
+++ b/canal/master.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
-	"github.com/siddontang/go-log/log"
+	"github.com/siddontang/go-log/loggers"
 )
 
 type masterInfo struct {
@@ -16,7 +16,7 @@ type masterInfo struct {
 
 	timestamp uint32
 
-	logger *log.Logger
+	logger loggers.Advanced
 }
 
 func (m *masterInfo) Update(pos mysql.Position) {

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/siddontang/go-log/loggers"
+
 	"github.com/google/uuid"
 	"github.com/pingcap/errors"
 	"github.com/siddontang/go-log/log"
@@ -112,7 +114,7 @@ type BinlogSyncerConfig struct {
 	Option func(*client.Conn) error
 
 	// Set Logger
-	Logger *log.Logger
+	Logger loggers.Advanced
 
 	// Set Dialer
 	Dialer client.Dialer


### PR DESCRIPTION
It is much easier to integrate 3rd-party log implementations by requiring an interface instead of requiring a Logger struct (which implements this interface).