### PR TITLE
EventHandlerV2 support handle event with replication.EventHeader

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -36,7 +36,6 @@ type Canal struct {
 	syncer     *replication.BinlogSyncer
 
 	eventHandler EventHandler
-	eventHandlerV2 EventHandlerV2
 
 	connLock sync.Mutex
 	conn     *client.Conn
@@ -249,11 +248,7 @@ func (c *Canal) Close() {
 	c.conn = nil
 	c.connLock.Unlock()
 
-	if c.eventHandlerV2 == nil {
-		_ = c.eventHandler.OnPosSynced(c.master.Position(), c.master.GTIDSet(), true)
-	} else {
-		_ = c.eventHandlerV2.OnPosSynced(nil, c.master.Position(), c.master.GTIDSet(), true)
-	}
+	_ = c.eventHandler.OnPosSynced(nil, c.master.Position(), c.master.GTIDSet(), true)
 }
 
 func (c *Canal) WaitDumpDone() <-chan struct{} {

--- a/canal/canal.go
+++ b/canal/canal.go
@@ -36,6 +36,7 @@ type Canal struct {
 	syncer     *replication.BinlogSyncer
 
 	eventHandler EventHandler
+	eventHandlerV2 EventHandlerV2
 
 	connLock sync.Mutex
 	conn     *client.Conn
@@ -248,7 +249,11 @@ func (c *Canal) Close() {
 	c.conn = nil
 	c.connLock.Unlock()
 
-	_ = c.eventHandler.OnPosSynced(c.master.Position(), c.master.GTIDSet(), true)
+	if c.eventHandlerV2 == nil {
+		_ = c.eventHandler.OnPosSynced(c.master.Position(), c.master.GTIDSet(), true)
+	} else {
+		_ = c.eventHandlerV2.OnPosSynced(nil, c.master.Position(), c.master.GTIDSet(), true)
+	}
 }
 
 func (c *Canal) WaitDumpDone() <-chan struct{} {

--- a/canal/canal_test.go
+++ b/canal/canal_test.go
@@ -123,7 +123,7 @@ func (h *testEventHandler) String() string {
 	return "testEventHandler"
 }
 
-func (h *testEventHandler) OnPosSynced(p mysql.Position, set mysql.GTIDSet, f bool) error {
+func (h *testEventHandler) OnPosSynced(header *replication.EventHeader, p mysql.Position, set mysql.GTIDSet, f bool) error {
 	return nil
 }
 

--- a/canal/dump.go
+++ b/canal/dump.go
@@ -179,7 +179,8 @@ func (c *Canal) dump() error {
 
 	pos := mysql.Position{Name: h.name, Pos: uint32(h.pos)}
 	c.master.Update(pos)
-	c.master.UpdateGTIDSet(h.gset)var err error
+	c.master.UpdateGTIDSet(h.gset)
+	var err error
 	if c.eventHandlerV2 == nil {
 		err = c.eventHandler.OnPosSynced(pos, c.master.GTIDSet(), true)
 	} else {

--- a/canal/dump.go
+++ b/canal/dump.go
@@ -110,11 +110,7 @@ func (h *dumpParseHandler) Data(db string, table string, values []string) error 
 	}
 
 	events := newRowsEvent(tableInfo, InsertAction, [][]interface{}{vs}, nil)
-	if h.c.eventHandlerV2 == nil {
-		return h.c.eventHandler.OnRow(events)
-	} else {
-		return h.c.eventHandlerV2.OnRow(events)
-	}
+	return h.c.eventHandler.OnRow(events)
 }
 
 func (c *Canal) AddDumpDatabases(dbs ...string) {
@@ -180,13 +176,7 @@ func (c *Canal) dump() error {
 	pos := mysql.Position{Name: h.name, Pos: uint32(h.pos)}
 	c.master.Update(pos)
 	c.master.UpdateGTIDSet(h.gset)
-	var err error
-	if c.eventHandlerV2 == nil {
-		err = c.eventHandler.OnPosSynced(pos, c.master.GTIDSet(), true)
-	} else {
-		err = c.eventHandlerV2.OnPosSynced(nil, pos, c.master.GTIDSet(), true)
-	}
-	if err != nil {
+	if err := c.eventHandler.OnPosSynced(nil, pos, c.master.GTIDSet(), true); err != nil {
 		return errors.Trace(err)
 	}
 	var startPos fmt.Stringer = pos

--- a/canal/dump.go
+++ b/canal/dump.go
@@ -110,7 +110,11 @@ func (h *dumpParseHandler) Data(db string, table string, values []string) error 
 	}
 
 	events := newRowsEvent(tableInfo, InsertAction, [][]interface{}{vs}, nil)
-	return h.c.eventHandler.OnRow(events)
+	if h.c.eventHandlerV2 == nil {
+		return h.c.eventHandler.OnRow(events)
+	} else {
+		return h.c.eventHandlerV2.OnRow(events)
+	}
 }
 
 func (c *Canal) AddDumpDatabases(dbs ...string) {
@@ -175,8 +179,13 @@ func (c *Canal) dump() error {
 
 	pos := mysql.Position{Name: h.name, Pos: uint32(h.pos)}
 	c.master.Update(pos)
-	c.master.UpdateGTIDSet(h.gset)
-	if err := c.eventHandler.OnPosSynced(pos, c.master.GTIDSet(), true); err != nil {
+	c.master.UpdateGTIDSet(h.gset)var err error
+	if c.eventHandlerV2 == nil {
+		err = c.eventHandler.OnPosSynced(pos, c.master.GTIDSet(), true)
+	} else {
+		err = c.eventHandlerV2.OnPosSynced(nil, pos, c.master.GTIDSet(), true)
+	}
+	if err != nil {
 		return errors.Trace(err)
 	}
 	var startPos fmt.Stringer = pos

--- a/canal/handler.go
+++ b/canal/handler.go
@@ -6,43 +6,6 @@ import (
 )
 
 type EventHandler interface {
-	OnRotate(rotateEvent *replication.RotateEvent) error
-	// OnTableChanged is called when the table is created, altered, renamed or dropped.
-	// You need to clear the associated data like cache with the table.
-	// It will be called before OnDDL.
-	OnTableChanged(schema string, table string) error
-	OnDDL(nextPos mysql.Position, queryEvent *replication.QueryEvent) error
-	OnRow(e *RowsEvent) error
-	OnXID(nextPos mysql.Position) error
-	OnGTID(gtid mysql.GTIDSet) error
-	// OnPosSynced Use your own way to sync position. When force is true, sync position immediately.
-	OnPosSynced(pos mysql.Position, set mysql.GTIDSet, force bool) error
-	String() string
-}
-
-type DummyEventHandler struct {
-}
-
-func (h *DummyEventHandler) OnRotate(*replication.RotateEvent) error          { return nil }
-func (h *DummyEventHandler) OnTableChanged(schema string, table string) error { return nil }
-func (h *DummyEventHandler) OnDDL(nextPos mysql.Position, queryEvent *replication.QueryEvent) error {
-	return nil
-}
-func (h *DummyEventHandler) OnRow(*RowsEvent) error                                { return nil }
-func (h *DummyEventHandler) OnXID(mysql.Position) error                            { return nil }
-func (h *DummyEventHandler) OnGTID(mysql.GTIDSet) error                            { return nil }
-func (h *DummyEventHandler) OnPosSynced(mysql.Position, mysql.GTIDSet, bool) error { return nil }
-
-func (h *DummyEventHandler) String() string { return "DummyEventHandler" }
-
-// `SetEventHandler` registers the sync handler, you must register your
-// own handler before starting Canal.
-func (c *Canal) SetEventHandler(h EventHandler) {
-	c.eventHandler = h
-}
-
-// EventHandlerV2 can process event with replication.EventHeader
-type EventHandlerV2 interface {
 	OnRotate(header *replication.EventHeader, rotateEvent *replication.RotateEvent) error
 	// OnTableChanged is called when the table is created, altered, renamed or dropped.
 	// You need to clear the associated data like cache with the table.
@@ -57,7 +20,29 @@ type EventHandlerV2 interface {
 	String() string
 }
 
-// SetEventHandlerV2 to registers EventHandlerV2 handler replace the EventHandler
-func (c *Canal) SetEventHandlerV2(h EventHandlerV2) {
-	c.eventHandlerV2 = h
+type DummyEventHandler struct {
+}
+
+func (h *DummyEventHandler) OnRotate(*replication.EventHeader, *replication.RotateEvent) error {
+	return nil
+}
+func (h *DummyEventHandler) OnTableChanged(*replication.EventHeader, string, string) error {
+	return nil
+}
+func (h *DummyEventHandler) OnDDL(*replication.EventHeader, mysql.Position, *replication.QueryEvent) error {
+	return nil
+}
+func (h *DummyEventHandler) OnRow(*RowsEvent) error                               { return nil }
+func (h *DummyEventHandler) OnXID(*replication.EventHeader, mysql.Position) error { return nil }
+func (h *DummyEventHandler) OnGTID(*replication.EventHeader, mysql.GTIDSet) error { return nil }
+func (h *DummyEventHandler) OnPosSynced(*replication.EventHeader, mysql.Position, mysql.GTIDSet, bool) error {
+	return nil
+}
+
+func (h *DummyEventHandler) String() string { return "DummyEventHandler" }
+
+// `SetEventHandler` registers the sync handler, you must register your
+// own handler before starting Canal.
+func (c *Canal) SetEventHandler(h EventHandler) {
+	c.eventHandler = h
 }

--- a/canal/handler.go
+++ b/canal/handler.go
@@ -40,3 +40,24 @@ func (h *DummyEventHandler) String() string { return "DummyEventHandler" }
 func (c *Canal) SetEventHandler(h EventHandler) {
 	c.eventHandler = h
 }
+
+// EventHandlerV2 can process event with replication.EventHeader
+type EventHandlerV2 interface {
+	OnRotate(header *replication.EventHeader, rotateEvent *replication.RotateEvent) error
+	// OnTableChanged is called when the table is created, altered, renamed or dropped.
+	// You need to clear the associated data like cache with the table.
+	// It will be called before OnDDL.
+	OnTableChanged(header *replication.EventHeader, schema string, table string) error
+	OnDDL(header *replication.EventHeader, nextPos mysql.Position, queryEvent *replication.QueryEvent) error
+	OnRow(e *RowsEvent) error
+	OnXID(header *replication.EventHeader, nextPos mysql.Position) error
+	OnGTID(header *replication.EventHeader, gtid mysql.GTIDSet) error
+	// OnPosSynced Use your own way to sync position. When force is true, sync position immediately.
+	OnPosSynced(header *replication.EventHeader, pos mysql.Position, set mysql.GTIDSet, force bool) error
+	String() string
+}
+
+// SetEventHandlerV2 to registers EventHandlerV2 handler replace the EventHandler
+func (c *Canal) SetEventHandlerV2(h EventHandlerV2) {
+	c.eventHandlerV2 = h
+}


### PR DESCRIPTION
add EventHandlerV2 to get timestamp from event, so that canal can show the how much time delay when process like

```go
func (s *handler) OnXID(header *replication.EventHeader, nextPos mysql.Position) error {
	s.queue <- model.Position{
		Name:      nextPos.Name,
		Pos:       nextPos.Pos,
		Timestamp: header.Timestamp,
		Force:     false,
	}
	return nil
}
```

it can show on UI like
binlog file: mysql-bin.000102
binlog position: 1142900
**binlog timestamp: 2022-11-25 15:54:07 (1669362847)**
**tiem delay:  2 sec**