### PR TITLE
fix panic when logger or dialer is not set in canal config

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"regexp"
 	"strconv"
@@ -19,6 +20,7 @@ import (
 	"github.com/go-mysql-org/go-mysql/schema"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser"
+	"github.com/siddontang/go-log/log"
 )
 
 // Canal can sync your MySQL data into everywhere, like Elasticsearch, Redis, etc...
@@ -60,6 +62,14 @@ var ErrExcludedTable = errors.New("excluded table meta")
 
 func NewCanal(cfg *Config) (*Canal, error) {
 	c := new(Canal)
+	if cfg.Logger == nil {
+		streamHandler, _ := log.NewStreamHandler(os.Stdout)
+		cfg.Logger = log.NewDefault(streamHandler)
+	}
+	if cfg.Dialer == nil {
+		dialer := &net.Dialer{}
+		cfg.Dialer = dialer.DialContext
+	}
 	c.cfg = cfg
 
 	c.ctx, c.cancel = context.WithCancel(context.Background())


### PR DESCRIPTION
If we do not use `canal.NewDefaultConfig()`, then the client will crash:

**When Logger is nil**

```text
[2022/11/26 19:48:41] [info] binlogsyncer.go:156 create BinlogSyncer with config {999 mysql 10.43.173.151 3306 root    false false <nil> false UTC false 0 0s 0s 0 false false 0 <nil> 0xc00011b320}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x5d1a45]

goroutine 1 [running]:
github.com/siddontang/go-log/log.(*Logger).Output(0x6bc30e?, 0xd?, 0x0?, {0xc00011ca40?, 0x0?})
        /home/fang/go/pkg/mod/github.com/siddontang/go-log@v0.0.0-20180807004314-8d05993dda07/log/logger.go:137 +0x45
github.com/siddontang/go-log/log.(*Logger).Infof(0x0?, {0x6bc30e?, 0x0?}, {0x0?, 0xc000147f50?, 0x645db8?})
        /home/fang/go/pkg/mod/github.com/siddontang/go-log@v0.0.0-20180807004314-8d05993dda07/log/logger.go:280 +0x51
github.com/go-mysql-org/go-mysql/canal.(*Canal).Close(0xc000288000)
        /home/fang/go/pkg/mod/github.com/go-mysql-org/go-mysql@v1.6.0/canal/canal.go:240 +0x57
main.main()
        /home/fang/codes/panic-proof/main.go:33 +0x65
exit status 2
```

**When Dialer is nil**

```text
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5e97a5]

goroutine 1 [running]:
github.com/go-mysql-org/go-mysql/client.ConnectWithDialer({0x7955f0, 0xc0000672c0}, {0x0, 0x0}, {0x6ec54c, 0x12}, {0x6e591f, 0x4}, {0x6f3c3f, 0x20}, ...)
        /home/fang/codes/go-mysql/client/conn.go:84 +0xe5
github.com/go-mysql-org/go-mysql/canal.(*Canal).connect(0xc000256000, {0xc000123e38, 0x0, 0x0})
        /home/fang/codes/go-mysql/canal/canal.go:476 +0x111
github.com/go-mysql-org/go-mysql/canal.(*Canal).Execute(0xc000256000, {0x6f9320, 0x2b}, {0x0, 0x0, 0x0})
        /home/fang/codes/go-mysql/canal/canal.go:494 +0x27b
github.com/go-mysql-org/go-mysql/canal.(*Canal).checkBinlogRowFormat(0xc000256000?)
        /home/fang/codes/go-mysql/canal/canal.go:420 +0x30
github.com/go-mysql-org/go-mysql/canal.NewCanal(0xc0001e2ea0)
        /home/fang/codes/go-mysql/canal/canal.go:93 +0x318
main.main()
        /home/fang/codes/panic-proof/main.go:30 +0x58
exit status 2
```

To verify this:

```go
package main

import (
	"github.com/go-mysql-org/go-mysql/canal"
	"github.com/go-mysql-org/go-mysql/mysql"
)

func main() {
	conf := canal.Config{
		ServerID: 999,
		Flavor:   mysql.MySQLFlavor,
		Addr:     "127.0.0.1:3306",
		User:     "root",
		Password: "password",
		Logger:   nil, // will panic if nil
		Dialer:   nil, // too.
	}
	c, err := canal.NewCanal(&conf)
	if err != nil {
		panic(err)
	}
	c.Close()
}
```