### PR TITLE
Support "mysql_clear_password" auth plugin

### DIFF
--- a/client/auth.go
+++ b/client/auth.go
@@ -120,6 +120,8 @@ func (c *Conn) genAuthResponse(authData []byte) ([]byte, bool, error) {
 		return CalcPassword(authData[:20], []byte(c.password)), false, nil
 	case AUTH_CACHING_SHA2_PASSWORD:
 		return CalcCachingSha2Password(authData, c.password), false, nil
+	case AUTH_CLEAR_PASSWORD:
+		return []byte(c.password), true, nil
 	case AUTH_SHA256_PASSWORD:
 		if len(c.password) == 0 {
 			return nil, true, nil

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -20,6 +20,7 @@ const (
 const (
 	AUTH_MYSQL_OLD_PASSWORD    = "mysql_old_password"
 	AUTH_NATIVE_PASSWORD       = "mysql_native_password"
+	AUTH_CLEAR_PASSWORD        = "mysql_clear_password"
 	AUTH_CACHING_SHA2_PASSWORD = "caching_sha2_password"
 	AUTH_SHA256_PASSWORD       = "sha256_password"
 )


### PR DESCRIPTION
This is required to connect with Amazon RDS MySQL databases that only supports clear password over TLS.