### PR TITLE
replication - just return an error not logging it

### DIFF
--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/shopspring/decimal"
-	"github.com/siddontang/go-log/log"
 	"github.com/siddontang/go/hack"
 
 	. "github.com/go-mysql-org/go-mysql/mysql"
@@ -906,9 +905,7 @@ func (e *RowsEvent) DecodeData(pos int, data []byte) (err2 error) {
 	// ... repeat rows until event-end
 	defer func() {
 		if r := recover(); r != nil {
-			errStr := fmt.Sprintf("parse rows event panic %v, data %q, parsed rows %#v, table map %#v", r, data, e, e.Table)
-			log.Errorf("%s\n%s", errStr, Pstack())
-			err2 = errors.Trace(errors.New(errStr))
+			err2 = errors.Errorf("parse rows event panic %v, data %q, parsed rows %#v, table map %#v", r, data, e, e.Table)
 		}
 	}()
 


### PR DESCRIPTION
A successfully passed test with output 
```
[2023/01/28 12:32:53] [error] row_event.go:910 parse rows event panic runtime error: index out of range [7] with length 7, data "@\x01\x00\x00\x00\x00\x01\x00\x02\xff\xfc\x01\x00\x00\x00\x00B\x14U\x16\x8ew", parsed rows &replication.RowsEvent{Version:1, tableIDSize:6, tables:map[uint64]*replication.TableMapEvent{0x140:(*replication.TableMapEvent)(0xc000242200)}, needBitmap2:false, Table:(*replication.TableMapEvent)(0xc000242200), TableID:0x140, Flags:0x1, ExtraData:[]uint8(nil), ColumnCount:0x2, ColumnBitmap1:[]uint8{0xff}, ColumnBitmap2:[]uint8(nil), Rows:[][]interface {}{}, SkippedColumns:[][]int{}, parseTime:false, timestampStringLocation:(*time.Location)(nil), useDecimal:false, ignoreJSONDecodeErr:false}, table map &replication.TableMapEvent{flavor:"", tableIDSize:6, TableID:0x140, Flags:0x1, Schema:[]uint8{0x74, 0x65, 0x73, 0x74}, Table:[]uint8{0x74}, ColumnCount:0x2, ColumnType:[]uint8{0x3, 0xc}, ColumnMeta:[]uint16{0x0, 0x0}, NullBitmap:[]uint8{0x2}, SignednessBitmap:[]uint8(nil), DefaultCharset:[]uint64(nil), ColumnCharset:[]uint64(nil), SetStrValue:[][][]uint8(nil), setStrValueString:[][]string(nil), EnumStrValue:[][][]uint8(nil), enumStrValueString:[][]string(nil), ColumnName:[][]uint8(nil), columnNameString:[]string(nil), GeometryType:[]uint64(nil), PrimaryKey:[]uint64(nil), PrimaryKeyPrefix:[]uint64(nil), EnumSetDefaultCharset:[]uint64(nil), EnumSetColumnCharset:[]uint64(nil)}
goroutine 124 [running]:
github.com/go-mysql-org/go-mysql/mysql.Pstack(...)
	.../go-mysql/mysql/util.go:22
github.com/go-mysql-org/go-mysql/replication.(*RowsEvent).DecodeData.func1()
	.../go-mysql/replication/row_event.go:910 +0x17c
panic({0x9cdf40, 0xc00021a078})
	.../go/src/runtime/panic.go:890 +0x262
encoding/binary.littleEndian.Uint64(...)
	.../go/src/encoding/binary/binary.go:102
github.com/go-mysql-org/go-mysql/replication.(*RowsEvent).decodeValue(0xc00023b110, {0xc00021a06f, 0x7, 0x9}, 0xc, 0x0)
	.../go-mysql/replication/row_event.go:1088 +0x1731
github.com/go-mysql-org/go-mysql/replication.(*RowsEvent).decodeRows(0xc00023b110, {0xc00021a06a, 0xc, 0xe}, 0xc000242200, {0xc00021a069, 0x1, 0x3?})
	.../go-mysql/replication/row_event.go:988 +0x556
github.com/go-mysql-org/go-mysql/replication.(*RowsEvent).DecodeData(0xc00023b110, 0xa, {0xc00021a060, 0x16, 0x18})
	
PASS: row_event_test.go:1188: testDecodeSuite.TestInvalidEvent	0.001s

```
doesn't look very friendly :)

This change doesn't break testDecodeSuite.TestInvalidEvent()