### PR TITLE
Allow to run all tests with mysql:8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,13 @@ build:
 test:
 	go test --race -timeout 2m ./...
 
+MYSQL_VERSION ?= 5.7
 test-local:
 	docker run --rm -d --network=host --name go-mysql-server \
 		-e MYSQL_ALLOW_EMPTY_PASSWORD=true \
 		-e MYSQL_DATABASE=test \
 		-v $${PWD}/docker/resources/replication.cnf:/etc/mysql/conf.d/replication.cnf \
-		mysql:5.7
+		mysql:$(MYSQL_VERSION)
 	docker/resources/waitfor.sh 127.0.0.1 3306 \
 		&& go test -race -v -timeout 2m ./... -gocheck.v
 	docker stop go-mysql-server

--- a/client/auth.go
+++ b/client/auth.go
@@ -43,7 +43,9 @@ func (c *Conn) readInitialHandshake() error {
 
 	// skip mysql version
 	// mysql version end with 0x00
-	pos := 1 + bytes.IndexByte(data[1:], 0x00) + 1
+	version := data[1 : bytes.IndexByte(data[1:], 0x00)+1]
+	c.serverVersion = string(version)
+	pos := 1 + len(version)
 
 	// connection id length is 4
 	c.connectionID = binary.LittleEndian.Uint32(data[pos : pos+4])
@@ -68,7 +70,7 @@ func (c *Conn) readInitialHandshake() error {
 
 	if len(data) > pos {
 		// skip server charset
-		//c.charset = data[pos]
+		// c.charset = data[pos]
 		pos += 1
 
 		c.status = binary.LittleEndian.Uint16(data[pos : pos+2])
@@ -194,14 +196,14 @@ func (c *Conn) writeAuthHandshake() error {
 		capability |= CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA
 	}
 
-	//packet length
-	//capability 4
-	//max-packet size 4
-	//charset 1
-	//reserved all[0] 23
-	//username
-	//auth
-	//mysql_native_password + null-terminated
+	// packet length
+	// capability 4
+	// max-packet size 4
+	// charset 1
+	// reserved all[0] 23
+	// username
+	// auth
+	// mysql_native_password + null-terminated
 	length := 4 + 4 + 1 + 23 + len(c.user) + 1 + len(authRespLEI) + len(auth) + 21 + 1
 	if addNull {
 		length++

--- a/client/conn.go
+++ b/client/conn.go
@@ -24,6 +24,7 @@ type Conn struct {
 	tlsConfig *tls.Config
 	proto     string
 
+	serverVersion string
 	// server capabilities
 	capability uint32
 	// client-set capabilities only
@@ -191,6 +192,10 @@ func (c *Conn) UseDB(dbName string) error {
 
 func (c *Conn) GetDB() string {
 	return c.db
+}
+
+func (c *Conn) GetServerVersion() string {
+	return c.serverVersion
 }
 
 func (c *Conn) Execute(command string, args ...interface{}) (*Result, error) {

--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,6 @@ require (
 	github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726
 	github.com/siddontang/go-log v0.0.0-20180807004314-8d05993dda07
 	github.com/stretchr/testify v1.8.0
+	golang.org/x/mod v0.3.0
 	golang.org/x/tools v0.0.0-20201125231158-b5590deeca9b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,7 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/exp v0.0.0-20181106170214-d68db9428509/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=


### PR DESCRIPTION
With a small fix, we can run all our tests with mysql 5 and 8.