### PR TITLE
Add support for MariaDB compressed binlog events

### DIFF
--- a/canal/sync.go
+++ b/canal/sync.go
@@ -253,11 +253,11 @@ func (c *Canal) handleRowsEvent(e *replication.BinlogEvent) error {
 	}
 	var action string
 	switch e.Header.EventType {
-	case replication.WRITE_ROWS_EVENTv1, replication.WRITE_ROWS_EVENTv2:
+	case replication.WRITE_ROWS_EVENTv1, replication.WRITE_ROWS_EVENTv2, replication.MARIADB_WRITE_ROWS_COMPRESSED_EVENT_V1:
 		action = InsertAction
-	case replication.DELETE_ROWS_EVENTv1, replication.DELETE_ROWS_EVENTv2:
+	case replication.DELETE_ROWS_EVENTv1, replication.DELETE_ROWS_EVENTv2, replication.MARIADB_DELETE_ROWS_COMPRESSED_EVENT_V1:
 		action = DeleteAction
-	case replication.UPDATE_ROWS_EVENTv1, replication.UPDATE_ROWS_EVENTv2:
+	case replication.UPDATE_ROWS_EVENTv1, replication.UPDATE_ROWS_EVENTv2, replication.MARIADB_UPDATE_ROWS_COMPRESSED_EVENT_V1:
 		action = UpdateAction
 	default:
 		return errors.Errorf("%s not supported now", e.Header.EventType)

--- a/replication/const.go
+++ b/replication/const.go
@@ -101,6 +101,11 @@ const (
 	MARIADB_BINLOG_CHECKPOINT_EVENT
 	MARIADB_GTID_EVENT
 	MARIADB_GTID_LIST_EVENT
+	MARIADB_START_ENCRYPTION_EVENT
+	MARIADB_QUERY_COMPRESSED_EVENT
+	MARIADB_WRITE_ROWS_COMPRESSED_EVENT_V1
+	MARIADB_UPDATE_ROWS_COMPRESSED_EVENT_V1
+	MARIADB_DELETE_ROWS_COMPRESSED_EVENT_V1
 )
 
 func (e EventType) String() string {
@@ -197,6 +202,12 @@ func (e EventType) String() string {
 		return "TransactionPayloadEvent"
 	case HEARTBEAT_LOG_EVENT_V2:
 		return "HeartbeatLogEventV2"
+	case MARIADB_WRITE_ROWS_COMPRESSED_EVENT_V1:
+		return "MariadbWriteRowsCompressedEventV1"
+	case MARIADB_UPDATE_ROWS_COMPRESSED_EVENT_V1:
+		return "MariadbUpdateRowsCompressedEventV1"
+	case MARIADB_DELETE_ROWS_COMPRESSED_EVENT_V1:
+		return "MariadbDeleteRowsCompressedEventV1"
 
 	default:
 		return "UnknownEvent"

--- a/replication/const.go
+++ b/replication/const.go
@@ -202,6 +202,10 @@ func (e EventType) String() string {
 		return "TransactionPayloadEvent"
 	case HEARTBEAT_LOG_EVENT_V2:
 		return "HeartbeatLogEventV2"
+	case MARIADB_START_ENCRYPTION_EVENT:
+		return "MariadbStartEncryptionEvent"
+	case MARIADB_QUERY_COMPRESSED_EVENT:
+		return "MariadbQueryCompressedEvent"
 	case MARIADB_WRITE_ROWS_COMPRESSED_EVENT_V1:
 		return "MariadbWriteRowsCompressedEventV1"
 	case MARIADB_UPDATE_ROWS_COMPRESSED_EVENT_V1:

--- a/replication/event.go
+++ b/replication/event.go
@@ -297,6 +297,9 @@ type QueryEvent struct {
 	Schema        []byte
 	Query         []byte
 
+	// for mariadb QUERY_COMPRESSED_EVENT
+	compressed bool
+
 	// in fact QueryEvent dosen't have the GTIDSet information, just for beneficial to use
 	GSet GTIDSet
 }
@@ -328,7 +331,15 @@ func (e *QueryEvent) Decode(data []byte) error {
 	//skip 0x00
 	pos++
 
-	e.Query = data[pos:]
+	if e.compressed {
+		decompressedQuery, err := DecompressMariadbData(data[pos:])
+		if err != nil {
+			return err
+		}
+		e.Query = decompressedQuery
+	} else {
+		e.Query = data[pos:]
+	}
 	return nil
 }
 

--- a/replication/parser.go
+++ b/replication/parser.go
@@ -270,7 +270,11 @@ func (p *BinlogParser) parseEvent(h *EventHeader, data []byte, rawData []byte) (
 				WRITE_ROWS_EVENTv2,
 				UPDATE_ROWS_EVENTv2,
 				DELETE_ROWS_EVENTv2,
+				MARIADB_WRITE_ROWS_COMPRESSED_EVENT_V1,
+				MARIADB_UPDATE_ROWS_COMPRESSED_EVENT_V1,
+				MARIADB_DELETE_ROWS_COMPRESSED_EVENT_V1,
 				PARTIAL_UPDATE_ROWS_EVENT: // Extension of UPDATE_ROWS_EVENT, allowing partial values according to binlog_row_value_options
+
 				e = p.newRowsEvent(h)
 			case ROWS_QUERY_EVENT:
 				e = &RowsQueryEvent{}
@@ -411,6 +415,16 @@ func (p *BinlogParser) newRowsEvent(h *EventHeader) *RowsEvent {
 		e.Version = 1
 	case UPDATE_ROWS_EVENTv1:
 		e.Version = 1
+		e.needBitmap2 = true
+	case MARIADB_WRITE_ROWS_COMPRESSED_EVENT_V1:
+		e.Version = 1
+		e.compressed = true
+	case MARIADB_DELETE_ROWS_COMPRESSED_EVENT_V1:
+		e.Version = 1
+		e.compressed = true
+	case MARIADB_UPDATE_ROWS_COMPRESSED_EVENT_V1:
+		e.Version = 1
+		e.compressed = true
 		e.needBitmap2 = true
 	case WRITE_ROWS_EVENTv2:
 		e.Version = 2

--- a/replication/parser.go
+++ b/replication/parser.go
@@ -249,6 +249,10 @@ func (p *BinlogParser) parseEvent(h *EventHeader, data []byte, rawData []byte) (
 			switch h.EventType {
 			case QUERY_EVENT:
 				e = &QueryEvent{}
+			case MARIADB_QUERY_COMPRESSED_EVENT:
+				e = &QueryEvent{
+					compressed: true,
+				}
 			case XID_EVENT:
 				e = &XIDEvent{}
 			case TABLE_MAP_EVENT:


### PR DESCRIPTION
This would fix https://github.com/go-mysql-org/go-mysql/issues/204

Events doc: https://mariadb.com/kb/en/rows_event_v1v2-rows_compressed_event_v1/

Based on [this](https://github.com/mariadb-corporation/mariadb-connector-c/blob/c2b322d2ca27ef66385d9938b98541c7cf14ac74/libmariadb/mariadb_rpl.c#L861) and [this](https://github.com/mariadb-corporation/mariadb-connector-c/blob/c2b322d2ca27ef66385d9938b98541c7cf14ac74/libmariadb/mariadb_rpl.c#L1771-L1789) 