### PR TITLE
Set library specific connection attributes

### DIFF
--- a/client/conn.go
+++ b/client/conn.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"runtime"
 	"strings"
 	"time"
 
@@ -77,6 +78,14 @@ type Dialer func(ctx context.Context, network, address string) (net.Conn, error)
 // Connect to a MySQL server using the given Dialer.
 func ConnectWithDialer(ctx context.Context, network string, addr string, user string, password string, dbName string, dialer Dialer, options ...func(*Conn)) (*Conn, error) {
 	c := new(Conn)
+
+	c.attributes = map[string]string{
+		"_client_name": "go-mysql",
+		// "_client_version": "0.1",
+		"_os":              runtime.GOOS,
+		"_platform":        runtime.GOARCH,
+		"_runtime_version": runtime.Version(),
+	}
 
 	if network == "" {
 		network = getNetProto(addr)
@@ -317,7 +326,9 @@ func (c *Conn) Rollback() error {
 }
 
 func (c *Conn) SetAttributes(attributes map[string]string) {
-	c.attributes = attributes
+	for k, v := range attributes {
+		c.attributes[k] = v
+	}
 }
 
 func (c *Conn) SetCharset(charset string) error {

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -891,6 +891,7 @@ func (b *BinlogSyncer) newConnection(ctx context.Context) (*client.Conn, error) 
 	return client.ConnectWithDialer(timeoutCtx, "", addr, b.cfg.User, b.cfg.Password,
 		"", b.cfg.Dialer, func(c *client.Conn) {
 			c.SetTLSConfig(b.cfg.TLSConfig)
+			c.SetAttributes(map[string]string{"_client_role": "binary_log_listener"})
 		})
 }
 


### PR DESCRIPTION
Set connection attributes like `_platform`, `_os`, `_client_name`, etc. by default. 

Have `SetAttributes()` update the map instead of overwriting it.

This makes it behave similar to other MySQL clients.

See also: https://dev.mysql.com/doc/refman/8.0/en/performance-schema-connection-attribute-tables.html

Wireshark:
![image](https://user-images.githubusercontent.com/1272980/236465174-ba1ee1e3-5615-4651-850d-91ea0ee514fa.png)

Example:
```go
package main

import "github.com/go-mysql-org/go-mysql/client"

func main() {
	conn, _ := client.Connect("127.0.0.1:4000", "root", "", "test", func(c *client.Conn) {
		c.SetAttributes(map[string]string{"app": "myapp"})
	})

	conn.Ping()
	conn.Close()
}
```