### PR TITLE
Switch zstd library to allow build on arm64 and amd64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [ 1.19, 1.18, 1.17, 1.16 ]
+        go: [ "1.20", "1.19", "1.18" ]
         os: [ ubuntu-22.04, ubuntu-20.04 ]
     name: Tests Go ${{ matrix.go }} # This name is used in main branch protection rules
     runs-on: ${{ matrix.os }}
@@ -49,3 +49,23 @@ jobs:
         with:
           version: latest
           args: --timeout=3m
+
+  platforms:
+    strategy:
+      matrix:
+        arch: [ "amd64", "arm64" ]
+        os: [ "linux", "freebsd", "darwin" ]
+    name: platforms
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare for Go
+        run: |
+          sudo apt-get install -y make gcc
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.20"
+      - name: Checkout code
+        uses: actions/checkout@v1
+      - name: Build on ${{ matrix.os }}/${{ matrix.arch }}
+        run: GOARCH=${{ matrix.arch }} GOOS=${{ matrix.os }} go build ./...

--- a/go.mod
+++ b/go.mod
@@ -1,21 +1,34 @@
 module github.com/go-mysql-org/go-mysql
 
-go 1.16
+go 1.18
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/DataDog/zstd v1.5.2
 	github.com/Masterminds/semver v1.5.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/jmoiron/sqlx v1.3.3
+	github.com/klauspost/compress v1.16.6
 	github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8
 	github.com/pingcap/errors v0.11.5-0.20210425183316-da1aaba5fb63
 	github.com/pingcap/tidb/parser v0.0.0-20221126021158-6b02a5d8ba7d
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24
 	github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726
 	github.com/siddontang/go-log v0.0.0-20180807004314-8d05993dda07
 	github.com/stretchr/testify v1.8.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.4.0 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	go.uber.org/zap v1.18.1 // indirect
+	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/tools v0.0.0-20201125231158-b5590deeca9b // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
-github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -19,6 +17,8 @@ github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jmoiron/sqlx v1.3.3 h1:j82X0bf7oQ27XeqxicSZsTU5suPwKElg3oyxNn43iTk=
 github.com/jmoiron/sqlx v1.3.3/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
+github.com/klauspost/compress v1.16.6 h1:91SKEy4K37vkp255cJ8QesJhjyRO0hn9i9G0GoUwLsk=
+github.com/klauspost/compress v1.16.6/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/packet/conn.go
+++ b/packet/conn.go
@@ -13,9 +13,9 @@ import (
 	"net"
 	"sync"
 
-	"github.com/DataDog/zstd"
 	. "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/utils"
+	"github.com/klauspost/compress/zstd"
 	"github.com/pingcap/errors"
 )
 
@@ -125,7 +125,7 @@ func (c *Conn) ReadPacketReuseMem(dst []byte) ([]byte, error) {
 				case MYSQL_COMPRESS_ZLIB:
 					c.compressedReader, err = zlib.NewReader(c.reader)
 				case MYSQL_COMPRESS_ZSTD:
-					c.compressedReader = zstd.NewReader(c.reader)
+					c.compressedReader, err = zstd.NewReader(c.reader)
 				}
 				if err != nil {
 					return nil, err
@@ -290,7 +290,7 @@ func (c *Conn) writeCompressed(data []byte) (n int, err error) {
 	case MYSQL_COMPRESS_ZLIB:
 		w, err = zlib.NewWriterLevel(&payload, zlib.HuffmanOnly)
 	case MYSQL_COMPRESS_ZSTD:
-		w = zstd.NewWriter(&payload)
+		w, err = zstd.NewWriter(&payload)
 	}
 	if err != nil {
 		return 0, err

--- a/replication/transaction_payload_event.go
+++ b/replication/transaction_payload_event.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/DataDog/zstd"
+	"github.com/klauspost/compress/zstd"
 
 	. "github.com/go-mysql-org/go-mysql/mysql"
 )
@@ -104,7 +104,13 @@ func (e *TransactionPayloadEvent) decodePayload() error {
 			e.CompressionType, e.compressionType())
 	}
 
-	payloadUncompressed, err := zstd.Decompress(nil, e.Payload)
+	var decoder, err = zstd.NewReader(nil, zstd.WithDecoderConcurrency(0))
+	if err != nil {
+		return err
+	}
+	defer decoder.Close()
+
+	payloadUncompressed, err := decoder.DecodeAll(e.Payload, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #799 

- Allow build on ARM64
- Switch from `github.com/DataDog/zstd` to `github.com/klauspost/compress`
- Change go version from 1.16 to 1.18 in `go.mod`
- Add basic CI tests for building for various OS and Arch combinations

Note that this basically removes support for older versions of Go (1.17 and 1.16)