### PR TITLE
refactor: modify the form of variable declarations

### DIFF
--- a/cmd/go-binlogparser/main.go
+++ b/cmd/go-binlogparser/main.go
@@ -7,8 +7,10 @@ import (
 	"github.com/go-mysql-org/go-mysql/replication"
 )
 
-var name = flag.String("name", "", "binlog file name")
-var offset = flag.Int64("offset", 0, "parse start offset")
+var (
+	name   = flag.String("name", "", "binlog file name")
+	offset = flag.Int64("offset", 0, "parse start offset")
+)
 
 func main() {
 	flag.Parse()

--- a/cmd/go-canal/main.go
+++ b/cmd/go-canal/main.go
@@ -15,26 +15,28 @@ import (
 	"github.com/go-mysql-org/go-mysql/mysql"
 )
 
-var host = flag.String("host", "127.0.0.1", "MySQL host")
-var port = flag.Int("port", 3306, "MySQL port")
-var user = flag.String("user", "root", "MySQL user, must have replication privilege")
-var password = flag.String("password", "", "MySQL password")
+var (
+	host     = flag.String("host", "127.0.0.1", "MySQL host")
+	port     = flag.Int("port", 3306, "MySQL port")
+	user     = flag.String("user", "root", "MySQL user, must have replication privilege")
+	password = flag.String("password", "", "MySQL password")
 
-var flavor = flag.String("flavor", "mysql", "Flavor: mysql or mariadb")
+	flavor = flag.String("flavor", "mysql", "Flavor: mysql or mariadb")
 
-var serverID = flag.Int("server-id", 101, "Unique Server ID")
-var mysqldump = flag.String("mysqldump", "mysqldump", "mysqldump execution path")
+	serverID  = flag.Int("server-id", 101, "Unique Server ID")
+	mysqldump = flag.String("mysqldump", "mysqldump", "mysqldump execution path")
 
-var dbs = flag.String("dbs", "test", "dump databases, separated by comma")
-var tables = flag.String("tables", "", "dump tables, separated by comma, will overwrite dbs")
-var tableDB = flag.String("table_db", "test", "database for dump tables")
-var ignoreTables = flag.String("ignore_tables", "", "ignore tables, must be database.table format, separated by comma")
+	dbs          = flag.String("dbs", "test", "dump databases, separated by comma")
+	tables       = flag.String("tables", "", "dump tables, separated by comma, will overwrite dbs")
+	tableDB      = flag.String("table_db", "test", "database for dump tables")
+	ignoreTables = flag.String("ignore_tables", "", "ignore tables, must be database.table format, separated by comma")
 
-var startName = flag.String("bin_name", "", "start sync from binlog name")
-var startPos = flag.Uint("bin_pos", 0, "start sync from binlog position of")
+	startName = flag.String("bin_name", "", "start sync from binlog name")
+	startPos  = flag.Uint("bin_pos", 0, "start sync from binlog position of")
 
-var heartbeatPeriod = flag.Duration("heartbeat", 60*time.Second, "master heartbeat period")
-var readTimeout = flag.Duration("read_timeout", 90*time.Second, "connection read timeout")
+	heartbeatPeriod = flag.Duration("heartbeat", 60*time.Second, "master heartbeat period")
+	readTimeout     = flag.Duration("read_timeout", 90*time.Second, "connection read timeout")
+)
 
 func main() {
 	flag.Parse()

--- a/cmd/go-mysqlbinlog/main.go
+++ b/cmd/go-mysqlbinlog/main.go
@@ -15,21 +15,23 @@ import (
 	"github.com/go-mysql-org/go-mysql/replication"
 )
 
-var host = flag.String("host", "127.0.0.1", "MySQL host")
-var port = flag.Int("port", 3306, "MySQL port")
-var user = flag.String("user", "root", "MySQL user, must have replication privilege")
-var password = flag.String("password", "", "MySQL password")
+var (
+	host     = flag.String("host", "127.0.0.1", "MySQL host")
+	port     = flag.Int("port", 3306, "MySQL port")
+	user     = flag.String("user", "root", "MySQL user, must have replication privilege")
+	password = flag.String("password", "", "MySQL password")
 
-var flavor = flag.String("flavor", "mysql", "Flavor: mysql or mariadb")
+	flavor = flag.String("flavor", "mysql", "Flavor: mysql or mariadb")
 
-var file = flag.String("file", "", "Binlog filename")
-var pos = flag.Int("pos", 4, "Binlog position")
-var gtid = flag.String("gtid", "", "Binlog GTID set that this slave has executed")
+	file = flag.String("file", "", "Binlog filename")
+	pos  = flag.Int("pos", 4, "Binlog position")
+	gtid = flag.String("gtid", "", "Binlog GTID set that this slave has executed")
 
-var semiSync = flag.Bool("semisync", false, "Support semi sync")
-var backupPath = flag.String("backup_path", "", "backup path to store binlog files")
+	semiSync   = flag.Bool("semisync", false, "Support semi sync")
+	backupPath = flag.String("backup_path", "", "backup path to store binlog files")
 
-var rawMode = flag.Bool("raw", false, "Use raw mode")
+	rawMode = flag.Bool("raw", false, "Use raw mode")
+)
 
 func main() {
 	flag.Parse()

--- a/cmd/go-mysqldump/main.go
+++ b/cmd/go-mysqldump/main.go
@@ -6,20 +6,23 @@ import (
 	"os"
 	"strings"
 
-	"github.com/go-mysql-org/go-mysql/dump"
 	"github.com/pingcap/errors"
+
+	"github.com/go-mysql-org/go-mysql/dump"
 )
 
-var addr = flag.String("addr", "127.0.0.1:3306", "MySQL addr")
-var user = flag.String("user", "root", "MySQL user")
-var password = flag.String("password", "", "MySQL password")
-var execution = flag.String("exec", "mysqldump", "mysqldump execution path")
-var output = flag.String("o", "", "dump output, empty for stdout")
+var (
+	addr      = flag.String("addr", "127.0.0.1:3306", "MySQL addr")
+	user      = flag.String("user", "root", "MySQL user")
+	password  = flag.String("password", "", "MySQL password")
+	execution = flag.String("exec", "mysqldump", "mysqldump execution path")
+	output    = flag.String("o", "", "dump output, empty for stdout")
 
-var dbs = flag.String("dbs", "", "dump databases, separated by comma")
-var tables = flag.String("tables", "", "dump tables, separated by comma, will overwrite dbs")
-var tableDB = flag.String("table_db", "", "database for dump tables")
-var ignoreTables = flag.String("ignore_tables", "", "ignore tables, must be database.table format, separated by comma")
+	dbs          = flag.String("dbs", "", "dump databases, separated by comma")
+	tables       = flag.String("tables", "", "dump tables, separated by comma, will overwrite dbs")
+	tableDB      = flag.String("table_db", "", "database for dump tables")
+	ignoreTables = flag.String("ignore_tables", "", "ignore tables, must be database.table format, separated by comma")
+)
 
 func main() {
 	flag.Parse()


### PR DESCRIPTION
I've changed the form of variable declarations which make the code look better (maybe...) 

the comparison is following :

before:
```go
var host = flag.String("host", "127.0.0.1", "MySQL host")
var port = flag.Int("port", 3306, "MySQL port")
var user = flag.String("user", "root", "MySQL user, must have replication privilege")
var password = flag.String("password", "", "MySQL password")
```
after:
```go
var (
	host     = flag.String("host", "127.0.0.1", "MySQL host")
	port     = flag.Int("port", 3306, "MySQL port")
	user     = flag.String("user", "root", "MySQL user, must have replication privilege")
	password = flag.String("password", "", "MySQL password")
)
```

I am not sure if this change is necessary, but if not, please ignore. :)
thank u for reviewing. 🫡 
