### PR TITLE
Add EventCacheCount as member of BinlogSyncerConfig to limit streamer's event channel size

### DIFF
--- a/replication/binlogstreamer.go
+++ b/replication/binlogstreamer.go
@@ -87,7 +87,7 @@ func (s *BinlogStreamer) closeWithError(err error) {
 func NewBinlogStreamer() *BinlogStreamer {
 	s := new(BinlogStreamer)
 
-	s.ch = make(chan *BinlogEvent, 10240)
+	s.ch = make(chan *BinlogEvent, 16)
 	s.ech = make(chan error, 4)
 
 	return s

--- a/replication/binlogstreamer.go
+++ b/replication/binlogstreamer.go
@@ -85,9 +85,17 @@ func (s *BinlogStreamer) closeWithError(err error) {
 }
 
 func NewBinlogStreamer() *BinlogStreamer {
+	return NewBinlogStreamerWithChanSize(10240)
+}
+
+func NewBinlogStreamerWithChanSize(chanSize int) *BinlogStreamer {
 	s := new(BinlogStreamer)
 
-	s.ch = make(chan *BinlogEvent, 16)
+	if chanSize <= 0 {
+		chanSize = 10240
+	}
+
+	s.ch = make(chan *BinlogEvent, chanSize)
 	s.ech = make(chan error, 4)
 
 	return s

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -123,7 +123,7 @@ type BinlogSyncerConfig struct {
 
 	DiscardGTIDSet bool
 
-	StreamerChanSize int
+	EventCacheSize int
 }
 
 // BinlogSyncer syncs binlog event from server.
@@ -168,8 +168,8 @@ func NewBinlogSyncer(cfg BinlogSyncerConfig) *BinlogSyncer {
 		dialer := &net.Dialer{}
 		cfg.Dialer = dialer.DialContext
 	}
-	if cfg.StreamerChanSize == 0 {
-		cfg.StreamerChanSize = 10240
+	if cfg.EventCacheSize == 0 {
+		cfg.EventCacheSize = 10240
 	}
 
 	// Clear the Password to avoid outputing it in log.
@@ -398,7 +398,7 @@ func (b *BinlogSyncer) prepare() error {
 func (b *BinlogSyncer) startDumpStream() *BinlogStreamer {
 	b.running = true
 
-	s := NewBinlogStreamerWithChanSize(b.cfg.StreamerChanSize)
+	s := NewBinlogStreamerWithChanSize(b.cfg.EventCacheSize)
 
 	b.wg.Add(1)
 	go b.onStream(s)

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -123,7 +123,7 @@ type BinlogSyncerConfig struct {
 
 	DiscardGTIDSet bool
 
-	EventCacheSize int
+	EventCacheCount int
 }
 
 // BinlogSyncer syncs binlog event from server.
@@ -168,8 +168,8 @@ func NewBinlogSyncer(cfg BinlogSyncerConfig) *BinlogSyncer {
 		dialer := &net.Dialer{}
 		cfg.Dialer = dialer.DialContext
 	}
-	if cfg.EventCacheSize == 0 {
-		cfg.EventCacheSize = 10240
+	if cfg.EventCacheCount == 0 {
+		cfg.EventCacheCount = 10240
 	}
 
 	// Clear the Password to avoid outputing it in log.
@@ -398,7 +398,7 @@ func (b *BinlogSyncer) prepare() error {
 func (b *BinlogSyncer) startDumpStream() *BinlogStreamer {
 	b.running = true
 
-	s := NewBinlogStreamerWithChanSize(b.cfg.EventCacheSize)
+	s := NewBinlogStreamerWithChanSize(b.cfg.EventCacheCount)
 
 	b.wg.Add(1)
 	go b.onStream(s)


### PR DESCRIPTION
#829 
I have tested on my own MySQL instance with an 8GB size Binlog, when the channel size is the default 10240, during the Binlog transmission, occasional nearly 2GB memory usage will be seen. 
Additionally, I have written a test program to calculate the theoretical maximum memory usage size under different channel size situations.  The theoretical result match the test. 

This is the theoretical usage calc function: 
`
func (c *MySQLClient) GetMaxWindowSize(ctx context.Context, streamerLength uint16) (es *EventStatistic, err error) {
	es = new(EventStatistic)
	es.StreamerChannelLength = streamerLength
	startTime := time.Now()

	// get streamer
	_, streamer, err := c.GetBinlogStreamer(true, streamerLength)
	if err != nil {
		return nil, err
	}
	// defer syncer.Close()
	defer func() {
		es.Duration = time.Since(startTime)
	}()

	// move window
	var window []uint32
	var currentWindowSize uint32
	var ev *replication.BinlogEvent

	var filename string
	var offset uint32

	var f *os.File
	defer func() {
		if f != nil {
			f.Close()
		}
	}()

	// get event time
	parser := replication.NewBinlogParser()
	parser.SetRawMode(true)
	for {
		eventCTX, cancel := context.WithTimeout(ctx, 5*time.Second)
		ev, err = streamer.GetEvent(eventCTX)
		cancel()
		if err == context.DeadlineExceeded {
			return es, nil
		}
		if ev == nil {
			return es, nil
		}
		es.Count++
		// calc the event size
		eventSize := ev.Header.EventSize
		es.TotalSize += uint64(eventSize)

		// add event to the window
		window = append(window, eventSize)
		currentWindowSize += eventSize

		// move event out of window
		if uint16(len(window)) > streamerLength {
			currentWindowSize -= window[0]
			window = window[1:]
		}

		if currentWindowSize > es.MaxStreamerChannelSize {
			es.MaxStreamerChannelSize = currentWindowSize
		}

		offset = ev.Header.LogPos

		if ev.Header.EventType == replication.ROTATE_EVENT {
			rotateEvent := ev.Event.(*replication.RotateEvent)
			filename = string(rotateEvent.NextLogName)

			if ev.Header.Timestamp == 0 || offset == 0 {
				// fake rotate event
				continue
			}
		} else if ev.Header.EventType == replication.FORMAT_DESCRIPTION_EVENT {
			// FormateDescriptionEvent is the first event in binlog, we will close old one and create a new

			if f != nil {
				f.Close()
			}

			if len(filename) == 0 {
				return nil, errors.Errorf("empty binlog filename for FormateDescriptionEvent")
			}

			f, err = os.OpenFile(path.Join("./", filename), os.O_CREATE|os.O_WRONLY, 0644)
			if err != nil {
				return nil, errors.Trace(err)
			}

			// write binlog header fe'bin'
			if _, err = f.Write(replication.BinLogFileHeader); err != nil {
				return nil, errors.Trace(err)
			}
		}

		if n, err := f.Write(ev.RawData); err != nil {
			return nil, errors.Trace(err)
		} else if n != len(ev.RawData) {
			return nil, errors.Trace(io.ErrShortWrite)
		}
		if es.Count > 1 && ev.Header.EventType == replication.ROTATE_EVENT {
			return es, nil
		}
	}
}`