### PR TITLE
Add a optional function to decode optional meta of table map event

### DIFF
--- a/replication/binlogstreamer.go
+++ b/replication/binlogstreamer.go
@@ -87,7 +87,7 @@ func (s *BinlogStreamer) closeWithError(err error) {
 func NewBinlogStreamer() *BinlogStreamer {
 	s := new(BinlogStreamer)
 
-	s.ch = make(chan *BinlogEvent, 10240)
+	s.ch = make(chan *BinlogEvent, 16)
 	s.ech = make(chan error, 4)
 
 	return s

--- a/replication/binlogstreamer.go
+++ b/replication/binlogstreamer.go
@@ -85,9 +85,17 @@ func (s *BinlogStreamer) closeWithError(err error) {
 }
 
 func NewBinlogStreamer() *BinlogStreamer {
+	return NewBinlogStreamerWithChanSize(10240)
+}
+
+func NewBinlogStreamerWithChanSize(chanSize int) *BinlogStreamer {
 	s := new(BinlogStreamer)
 
-	s.ch = make(chan *BinlogEvent, 16)
+	if chanSize <= 0 {
+		chanSize = 10240
+	}
+
+	s.ch = make(chan *BinlogEvent, chanSize)
 	s.ech = make(chan error, 4)
 
 	return s

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -123,7 +123,7 @@ type BinlogSyncerConfig struct {
 
 	DiscardGTIDSet bool
 
-	StreamerChanSize int
+	EventCacheSize int
 }
 
 // BinlogSyncer syncs binlog event from server.
@@ -168,8 +168,8 @@ func NewBinlogSyncer(cfg BinlogSyncerConfig) *BinlogSyncer {
 		dialer := &net.Dialer{}
 		cfg.Dialer = dialer.DialContext
 	}
-	if cfg.StreamerChanSize == 0 {
-		cfg.StreamerChanSize = 10240
+	if cfg.EventCacheSize == 0 {
+		cfg.EventCacheSize = 10240
 	}
 
 	// Clear the Password to avoid outputing it in log.
@@ -398,7 +398,7 @@ func (b *BinlogSyncer) prepare() error {
 func (b *BinlogSyncer) startDumpStream() *BinlogStreamer {
 	b.running = true
 
-	s := NewBinlogStreamerWithChanSize(b.cfg.StreamerChanSize)
+	s := NewBinlogStreamerWithChanSize(b.cfg.EventCacheSize)
 
 	b.wg.Add(1)
 	go b.onStream(s)

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -121,6 +121,8 @@ type BinlogSyncerConfig struct {
 
 	RowsEventDecodeFunc func(*RowsEvent, []byte) error
 
+	TableMapOptionalMetaDecodeFunc func([]byte) error
+
 	DiscardGTIDSet bool
 
 	EventCacheCount int
@@ -189,6 +191,7 @@ func NewBinlogSyncer(cfg BinlogSyncerConfig) *BinlogSyncer {
 	b.parser.SetUseDecimal(b.cfg.UseDecimal)
 	b.parser.SetVerifyChecksum(b.cfg.VerifyChecksum)
 	b.parser.SetRowsEventDecodeFunc(b.cfg.RowsEventDecodeFunc)
+	b.parser.SetTableMapOptionalMetaDecodeFunc(b.cfg.TableMapOptionalMetaDecodeFunc)
 	b.running = false
 	b.ctx, b.cancel = context.WithCancel(context.Background())
 

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -123,7 +123,7 @@ type BinlogSyncerConfig struct {
 
 	DiscardGTIDSet bool
 
-	EventCacheSize int
+	EventCacheCount int
 }
 
 // BinlogSyncer syncs binlog event from server.
@@ -168,8 +168,8 @@ func NewBinlogSyncer(cfg BinlogSyncerConfig) *BinlogSyncer {
 		dialer := &net.Dialer{}
 		cfg.Dialer = dialer.DialContext
 	}
-	if cfg.EventCacheSize == 0 {
-		cfg.EventCacheSize = 10240
+	if cfg.EventCacheCount == 0 {
+		cfg.EventCacheCount = 10240
 	}
 
 	// Clear the Password to avoid outputing it in log.
@@ -398,7 +398,7 @@ func (b *BinlogSyncer) prepare() error {
 func (b *BinlogSyncer) startDumpStream() *BinlogStreamer {
 	b.running = true
 
-	s := NewBinlogStreamerWithChanSize(b.cfg.EventCacheSize)
+	s := NewBinlogStreamerWithChanSize(b.cfg.EventCacheCount)
 
 	b.wg.Add(1)
 	go b.onStream(s)

--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -84,6 +84,8 @@ type TableMapEvent struct {
 
 	// VisibilityBitmap stores bits that are set if corresponding column is not invisible (MySQL 8.0.23+)
 	VisibilityBitmap []byte
+
+	optionalMetaDecodeFunc func(data []byte) (err error)
 }
 
 func (e *TableMapEvent) Decode(data []byte) error {
@@ -140,8 +142,14 @@ func (e *TableMapEvent) Decode(data []byte) error {
 
 	pos += nullBitmapSize
 
-	if err = e.decodeOptionalMeta(data[pos:]); err != nil {
-		return err
+	if e.optionalMetaDecodeFunc != nil {
+		if err = e.optionalMetaDecodeFunc(data[pos:]); err != nil {
+			return err
+		}
+	} else {
+		if err = e.decodeOptionalMeta(data[pos:]); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
I have a hacked version of MySQL which has a UDF optional meta in table map event. I managed to add a TableMapOptionalMetaDecodeFunc to decode the optional meta.