### PR TITLE
Update client pool logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test-local:
 		-v $${PWD}/docker/resources/replication.cnf:/etc/mysql/conf.d/replication.cnf \
 		mysql:$(MYSQL_VERSION)
 	docker/resources/waitfor.sh 127.0.0.1 3306 \
-		&& go test -race -v -timeout 2m ./client/...
+		&& go test -race -v -timeout 2m ./...
 	docker stop go-mysql-server
 
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test-local:
 		-v $${PWD}/docker/resources/replication.cnf:/etc/mysql/conf.d/replication.cnf \
 		mysql:$(MYSQL_VERSION)
 	docker/resources/waitfor.sh 127.0.0.1 3306 \
-		&& go test -race -v -timeout 2m ./... -gocheck.v
+		&& go test -race -v -timeout 2m ./client/...
 	docker stop go-mysql-server
 
 fmt:

--- a/client/pool.go
+++ b/client/pool.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"log"
 	"math"
 	"math/rand"
 	"sync"
@@ -85,12 +86,13 @@ func NewPoolWithOptions(
 	dbName string,
 	options ...PoolOption,
 ) (*Pool, error) {
-	po := poolOptions{
-		addr:     addr,
-		user:     user,
-		password: password,
-		dbName:   dbName,
-	}
+	po := getDefaultPoolOptions()
+
+	po.addr = addr
+	po.user = user
+	po.password = password
+	po.dbName = dbName
+
 	for _, o := range options {
 		o(&po)
 	}
@@ -596,5 +598,15 @@ func (pool *Pool) checkConnection(ctx context.Context) error {
 		return err
 	case <-ctx.Done():
 		return ctx.Err()
+	}
+}
+
+// getDefaultPoolOptions returns pool config for low load services
+func getDefaultPoolOptions() poolOptions {
+	return poolOptions{
+		logFunc:  log.Printf,
+		minAlive: 1,
+		maxAlive: 10,
+		maxIdle:  2,
 	}
 }

--- a/client/pool_options.go
+++ b/client/pool_options.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"time"
+)
+
+type (
+	poolOptions struct {
+		logFunc LogFunc
+
+		minAlive int
+		maxAlive int
+		maxIdle  int
+
+		addr     string
+		user     string
+		password string
+		dbName   string
+
+		connOptions []func(conn *Conn)
+
+		newPoolPingTimeout time.Duration
+	}
+)
+
+type (
+	PoolOption func(o *poolOptions)
+)
+
+// WithPoolLimits sets pool limits:
+//   - minAlive specifies the minimum number of open connections that the pool will try to maintain.
+//   - maxAlive specifies the maximum number of open connections (for internal reasons,
+//     may be greater by 1 inside newConnectionProducer).
+//   - maxIdle specifies the maximum number of idle connections (see DefaultIdleTimeout).
+func WithPoolLimits(minAlive, maxAlive, maxIdle int) PoolOption {
+	return func(o *poolOptions) {
+		o.minAlive = minAlive
+		o.maxAlive = maxAlive
+		o.maxIdle = maxIdle
+	}
+}
+
+func WithLogFunc(f LogFunc) PoolOption {
+	return func(o *poolOptions) {
+		o.logFunc = f
+	}
+}
+
+func WithConnOptions(options ...func(conn *Conn)) PoolOption {
+	return func(o *poolOptions) {
+		o.connOptions = append(o.connOptions, options...)
+	}
+}
+
+// WithNewPoolPingTimeout enables connect & ping to DB during the pool initialization
+func WithNewPoolPingTimeout(timeout time.Duration) PoolOption {
+	return func(o *poolOptions) {
+		o.newPoolPingTimeout = timeout
+	}
+}

--- a/client/pool_test.go
+++ b/client/pool_test.go
@@ -3,8 +3,10 @@ package client
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-mysql-org/go-mysql/test_util"
 	"github.com/siddontang/go-log/log"
@@ -26,7 +28,12 @@ func TestPoolSuite(t *testing.T) {
 
 func (s *poolTestSuite) TestPool_Close() {
 	addr := fmt.Sprintf("%s:%s", *test_util.MysqlHost, s.port)
-	pool := NewPool(log.Debugf, 5, 10, 5, addr, *testUser, *testPassword, "")
+	pool, err := NewPoolWithOptions(addr, *testUser, *testPassword, "",
+		WithPoolLimits(5, 10, 5),
+		WithLogFunc(log.Debugf),
+	)
+	require.NoError(s.T(), err)
+
 	conn, err := pool.GetConn(context.Background())
 	require.NoError(s.T(), err)
 	err = conn.Ping()
@@ -35,8 +42,40 @@ func (s *poolTestSuite) TestPool_Close() {
 	pool.Close()
 	var poolStats ConnectionStats
 	pool.GetStats(&poolStats)
-	require.Equal(s.T(), 0, poolStats.TotalCount)
+	require.Equal(s.T(), 0, poolStats.IdleCount)
 	require.Len(s.T(), pool.readyConnection, 0)
 	_, err = pool.GetConn(context.Background())
+	require.Error(s.T(), err)
+}
+
+func (s *poolTestSuite) TestPool_WrongPassword() {
+	addr := fmt.Sprintf("%s:%s", *test_util.MysqlHost, s.port)
+
+	_, err := NewPoolWithOptions(addr, *testUser, "wrong-password", "",
+		WithPoolLimits(5, 10, 5),
+		WithLogFunc(log.Debugf),
+		WithNewPoolPingTimeout(time.Second),
+	)
+
+	if (err == nil) || !strings.Contains(err.Error(), "ERROR 1045 (28000): Access denied for user") {
+		require.FailNow(s.T(), "unexpected error", "%v", err)
+	}
+}
+
+func (s *poolTestSuite) TestPool_WrongAddr() {
+	l, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(s.T(), err)
+
+	laddr, ok := l.Addr().(*net.TCPAddr)
+	require.True(s.T(), ok)
+
+	_ = l.Close()
+
+	_, err = NewPoolWithOptions(laddr.String(), *testUser, *testPassword, "",
+		WithPoolLimits(5, 10, 5),
+		WithLogFunc(log.Debugf),
+		WithNewPoolPingTimeout(time.Second),
+	)
+
 	require.Error(s.T(), err)
 }

--- a/client/pool_test.go
+++ b/client/pool_test.go
@@ -57,9 +57,7 @@ func (s *poolTestSuite) TestPool_WrongPassword() {
 		WithNewPoolPingTimeout(time.Second),
 	)
 
-	if (err == nil) || !strings.Contains(err.Error(), "ERROR 1045 (28000): Access denied for user") {
-		require.FailNow(s.T(), "unexpected error", "%v", err)
-	}
+	require.ErrorContains(s.T(), err, "ERROR 1045 (28000): Access denied for user")
 }
 
 func (s *poolTestSuite) TestPool_WrongAddr() {


### PR DESCRIPTION
client/pool does not report connection problems properly: in cases of authorization errors, version incompatibility, incorrect database address, network problems, etc.
Also, we have https://github.com/go-mysql-org/go-mysql/pull/701 with a request for new functionality in the same case.

This PR updates the pool logic a bit: more user-friendly function `NewPoolWithOptions`, and option `WithNewPoolPingTimeout` for doing connect&ping during pool initialization.

Also, this fixes `make test-local` after https://github.com/go-mysql-org/go-mysql/pull/803.
