### PR TITLE
tune slice append performance

### DIFF
--- a/canal/sync.go
+++ b/canal/sync.go
@@ -183,12 +183,12 @@ type node struct {
 func parseStmt(stmt ast.StmtNode) (ns []*node) {
 	switch t := stmt.(type) {
 	case *ast.RenameTableStmt:
-		for _, tableInfo := range t.TableToTables {
-			n := &node{
+		ns = make([]*node, len(t.TableToTables))
+		for i, tableInfo := range t.TableToTables {
+			ns[i] = &node{
 				db:    tableInfo.OldTable.Schema.String(),
 				table: tableInfo.OldTable.Name.String(),
 			}
-			ns = append(ns, n)
 		}
 	case *ast.AlterTableStmt:
 		n := &node{
@@ -197,12 +197,12 @@ func parseStmt(stmt ast.StmtNode) (ns []*node) {
 		}
 		ns = []*node{n}
 	case *ast.DropTableStmt:
-		for _, table := range t.Tables {
-			n := &node{
+		ns = make([]*node, len(t.Tables))
+		for i, table := range t.Tables {
+			ns[i] = &node{
 				db:    table.Schema.String(),
 				table: table.Name.String(),
 			}
-			ns = append(ns, n)
 		}
 	case *ast.CreateTableStmt:
 		n := &node{

--- a/replication/binlogstreamer.go
+++ b/replication/binlogstreamer.go
@@ -60,9 +60,9 @@ func (s *BinlogStreamer) GetEventWithStartTime(ctx context.Context, startTime ti
 // DumpEvents dumps all left events
 func (s *BinlogStreamer) DumpEvents() []*BinlogEvent {
 	count := len(s.ch)
-	events := make([]*BinlogEvent, 0, count)
+	events := make([]*BinlogEvent, count)
 	for i := 0; i < count; i++ {
-		events = append(events, <-s.ch)
+		events[i] = <-s.ch
 	}
 	return events
 }

--- a/replication/binlogstreamer.go
+++ b/replication/binlogstreamer.go
@@ -61,7 +61,7 @@ func (s *BinlogStreamer) GetEventWithStartTime(ctx context.Context, startTime ti
 func (s *BinlogStreamer) DumpEvents() []*BinlogEvent {
 	count := len(s.ch)
 	events := make([]*BinlogEvent, count)
-	for i := 0; i < count; i++ {
+	for i := range events {
 		events[i] = <-s.ch
 	}
 	return events

--- a/replication/event.go
+++ b/replication/event.go
@@ -225,17 +225,17 @@ type PreviousGTIDsEvent struct {
 }
 
 func (e *PreviousGTIDsEvent) Decode(data []byte) error {
-	var previousGTIDSets []string
 	pos := 0
 	uuidCount := binary.LittleEndian.Uint16(data[pos : pos+8])
 	pos += 8
 
+	previousGTIDSets := make([]string, uuidCount)
 	for i := uint16(0); i < uuidCount; i++ {
 		uuid := e.decodeUuid(data[pos : pos+16])
 		pos += 16
 		sliceCount := binary.LittleEndian.Uint16(data[pos : pos+8])
 		pos += 8
-		var intervals []string
+		intervals := make([]string, sliceCount)
 		for i := uint16(0); i < sliceCount; i++ {
 			start := e.decodeInterval(data[pos : pos+8])
 			pos += 8
@@ -247,9 +247,9 @@ func (e *PreviousGTIDsEvent) Decode(data []byte) error {
 			} else {
 				interval = fmt.Sprintf("%d-%d", start, stop-1)
 			}
-			intervals = append(intervals, interval)
+			intervals[i] = interval
 		}
-		previousGTIDSets = append(previousGTIDSets, fmt.Sprintf("%s:%s", uuid, strings.Join(intervals, ":")))
+		previousGTIDSets[i] = fmt.Sprintf("%s:%s", uuid, strings.Join(intervals, ":"))
 	}
 	e.GTIDSets = strings.Join(previousGTIDSets, ",")
 	return nil

--- a/replication/event.go
+++ b/replication/event.go
@@ -230,13 +230,13 @@ func (e *PreviousGTIDsEvent) Decode(data []byte) error {
 	pos += 8
 
 	previousGTIDSets := make([]string, uuidCount)
-	for i := uint16(0); i < uuidCount; i++ {
+	for i := range previousGTIDSets {
 		uuid := e.decodeUuid(data[pos : pos+16])
 		pos += 16
 		sliceCount := binary.LittleEndian.Uint16(data[pos : pos+8])
 		pos += 8
 		intervals := make([]string, sliceCount)
-		for i := uint16(0); i < sliceCount; i++ {
+		for i := range intervals {
 			start := e.decodeInterval(data[pos : pos+8])
 			pos += 8
 			stop := e.decodeInterval(data[pos : pos+8])

--- a/replication/parser.go
+++ b/replication/parser.go
@@ -142,8 +142,7 @@ func (p *BinlogParser) parseSingleEvent(r io.Reader, onEvent OnEventFunc) (bool,
 		return false, errors.Errorf("invalid raw data size in event %s, need %d but got %d", h.EventType, h.EventSize, buf.Len())
 	}
 
-	var rawData []byte
-	rawData = append(rawData, buf.Bytes()...)
+	rawData := buf.Bytes()
 	bodyLen := int(h.EventSize) - EventHeaderSize
 	body := rawData[EventHeaderSize:]
 	if len(body) != bodyLen {

--- a/replication/parser.go
+++ b/replication/parser.go
@@ -142,10 +142,8 @@ func (p *BinlogParser) parseSingleEvent(r io.Reader, onEvent OnEventFunc) (bool,
 		return false, errors.Errorf("invalid raw data size in event %s, need %d but got %d", h.EventType, h.EventSize, buf.Len())
 	}
 
-	rawData := make([]byte, buf.Len())
-	for i, b := range buf.Bytes() {
-		rawData[i] = b
-	}
+	var rawData []byte
+	rawData = append(rawData, buf.Bytes()...)
 	bodyLen := int(h.EventSize) - EventHeaderSize
 	body := rawData[EventHeaderSize:]
 	if len(body) != bodyLen {

--- a/replication/parser.go
+++ b/replication/parser.go
@@ -142,7 +142,8 @@ func (p *BinlogParser) parseSingleEvent(r io.Reader, onEvent OnEventFunc) (bool,
 		return false, errors.Errorf("invalid raw data size in event %s, need %d but got %d", h.EventType, h.EventSize, buf.Len())
 	}
 
-	rawData := buf.Bytes()
+	var rawData []byte
+	rawData = append(rawData, buf.Bytes()...)
 	bodyLen := int(h.EventSize) - EventHeaderSize
 	body := rawData[EventHeaderSize:]
 	if len(body) != bodyLen {

--- a/replication/parser.go
+++ b/replication/parser.go
@@ -142,8 +142,10 @@ func (p *BinlogParser) parseSingleEvent(r io.Reader, onEvent OnEventFunc) (bool,
 		return false, errors.Errorf("invalid raw data size in event %s, need %d but got %d", h.EventType, h.EventSize, buf.Len())
 	}
 
-	var rawData []byte
-	rawData = append(rawData, buf.Bytes()...)
+	rawData := make([]byte, buf.Len())
+	for i, b := range buf.Bytes() {
+		rawData[i] = b
+	}
 	bodyLen := int(h.EventSize) - EventHeaderSize
 	body := rawData[EventHeaderSize:]
 	if len(body) != bodyLen {

--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -570,12 +570,9 @@ func (e *TableMapEvent) SetStrValueString() [][]string {
 		if len(e.SetStrValue) == 0 {
 			return nil
 		}
-		e.setStrValueString = make([][]string, 0, len(e.SetStrValue))
-		for _, vals := range e.SetStrValue {
-			e.setStrValueString = append(
-				e.setStrValueString,
-				e.bytesSlice2StrSlice(vals),
-			)
+		e.setStrValueString = make([][]string, len(e.SetStrValue))
+		for i, vals := range e.SetStrValue {
+			e.setStrValueString[i] = e.bytesSlice2StrSlice(vals)
 		}
 	}
 	return e.setStrValueString
@@ -588,12 +585,9 @@ func (e *TableMapEvent) EnumStrValueString() [][]string {
 		if len(e.EnumStrValue) == 0 {
 			return nil
 		}
-		e.enumStrValueString = make([][]string, 0, len(e.EnumStrValue))
-		for _, vals := range e.EnumStrValue {
-			e.enumStrValueString = append(
-				e.enumStrValueString,
-				e.bytesSlice2StrSlice(vals),
-			)
+		e.enumStrValueString = make([][]string, len(e.EnumStrValue))
+		for i, vals := range e.EnumStrValue {
+			e.enumStrValueString[i] = e.bytesSlice2StrSlice(vals)
 		}
 	}
 	return e.enumStrValueString
@@ -612,9 +606,9 @@ func (e *TableMapEvent) bytesSlice2StrSlice(src [][]byte) []string {
 	if src == nil {
 		return nil
 	}
-	ret := make([]string, 0, len(src))
-	for _, item := range src {
-		ret = append(ret, string(item))
+	ret := make([]string, len(src))
+	for i, item := range src {
+		ret[i] = string(item)
 	}
 	return ret
 }


### PR DESCRIPTION
I find some codes abount binlog, which is doing slices assignment or append could be simply changed, so that we can get some perfomance tuning.
Hope that it could help

some corresponding benchmark code may be as follow:

```
package main_test

import (
	"testing"
)

func BenchmarkAppend(b *testing.B) {
	strs := []string{"a", "b", "c"}
	tmp := make([]string, 0, len(strs))

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		for _, str := range strs {
			tmp = append(tmp, str)
		}
	}
}

func BenchmarkAssign(b *testing.B) {
	strs := []string{"a", "b", "c"}
	tmp := make([]string, len(strs))

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		for i, str := range strs {
			tmp[i] = str
		}
	}
}
```