### PR TITLE
Fix comparison bug in MariadbGTIDSet.Equal() function

### DIFF
--- a/mysql/mariadb_gtid.go
+++ b/mysql/mariadb_gtid.go
@@ -217,6 +217,9 @@ func (s *MariadbGTIDSet) Equal(o GTIDSet) bool {
 		if !ok {
 			return false
 		}
+		if len(serverSet) != len(set) {
+			return false
+		}
 		for serverID, gtid := range set {
 			if o, ok := serverSet[serverID]; !ok {
 				return false

--- a/mysql/mariadb_gtid_test.go
+++ b/mysql/mariadb_gtid_test.go
@@ -181,6 +181,7 @@ func TestMariaDBGTIDSetEqual(t *testing.T) {
 		{"1-1-1,2-2-2", "1-1-1", false},
 		{"1-1-1,2-2-2", "1-1-1,2-2-2", true},
 		{"1-1-1,2-2-2", "1-1-1,2-2-3", false},
+		{"0-1-1,0-2-2", "0-2-2", false},
 	}
 
 	for _, cs := range cases {


### PR DESCRIPTION
I am sorry evolved this bug in https://github.com/go-mysql-org/go-mysql/pull/852

"0-1-1,0-2-2", "0-2-2" could be viewed as equal
