### PR TITLE
Fix close canal client panic if use Execute after mysql host down

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -254,8 +254,10 @@ func (c *Canal) Close() {
 	c.cancel()
 	c.syncer.Close()
 	c.connLock.Lock()
-	c.conn.Close()
-	c.conn = nil
+	if c.conn != nil {
+		c.conn.Close()
+		c.conn = nil
+	}
 	c.connLock.Unlock()
 
 	_ = c.eventHandler.OnPosSynced(nil, c.master.Position(), c.master.GTIDSet(), true)


### PR DESCRIPTION
Execute some query when mysql host is down or unavailable will set `c.conn = nil ` and it case panic when close canal client.

https://github.com/go-mysql-org/go-mysql/blob/f0df38a3258e781900cafb36c1887cc9e71e9089/canal/canal.go#L521-L526