### PR TITLE
allow setting the collation in auth handshake

### DIFF
--- a/client/auth.go
+++ b/client/auth.go
@@ -269,7 +269,7 @@ func (c *Conn) writeAuthHandshake() error {
 	data[11] = 0x00
 
 	// Charset [1 byte]
-	// use default collation id 33 here, is utf-8
+	// use default collation id 33 here, is `utf8mb3_general_ci`
 	collationName := c.collation
 	if len(collationName) == 0 {
 		collationName = DEFAULT_COLLATION_NAME

--- a/client/auth.go
+++ b/client/auth.go
@@ -5,11 +5,11 @@ import (
 	"crypto/tls"
 	"encoding/binary"
 	"fmt"
-	"github.com/pingcap/tidb/pkg/parser/charset"
 
 	. "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/packet"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/parser/charset"
 )
 
 const defaultAuthPluginName = AUTH_NATIVE_PASSWORD

--- a/client/auth.go
+++ b/client/auth.go
@@ -310,7 +310,7 @@ func (c *Conn) writeAuthHandshake() error {
 
 	// Filler [23 bytes] (all 0x00)
 	// the filler starts at position 13, but the first byte of the filler
-	// has been set earlier with collaction id earlier, so position 13 at this point
+	// has been set earlier with collation id earlier, so position 13 at this point
 	// will be either 0x00 or the right middle 8 bits of the collation id.
 	// Therefore, we start at position 14 and fill the remaining 22 bytes with 0x00.
 	pos := 14

--- a/client/auth.go
+++ b/client/auth.go
@@ -285,7 +285,8 @@ func (c *Conn) writeAuthHandshake() error {
 	// see https://github.com/mysql/mysql-server/pull/541
 	data[12] = byte(collation.ID & 0xff)
 	// if the collation ID is <= 255 the middle 8 bits are 0s so this is the equivalent of
-	// padding the filler with a 0.
+	// padding the filler with a 0. If ID is > 255 then the first byte of filler will contain
+	// the right middle 8 bits of the collation ID.
 	data[13] = byte((collation.ID & 0xff00) >> 8)
 
 	// SSL Connection Request Packet
@@ -309,9 +310,9 @@ func (c *Conn) writeAuthHandshake() error {
 
 	// Filler [23 bytes] (all 0x00)
 	// the filler starts at position 13, but the first byte of the filler
-	// maybe have been set by the collation id earlier. So we only position 13
-	// will be either 0x00 or the right middle 8 bits of the collation id. Therefore
-	// here we start at position 14 and fill the remaining 22 bytes with 0x00.
+	// has been set earlier with collaction id earlier, so position 13 at this point
+	// will be either 0x00 or the right middle 8 bits of the collation id.
+	// Therefore, we start at position 14 and fill the remaining 22 bytes with 0x00.
 	pos := 14
 	for ; pos < 14+22; pos++ {
 		data[pos] = 0

--- a/client/auth.go
+++ b/client/auth.go
@@ -280,7 +280,7 @@ func (c *Conn) writeAuthHandshake() error {
 	}
 
 	// the MySQL protocol calls for the collation id to be sent as 1, where only the
-	// lower 8 bits are used in this field. But wireshark shows that the first by of
+	// lower 8 bits are used in this field. But wireshark shows that the first byte of
 	// the 23 bytes of filler is used to send the right middle 8 bits of the collation id.
 	// see https://github.com/mysql/mysql-server/pull/541
 	data[12] = byte(collation.ID & 0xff)
@@ -310,8 +310,8 @@ func (c *Conn) writeAuthHandshake() error {
 
 	// Filler [23 bytes] (all 0x00)
 	// the filler starts at position 13, but the first byte of the filler
-	// has been set earlier with collation id earlier, so position 13 at this point
-	// will be either 0x00 or the right middle 8 bits of the collation id.
+	// has been set with the collation id earlier, so position 13 at this point
+	// will be either 0x00, or the right middle 8 bits of the collation id.
 	// Therefore, we start at position 14 and fill the remaining 22 bytes with 0x00.
 	pos := 14
 	for ; pos < 14+22; pos++ {

--- a/client/auth_test.go
+++ b/client/auth_test.go
@@ -39,13 +39,15 @@ func TestConnGenAttributes(t *testing.T) {
 }
 
 func TestConnCollation(t *testing.T) {
-	collations := []string{"big5_chinese_ci",
-		"utf8_general_ci",
-		"utf8mb4_0900_ai_ci",
-		"utf8mb4_de_pb_0900_ai_ci",
-		"utf8mb4_ja_0900_as_cs",
-		"utf8mb4_0900_bin",
-		"utf8mb4_zh_pinyin_tidb_as_cs"}
+	collations := []string{
+		//"big5_chinese_ci",
+		//"utf8_general_ci",
+		//"utf8mb4_0900_ai_ci",
+		//"utf8mb4_de_pb_0900_ai_ci",
+		//"utf8mb4_ja_0900_as_cs",
+		//"utf8mb4_0900_bin",
+		"utf8mb4_zh_pinyin_tidb_as_cs",
+	}
 
 	// test all supported collations by calling writeAuthHandshake() and reading the bytes
 	// sent to the server to ensure the collation id is set correctly
@@ -63,19 +65,17 @@ func TestConnCollation(t *testing.T) {
 		// if the collation ID is <= 255 the collation ID is stored in the 12th byte
 		if collation.ID <= 255 {
 			require.Equal(t, byte(collation.ID), handShakeResponse[12])
-			// sanity check: validate the 23 bytes of filler with value 0x00 are set correctly
-			for i := 13; i < 13+23; i++ {
-				require.Equal(t, byte(0x00), handShakeResponse[i])
-			}
+			// the 13th byte should always be 0x00
+			require.Equal(t, byte(0x00), handShakeResponse[13])
 		} else {
 			// if the collation ID is > 255 the collation ID is stored in the 12th and 13th bytes
 			require.Equal(t, byte(collation.ID&0xff), handShakeResponse[12])
 			require.Equal(t, byte(collation.ID>>8), handShakeResponse[13])
+		}
 
-			// sanity check: validate the 22 bytes of filler with value 0x00 are set correctly
-			for i := 14; i < 14+22; i++ {
-				require.Equal(t, byte(0x00), handShakeResponse[i])
-			}
+		// sanity check: validate the 22 bytes of filler with value 0x00 are set correctly
+		for i := 14; i < 14+22; i++ {
+			require.Equal(t, byte(0x00), handShakeResponse[i])
 		}
 
 		// and finally the username

--- a/client/auth_test.go
+++ b/client/auth_test.go
@@ -80,8 +80,8 @@ func TestConnCollation(t *testing.T) {
 		}
 
 		// and finally the username
-		password := string(handShakeResponse[36:40])
-		require.Equal(t, "test", password)
+		username := string(handShakeResponse[36:40])
+		require.Equal(t, "test", username)
 
 		require.NoError(t, server.Close())
 	}

--- a/client/auth_test.go
+++ b/client/auth_test.go
@@ -105,6 +105,8 @@ func sendAuthResponse(t *testing.T, collation string) net.Conn {
 	go func() {
 		err := c.writeAuthHandshake()
 		require.NoError(t, err)
+		err = c.Close()
+		require.NoError(t, err)
 	}()
 	return server
 }

--- a/client/auth_test.go
+++ b/client/auth_test.go
@@ -41,12 +41,12 @@ func TestConnGenAttributes(t *testing.T) {
 
 func TestConnCollation(t *testing.T) {
 	collations := []string{
-		//"big5_chinese_ci",
-		//"utf8_general_ci",
-		//"utf8mb4_0900_ai_ci",
-		//"utf8mb4_de_pb_0900_ai_ci",
-		//"utf8mb4_ja_0900_as_cs",
-		//"utf8mb4_0900_bin",
+		"big5_chinese_ci",
+		"utf8_general_ci",
+		"utf8mb4_0900_ai_ci",
+		"utf8mb4_de_pb_0900_ai_ci",
+		"utf8mb4_ja_0900_as_cs",
+		"utf8mb4_0900_bin",
 		"utf8mb4_zh_pinyin_tidb_as_cs",
 	}
 

--- a/client/auth_test.go
+++ b/client/auth_test.go
@@ -1,13 +1,14 @@
 package client
 
 import (
-	"github.com/go-mysql-org/go-mysql/packet"
-	"github.com/pingcap/tidb/pkg/parser/charset"
 	"net"
 	"testing"
 
-	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/packet"
 )
 
 func TestConnGenAttributes(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -235,6 +235,7 @@ func (s *clientTestSuite) TestConn_SetCharset() {
 func (s *clientTestSuite) TestConn_SetCollationAfterConnect() {
 	err := s.c.SetCollation("latin1_swedish_ci")
 	require.Error(s.T(), err)
+	require.ErrorContains(s.T(), err, "cannot set collation after connection is established")
 }
 
 func (s *clientTestSuite) TestConn_SetCollation() {

--- a/client/conn.go
+++ b/client/conn.go
@@ -364,12 +364,11 @@ func (c *Conn) SetCharset(charset string) error {
 }
 
 func (c *Conn) SetCollation(collation string) error {
-	if c.status == 0 {
-		c.collation = collation
-	} else {
+	if len(c.serverVersion) != 0 {
 		return errors.Trace(errors.Errorf("cannot set collation after connection is established"))
 	}
 
+	c.collation = collation
 	return nil
 }
 

--- a/client/conn.go
+++ b/client/conn.go
@@ -69,15 +69,19 @@ func Connect(addr string, user string, password string, dbName string, options .
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
-	dialer := &net.Dialer{}
+	return ConnectWithContext(ctx, addr, user, password, dbName, options...)
+}
 
+// ConnectWithContext to a MySQL addr using the provided context.
+func ConnectWithContext(ctx context.Context, addr string, user string, password string, dbName string, options ...func(*Conn)) (*Conn, error) {
+	dialer := &net.Dialer{}
 	return ConnectWithDialer(ctx, "", addr, user, password, dbName, dialer.DialContext, options...)
 }
 
 // Dialer connects to the address on the named network using the provided context.
 type Dialer func(ctx context.Context, network, address string) (net.Conn, error)
 
-// Connect to a MySQL server using the given Dialer.
+// ConnectWithDialer to a MySQL server using the given Dialer.
 func ConnectWithDialer(ctx context.Context, network string, addr string, user string, password string, dbName string, dialer Dialer, options ...func(*Conn)) (*Conn, error) {
 	c := new(Conn)
 

--- a/client/conn.go
+++ b/client/conn.go
@@ -37,6 +37,8 @@ type Conn struct {
 	status uint16
 
 	charset string
+	// sets the collation to be set on the auth handshake, this does not issue a 'set names' command
+	collation string
 
 	salt           []byte
 	authPluginName string
@@ -355,6 +357,20 @@ func (c *Conn) SetCharset(charset string) error {
 		c.charset = charset
 		return nil
 	}
+}
+
+func (c *Conn) SetCollation(collation string) error {
+	if c.status == 0 {
+		c.collation = collation
+	} else {
+		return errors.Trace(errors.Errorf("cannot set collation after connection is established"))
+	}
+
+	return nil
+}
+
+func (c *Conn) GetCollation() string {
+	return c.collation
 }
 
 func (c *Conn) FieldList(table string, wildcard string) ([]*Field, error) {


### PR DESCRIPTION
This PR is to allow the collation to be set during the auth handshake in order to avoid requiring calls to `SET NAMES` post connection.