### PR TITLE
set read deadline for new conection to fix handshake stuck

### DIFF
--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -901,7 +901,7 @@ func (b *BinlogSyncer) newConnection(ctx context.Context) (*client.Conn, error) 
 			c.SetTLSConfig(b.cfg.TLSConfig)
 			c.SetAttributes(map[string]string{"_client_role": "binary_log_listener"})
 			if b.cfg.ReadTimeout > 0 {
-				c.SetReadDeadline(time.Now().Add(b.cfg.ReadTimeout))
+				_ = c.SetReadDeadline(time.Now().Add(b.cfg.ReadTimeout))
 			}
 		})
 }

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -900,6 +900,9 @@ func (b *BinlogSyncer) newConnection(ctx context.Context) (*client.Conn, error) 
 		"", b.cfg.Dialer, func(c *client.Conn) {
 			c.SetTLSConfig(b.cfg.TLSConfig)
 			c.SetAttributes(map[string]string{"_client_role": "binary_log_listener"})
+			if b.cfg.ReadTimeout > 0 {
+				c.SetReadDeadline(time.Now().Add(b.cfg.ReadTimeout))
+			}
 		})
 }
 


### PR DESCRIPTION
We encountered a stuck issue caused by `BinlogSyncer.close()`:

There is "syncer is closing" in log, but no "syncer is closed".

```
[info] binlogsyncer.go:206 syncer is closing...
```

Here are parts of the goroutines:
```
                                                 1   100% |   github.com/go-mysql-org/go-mysql/client.ConnectWithDialer github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/client/conn.go:109
         0     0%   100%          1  0.89%                | github.com/go-mysql-org/go-mysql/client.(*Conn).handshake github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/client/conn.go:118
                                                 1   100% |   github.com/go-mysql-org/go-mysql/client.(*Conn).readInitialHandshake github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/client/auth.go:31
----------------------------------------------------------+-------------
                                                 1   100% |   github.com/go-mysql-org/go-mysql/client.(*Conn).handshake github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/client/conn.go:118
         0     0%   100%          1  0.89%                | github.com/go-mysql-org/go-mysql/client.(*Conn).readInitialHandshake github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/client/auth.go:31
                                                 1   100% |   github.com/go-mysql-org/go-mysql/packet.(*Conn).ReadPacket github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/packet/conn.go:87 (inline)
----------------------------------------------------------+-------------
                                                 1   100% |   github.com/go-mysql-org/go-mysql/replication.(*BinlogSyncer).newConnection github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/replication/binlogsyncer.go:891
         0     0%   100%          1  0.89%                | github.com/go-mysql-org/go-mysql/client.ConnectWithDialer github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/client/conn.go:109
                                                 1   100% |   github.com/go-mysql-org/go-mysql/client.(*Conn).handshake github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/client/conn.go:118
----------------------------------------------------------+-------------
                                                 1   100% |   github.com/go-mysql-org/go-mysql/client.(*Conn).readInitialHandshake github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/client/auth.go:31 (inline)
         0     0%   100%          1  0.89%                | github.com/go-mysql-org/go-mysql/packet.(*Conn).ReadPacket github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/packet/conn.go:87
                                                 1   100% |   github.com/go-mysql-org/go-mysql/packet.(*Conn).ReadPacketReuseMem github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/packet/conn.go:97
----------------------------------------------------------+-------------
                                                 1   100% |   github.com/go-mysql-org/go-mysql/packet.(*Conn).ReadPacket github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/packet/conn.go:87
         0     0%   100%          1  0.89%                | github.com/go-mysql-org/go-mysql/packet.(*Conn).ReadPacketReuseMem github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/packet/conn.go:97
                                                 1   100% |   github.com/go-mysql-org/go-mysql/packet.(*Conn).ReadPacketTo github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/packet/conn.go:149
----------------------------------------------------------+-------------
                                                 1   100% |   github.com/go-mysql-org/go-mysql/packet.(*Conn).ReadPacketReuseMem github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/packet/conn.go:97
         0     0%   100%          1  0.89%                | github.com/go-mysql-org/go-mysql/packet.(*Conn).ReadPacketTo github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/packet/conn.go:149
                                                 1   100% |   io.ReadFull io/io.go:351 (inline)
----------------------------------------------------------+-------------
                                                 1   100% |   github.com/pingcap/tiflow/dm/syncer/binlogstream.(*StreamerController).resetReplicationSyncer github.com/pingcap/tiflow/dm/syncer/binlogstream/streamer_controller.go:259
         0     0%   100%          1  0.89%                | github.com/go-mysql-org/go-mysql/replication.(*BinlogSyncer).Close github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/replication/binlogsyncer.go:198
                                                 1   100% |   github.com/go-mysql-org/go-mysql/replication.(*BinlogSyncer).close github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/replication/binlogsyncer.go:223
----------------------------------------------------------+-------------
                                                 1   100% |   github.com/go-mysql-org/go-mysql/replication.(*BinlogSyncer).Close github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/replication/binlogsyncer.go:198
         0     0%   100%          1  0.89%                | github.com/go-mysql-org/go-mysql/replication.(*BinlogSyncer).close github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/replication/binlogsyncer.go:223
                                                 1   100% |   github.com/go-mysql-org/go-mysql/replication.(*BinlogSyncer).newConnection github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/replication/binlogsyncer.go:891
----------------------------------------------------------+-------------
                                                 1   100% |   github.com/go-mysql-org/go-mysql/replication.(*BinlogSyncer).close github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/replication/binlogsyncer.go:223
         0     0%   100%          1  0.89%                | github.com/go-mysql-org/go-mysql/replication.(*BinlogSyncer).newConnection github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/replication/binlogsyncer.go:891
                                                 1   100% |   github.com/go-mysql-org/go-mysql/client.ConnectWithDialer github.com/go-mysql-org/go-mysql@v1.6.1-0.20221223014230-81966e15b9c5/client/conn.go:109
```

Because there is no deadline/timeout for `readPacket`, it may block forever.

This PR set timeout for all read operations of a connection.