### PR TITLE
Use new terms for replication on MySQL 8.4.0

### DIFF
--- a/canal/sync.go
+++ b/canal/sync.go
@@ -309,7 +309,12 @@ func (c *Canal) WaitUntilPos(pos mysql.Position, timeout time.Duration) error {
 }
 
 func (c *Canal) GetMasterPos() (mysql.Position, error) {
-	rr, err := c.Execute("SHOW MASTER STATUS")
+	showBinlogStatus := "SHOW BINARY LOG STATUS"
+	if eq, err := c.conn.CompareServerVersion("8.4.0"); (err == nil) && (eq < 0) {
+		showBinlogStatus = "SHOW MASTER STATUS"
+	}
+
+	rr, err := c.Execute(showBinlogStatus)
 	if err != nil {
 		return mysql.Position{}, errors.Trace(err)
 	}

--- a/replication/backup_test.go
+++ b/replication/backup_test.go
@@ -13,7 +13,12 @@ import (
 func (t *testSyncerSuite) TestStartBackupEndInGivenTime() {
 	t.setupTest(mysql.MySQLFlavor)
 
-	t.testExecute("RESET MASTER")
+	resetBinaryLogs := "RESET BINARY LOGS AND GTIDS"
+	if eq, err := t.c.CompareServerVersion("8.4.0"); (err == nil) && (eq < 0) {
+		resetBinaryLogs = "RESET MASTER"
+	}
+
+	t.testExecute(resetBinaryLogs)
 
 	for times := 1; times <= 2; times++ {
 		t.testSync(nil)


### PR DESCRIPTION
Ref #866 

This fixes the failed tests. This doesn't yet fix other places where we use the old terms.