### PR TITLE
CI: Fix warning about restore cache failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,12 @@ jobs:
       - name: Prepare for Go
         run: |
           sudo apt-get install -y make gcc
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
-      - name: Checkout code
-        uses: actions/checkout@v4
       - name: Run tests
         run: |
           # separate test to avoid RESET MASTER conflict
@@ -64,11 +64,11 @@ jobs:
       - name: Prepare for Go
         run: |
           sudo apt-get install -y make gcc
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: "1.22"
-      - name: Checkout code
-        uses: actions/checkout@v4
       - name: Build on ${{ matrix.os }}/${{ matrix.arch }}
         run: GOARCH=${{ matrix.arch }} GOOS=${{ matrix.os }} go build ./...


### PR DESCRIPTION
The order of `actions/checkout` and `actions/setup-go` seems to be important for caching.

![image](https://github.com/go-mysql-org/go-mysql/assets/1272980/4b1cc4e7-e883-4484-9c9c-935a9d0cb0fd)
