### PR TITLE
Make protocol version check more strict

### DIFF
--- a/client/auth.go
+++ b/client/auth.go
@@ -42,8 +42,14 @@ func (c *Conn) readInitialHandshake() error {
 		return errors.Annotate(c.handleErrorPacket(data), "read initial handshake error")
 	}
 
-	if data[0] < MinProtocolVersion {
-		return errors.Errorf("invalid protocol version %d, must >= 10", data[0])
+	if data[0] != ClassicProtocolVersion {
+		if data[0] == XProtocolVersion {
+			return errors.Errorf(
+				"invalid protocol version %d, expected 10. "+
+					"This might be X Protocol, make sure to connect to the right port",
+				data[0])
+		}
+		return errors.Errorf("invalid protocol version %d, expected 10", data[0])
 	}
 	pos := 1
 

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -1,9 +1,10 @@
 package mysql
 
 const (
-	MinProtocolVersion byte   = 10
-	MaxPayloadLen      int    = 1<<24 - 1
-	TimeFormat         string = "2006-01-02 15:04:05"
+	ClassicProtocolVersion byte   = 10
+	XProtocolVersion       byte   = 11
+	MaxPayloadLen          int    = 1<<24 - 1
+	TimeFormat             string = "2006-01-02 15:04:05"
 )
 
 const (


### PR DESCRIPTION
Closes #876 

MySQL has:
- Protocol version 9 (very very old on port 3306/tcp)
- Protocol version 10 (a.k.a. Classic Protocol on port 3306/tcp)
- Protocol version 11 (X Protocol, this is a new protocol (protobuf based) and on port 33060/tcp)

When connecting to port 33060 instead of 3306 by mistake the version check didn't return an error when it should have.

```
$ go run go-mysql-876.go 
2024/05/13 22:08:39 failed to query: readInitialHandshake: invalid protocol version 11, expected 10. This might be X Protocol, make sure to connect to the right port
exit status 1
```

```go
package main

import (
	"database/sql"
	"log"

	_ "github.com/go-mysql-org/go-mysql/driver"
)

func main() {
	db, err := sql.Open("mysql", "root@127.0.0.1:33070")
	if err != nil {
		log.Fatalf("failed to connect to mysql: %s", err)
	}
	defer db.Close()

	_, err = db.Exec("DO 1")
	if err != nil {
		log.Fatalf("failed to query: %s", err)
	}
}
```

```
podman run -p 3307:3306 -p 33070:33060 --env MYSQL_ALLOW_EMPTY_PASSWORD=1 -it mysql:8.4.0
```