### PR TITLE
Support DSN without 'user:password@'

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,14 @@ Configuration options can be provided by the standard DSN (Data Source Name).
 [user[:password]@]addr[/db[?param=X]]
 ```
 
+#### `collation`
+
+Set a collation during the Auth handshake.
+
+| Type      | Default         | Example                                               |
+| --------- | --------------- | ----------------------------------------------------- |
+| string    | utf8_general_ci | user:pass@localhost/mydb?collation=latin1_general_ci  |
+
 #### `compress`
 
 Enable compression between the client and the server. Valid values are 'zstd','zlib','uncompressed'.

--- a/client/auth.go
+++ b/client/auth.go
@@ -285,10 +285,8 @@ func (c *Conn) writeAuthHandshake() error {
 		return fmt.Errorf("invalid collation name %s", collationName)
 	}
 
-	// the MySQL protocol calls for the collation id to be sent as 1, where only the
-	// lower 8 bits are used in this field. But wireshark shows that the first byte of
-	// the 23 bytes of filler is used to send the right middle 8 bits of the collation id.
-	// see https://github.com/mysql/mysql-server/pull/541
+	// the MySQL protocol calls for the collation id to be sent as 1 byte, where only the
+	// lower 8 bits are used in this field.
 	data[12] = byte(collation.ID & 0xff)
 
 	// SSL Connection Request Packet

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -57,7 +57,6 @@ type connInfo struct {
 //
 // Optional parameters are supported in the standard DSN form
 func parseDSN(dsn string) (connInfo, error) {
-
 	ci := connInfo{}
 
 	// If a "/" occurs after "@" and then no more "@" or "/" occur after that

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -94,9 +94,10 @@ func TestParseDSN(t *testing.T) {
 		"user:password@5.domain.com/db?compress=zlib":   {standardDSN: true, addr: "5.domain.com", user: "user", password: "password", db: "db", params: url.Values{"compress": []string{"zlib"}}},
 
 		// per the documentation in the README, the 'user:password@' is optional as are the '/db?param=X' portions of the DSN
-		"2.domain.com":                  {standardDSN: false, addr: "2.domain.com", user: "", password: "", db: "", params: url.Values{}},
-		"2.domain.com/db":               {standardDSN: true, addr: "2.domain.com", user: "", password: "", db: "db", params: url.Values{}},
-		"5.domain.com/db?compress=zlib": {standardDSN: true, addr: "5.domain.com", user: "", password: "", db: "db", params: url.Values{"compress": []string{"zlib"}}},
+		"6.domain.com":                  {standardDSN: false, addr: "6.domain.com", user: "", password: "", db: "", params: url.Values{}},
+		"7.domain.com?db":               {standardDSN: false, addr: "7.domain.com", user: "", password: "", db: "db", params: url.Values{}},
+		"8.domain.com/db":               {standardDSN: true, addr: "8.domain.com", user: "", password: "", db: "db", params: url.Values{}},
+		"9.domain.com/db?compress=zlib": {standardDSN: true, addr: "9.domain.com", user: "", password: "", db: "db", params: url.Values{"compress": []string{"zlib"}}},
 	}
 
 	for supplied, expected := range testDSNs {

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -92,6 +92,11 @@ func TestParseDSN(t *testing.T) {
 		"user:password@5.domain.com/db?readTimeout=1m":  {standardDSN: true, addr: "5.domain.com", user: "user", password: "password", db: "db", params: url.Values{"readTimeout": []string{"1m"}}},
 		"user:password@5.domain.com/db?writeTimeout=1m": {standardDSN: true, addr: "5.domain.com", user: "user", password: "password", db: "db", params: url.Values{"writeTimeout": []string{"1m"}}},
 		"user:password@5.domain.com/db?compress=zlib":   {standardDSN: true, addr: "5.domain.com", user: "user", password: "password", db: "db", params: url.Values{"compress": []string{"zlib"}}},
+
+		// per the documentation in the README, the 'user:password@' is optional as are the '/db?param=X' portions of the DSN
+		"2.domain.com":                  {standardDSN: false, addr: "2.domain.com", user: "", password: "", db: "", params: url.Values{}},
+		"2.domain.com/db":               {standardDSN: true, addr: "2.domain.com", user: "", password: "", db: "db", params: url.Values{}},
+		"5.domain.com/db?compress=zlib": {standardDSN: true, addr: "5.domain.com", user: "", password: "", db: "db", params: url.Values{"compress": []string{"zlib"}}},
 	}
 
 	for supplied, expected := range testDSNs {


### PR DESCRIPTION
I noticed that a DSN like this:

```
db.example.com:3307/db?ssl=true
```

would incorrectly have the property `db` in the `connInfo` object set to `ssl=true` when it should have been set to `db`.

According to the README the DSN format allows for an optional `user:password@`.

```
[user[:password]@]addr[/db[?param=X]]
```

Adding unit tests for the `ParseDSN` function to cover those cases.