### PR TITLE
allow packet.Conn buffer size to be adjustable

### DIFF
--- a/client/auth.go
+++ b/client/auth.go
@@ -304,7 +304,7 @@ func (c *Conn) writeAuthHandshake() error {
 		}
 
 		currentSequence := c.Sequence
-		c.Conn = packet.NewConn(tlsConn)
+		c.Conn = packet.NewBufferedConn(tlsConn, c.BufferSize)
 		c.Sequence = currentSequence
 	}
 

--- a/driver/driver_options_test.go
+++ b/driver/driver_options_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -64,6 +65,29 @@ func TestDriverOptions_ConnectTimeout(t *testing.T) {
 	defer srv.Stop()
 
 	conn, err := sql.Open("mysql", "root@127.0.0.1:3307/test?timeout=1s")
+	require.NoError(t, err)
+
+	rows, err := conn.QueryContext(context.TODO(), "select * from table;")
+	require.NotNil(t, rows)
+	require.NoError(t, err)
+
+	conn.Close()
+}
+
+func TestDriverOptions_BufferSize(t *testing.T) {
+	log.SetLevel(log.LevelDebug)
+	srv := CreateMockServer(t)
+	defer srv.Stop()
+
+	SetDSNOptions(map[string]DriverOption{
+		"bufferSize": func(c *client.Conn, value string) error {
+			var err error
+			c.BufferSize, err = strconv.Atoi(value)
+			return err
+		},
+	})
+
+	conn, err := sql.Open("mysql", "root@127.0.0.1:3307/test?bufferSize=4096")
 	require.NoError(t, err)
 
 	rows, err := conn.QueryContext(context.TODO(), "select * from table;")

--- a/packet/conn.go
+++ b/packet/conn.go
@@ -53,10 +53,14 @@ type Conn struct {
 }
 
 func NewConn(conn net.Conn) *Conn {
+	return NewBufferedConn(conn, 65536) // 64kb
+}
+
+func NewBufferedConn(conn net.Conn, bufferSize int) *Conn {
 	c := new(Conn)
 	c.Conn = conn
 
-	c.br = bufio.NewReaderSize(c, 65536) // 64kb
+	c.br = bufio.NewReaderSize(c, bufferSize)
 	c.reader = c.br
 
 	c.copyNBuf = make([]byte, DefaultBufferSize)
@@ -64,8 +68,8 @@ func NewConn(conn net.Conn) *Conn {
 	return c
 }
 
-func NewConnWithTimeout(conn net.Conn, readTimeout, writeTimeout time.Duration) *Conn {
-	c := NewConn(conn)
+func NewConnWithTimeout(conn net.Conn, readTimeout, writeTimeout time.Duration, bufferSize int) *Conn {
+	c := NewBufferedConn(conn, bufferSize)
 	c.readTimeout = readTimeout
 	c.writeTimeout = writeTimeout
 	return c


### PR DESCRIPTION
Our usage of this library is in an application that will maintain a few thousand active MySQL connections from a single instance and we've noticed that the application is holding a lot of memory in `packet.Conn`, specifically the `bufio.Reader` instances are holding about 500MB of the total 800MB heap.

This PR will allow our application to change the hardcoded `65536` buffer size to something more reasonable for our use case (maybe `4096`), which should reduce our heap by at least 50%.