### PR TITLE
allow disabling the default golang database/sql retry behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,18 @@ golang's [ParseDuration](https://pkg.go.dev/time#ParseDuration) format.
 | --------- | --------- | ----------------------------------------------- |
 | duration  | 0         | user:pass@localhost/mydb?writeTimeout=1m30s     |
 
+#### `retries`
+
+Allows disabling the golang `database/sql` default behavior to retry errors
+when `ErrBadConn` is returned by the driver. When retries are disabled
+this driver will not return `ErrBadConn` from the `database/sql` package.
+
+Valid values are `on` (default) and `off`.
+
+| Type      | Default   | Example                                         |
+| --------- | --------- | ----------------------------------------------- |
+| string    | on        | user:pass@localhost/mydb?retries=off            |
+
 ### Custom Driver Options
 
 The driver package exposes the function `SetDSNOptions`, allowing for modification of the

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -97,7 +97,11 @@ func parseDSN(dsn string) (connInfo, error) {
 // Open takes a supplied DSN string and opens a connection
 // See ParseDSN for more information on the form of the DSN
 func (d driver) Open(dsn string) (sqldriver.Conn, error) {
-	var c *client.Conn
+	var (
+		c *client.Conn
+		// by default database/sql driver retries will be enabled
+		retries = true
+	)
 
 	ci, err := parseDSN(dsn)
 
@@ -134,6 +138,10 @@ func (d driver) Open(dsn string) (sqldriver.Conn, error) {
 				if timeout, err = time.ParseDuration(value[0]); err != nil {
 					return nil, errors.Wrap(err, "invalid duration value for timeout option")
 				}
+			} else if key == "retries" && len(value) > 0 {
+				// by default keep the golang database/sql retry behavior enabled unless
+				// the retries driver option is explicitly set to 'false'
+				retries = !strings.EqualFold(value[0], "off")
 			} else {
 				if option, ok := options[key]; ok {
 					opt := func(o DriverOption, v string) client.Option {
@@ -161,15 +169,27 @@ func (d driver) Open(dsn string) (sqldriver.Conn, error) {
 		return nil, err
 	}
 
-	return &conn{c}, nil
+	// if retries is true then return sqldriver.ErrBadConn which will trigger up to 3
+	// retries by the database/sql package. If retries are disabled then we'll return
+	// the native go-mysql-org/go-mysql 'mysql.ErrBadConn' erorr which will prevent a retry.
+	// In this case the sqldriver.Validator interface is implemented and will return
+	// false for IsValid() signaling that the connection is bad and should be discarded.
+	return &conn{Conn: c, state: &state{valid: true, useDriverErrors: !retries}}, nil
 }
 
 type CheckNamedValueFunc func(*sqldriver.NamedValue) error
 
 var _ sqldriver.NamedValueChecker = &conn{}
+var _ sqldriver.Validator = &conn{}
+
+type state struct {
+	valid           bool
+	useDriverErrors bool
+}
 
 type conn struct {
 	*client.Conn
+	state *state
 }
 
 func (c *conn) CheckNamedValue(nv *sqldriver.NamedValue) error {
@@ -190,13 +210,17 @@ func (c *conn) CheckNamedValue(nv *sqldriver.NamedValue) error {
 	return sqldriver.ErrSkip
 }
 
+func (c *conn) IsValid() bool {
+	return c.state.valid
+}
+
 func (c *conn) Prepare(query string) (sqldriver.Stmt, error) {
 	st, err := c.Conn.Prepare(query)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	return &stmt{st}, nil
+	return &stmt{Stmt: st, connectionState: c.state}, nil
 }
 
 func (c *conn) Close() error {
@@ -222,10 +246,16 @@ func buildArgs(args []sqldriver.Value) []interface{} {
 	return a
 }
 
-func replyError(err error) error {
-	if mysql.ErrorEqual(err, mysql.ErrBadConn) {
+func (st *state) replyError(err error) error {
+	isBadConnection := mysql.ErrorEqual(err, mysql.ErrBadConn)
+
+	if !st.useDriverErrors && isBadConnection {
 		return sqldriver.ErrBadConn
 	} else {
+		// if we have a bad connection, this mark the state of this connection as not valid
+		// do the database/sql package can discard it instead of placing it back in the
+		// sql.DB pool.
+		st.valid = !isBadConnection
 		return errors.Trace(err)
 	}
 }
@@ -234,7 +264,7 @@ func (c *conn) Exec(query string, args []sqldriver.Value) (sqldriver.Result, err
 	a := buildArgs(args)
 	r, err := c.Conn.Execute(query, a...)
 	if err != nil {
-		return nil, replyError(err)
+		return nil, c.state.replyError(err)
 	}
 	return &result{r}, nil
 }
@@ -243,13 +273,14 @@ func (c *conn) Query(query string, args []sqldriver.Value) (sqldriver.Rows, erro
 	a := buildArgs(args)
 	r, err := c.Conn.Execute(query, a...)
 	if err != nil {
-		return nil, replyError(err)
+		return nil, c.state.replyError(err)
 	}
 	return newRows(r.Resultset)
 }
 
 type stmt struct {
 	*client.Stmt
+	connectionState *state
 }
 
 func (s *stmt) Close() error {
@@ -264,7 +295,7 @@ func (s *stmt) Exec(args []sqldriver.Value) (sqldriver.Result, error) {
 	a := buildArgs(args)
 	r, err := s.Stmt.Execute(a...)
 	if err != nil {
-		return nil, replyError(err)
+		return nil, s.connectionState.replyError(err)
 	}
 	return &result{r}, nil
 }
@@ -273,7 +304,7 @@ func (s *stmt) Query(args []sqldriver.Value) (sqldriver.Rows, error) {
 	a := buildArgs(args)
 	r, err := s.Stmt.Execute(a...)
 	if err != nil {
-		return nil, replyError(err)
+		return nil, s.connectionState.replyError(err)
 	}
 	return newRows(r.Resultset)
 }

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -169,11 +169,11 @@ func (d driver) Open(dsn string) (sqldriver.Conn, error) {
 		return nil, err
 	}
 
-	// if retries is true then return sqldriver.ErrBadConn which will trigger up to 3
-	// retries by the database/sql package. If retries are disabled then we'll return
+	// if retries are 'on' then return sqldriver.ErrBadConn which will trigger up to 3
+	// retries by the database/sql package. If retries are 'off' then we'll return
 	// the native go-mysql-org/go-mysql 'mysql.ErrBadConn' erorr which will prevent a retry.
 	// In this case the sqldriver.Validator interface is implemented and will return
-	// false for IsValid() signaling that the connection is bad and should be discarded.
+	// false for IsValid() signaling the connection is bad and should be discarded.
 	return &conn{Conn: c, state: &state{valid: true, useDriverErrors: !retries}}, nil
 }
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -140,7 +140,7 @@ func (d driver) Open(dsn string) (sqldriver.Conn, error) {
 				}
 			} else if key == "retries" && len(value) > 0 {
 				// by default keep the golang database/sql retry behavior enabled unless
-				// the retries driver option is explicitly set to 'false'
+				// the retries driver option is explicitly set to 'off'
 				retries = !strings.EqualFold(value[0], "off")
 			} else {
 				if option, ok := options[key]; ok {


### PR DESCRIPTION
We've run into a problem caused by the Golangs `database/sql` package [default retry behavior](https://github.com/golang/go/blob/c5430dc1d8d96cfd0c85a6d760262676d798a6a9/src/database/sql/sql.go#L1663) (which can't be disabled by the way) when an [ErrBadConn](https://pkg.go.dev/database/sql/driver@go1.22.5#ErrBadConn) from the `database/sql/driver` is returned by the driver. We're looking to have our application fail fast when an issue occurs reaching the DB, but as of now we're seeing 3 retries, causing our application to hang up longer than we'd like.

Seems like others in the community have been asking for a way to disable retries, see https://github.com/golang/go/issues/52886 but the go developers have decided to not allow developers to configure that behavior.

This PR makes use of the [Validator](https://pkg.go.dev/database/sql/driver@go1.22.5#Validator) interface, along with introducing a new Driver argument called `retries` to determine if [ErrBadConn](https://pkg.go.dev/database/sql/driver@go1.22.5#ErrBadConn) or the go-mysql-org native [ErrBadConn](https://github.com/go-mysql-org/go-mysql/blob/3b1dd0e7703815062f7999fd7d503df0061807a9/mysql/error.go#L10) should be returned.

This takes advantage of the fact that retry won't occur unless the database/sql ErrBadConn is returned.  Per go docs:

> To prevent duplicate operations, ErrBadConn should NOT be returned if there's a possibility that the database server might have performed the operation. Even if the server sends back an error, you shouldn't return ErrBadConn.

And to maintain the behavior of discarding bad connection, the Validator interface will return false for isValid(), preventing the bad connection from being cached for reuse in sql.DB.

Thoughts on this are appreciated.
