### PR TITLE
Add `DisableFlushBinlogWhileWaiting` config and almost every query event triggers `OnPosSynced`

### DIFF
--- a/canal/canal_test.go
+++ b/canal/canal_test.go
@@ -133,6 +133,7 @@ func (s *canalTestSuite) TestCanal() {
 	)
 	s.execute("ALTER TABLE test.canal_test ADD `age` INT(5) NOT NULL AFTER `name`")
 	s.execute("INSERT INTO test.canal_test (name,age) VALUES (?,?)", "d", "18")
+	s.execute("ANALYZE TABLE test.canal_test")
 
 	err := s.c.CatchMasterPos(10 * time.Second)
 	require.NoError(s.T(), err)

--- a/canal/canal_test.go
+++ b/canal/canal_test.go
@@ -150,9 +150,19 @@ func (s *canalTestSuite) TestAnalyzeAdvancesSyncedPos() {
 		s.c.cfg.DisableFlushBinlogWhileWaiting = false
 	}()
 
-	s.execute("ANALYZE TABLE test.canal_test")
-	err := s.c.CatchMasterPos(10 * time.Second)
+	startingPos, err := s.c.GetMasterPos()
 	require.NoError(s.T(), err)
+
+	s.execute("ANALYZE TABLE test.canal_test")
+	err = s.c.CatchMasterPos(10 * time.Second)
+	require.NoError(s.T(), err)
+
+	// Ensure the ending pos is greater than the starting pos
+	// but the filename is the same. This ensures that
+	// FLUSH BINARY LOGS was not used.
+	endingPos, err := s.c.GetMasterPos()
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), startingPos.Name, endingPos.Name)
 }
 
 func (s *canalTestSuite) TestCanalFilter() {

--- a/canal/canal_test.go
+++ b/canal/canal_test.go
@@ -163,6 +163,7 @@ func (s *canalTestSuite) TestAnalyzeAdvancesSyncedPos() {
 	endingPos, err := s.c.GetMasterPos()
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), startingPos.Name, endingPos.Name)
+	require.Greater(s.T(), endingPos.Pos, startingPos.Pos)
 }
 
 func (s *canalTestSuite) TestCanalFilter() {

--- a/canal/config.go
+++ b/canal/config.go
@@ -91,6 +91,11 @@ type Config struct {
 	// whether disable re-sync for broken connection
 	DisableRetrySync bool `toml:"disable_retry_sync"`
 
+	// whether the function WaitUntilPos() can use FLUSH BINARY LOGS
+	// to ensure we advance past a position. This should not strictly be required,
+	// and requires additional privileges.
+	DisableFlushBinlogWhileWaiting bool `toml:"disable_flush_binlog_while_waiting"`
+
 	// Set TLS config
 	TLSConfig *tls.Config
 

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -235,6 +235,14 @@ func parseStmt(stmt ast.StmtNode) (ns []*node) {
 			table: t.Table.Name.String(),
 		}
 		ns = []*node{n}
+	case *ast.AnalyzeTableStmt:
+		ns = make([]*node, len(t.TableNames))
+		for i, table := range t.TableNames {
+			ns[i] = &node{
+				db:    table.Schema.String(),
+				table: table.Name.String(),
+			}
+		}
 	}
 	return ns
 }


### PR DESCRIPTION
`ANALYZE TABLE` was not being considered in DDL statements.

This is a problem because if it doesn't return as one of the nodes from `parseStmt()` then it won't set `savePos` to `true` here:

https://github.com/go-mysql-org/go-mysql/blob/3b1dd0e7703815062f7999fd7d503df0061807a9/canal/sync.go#L157-L182

Which means the binary log doesn't advance.

We rely on the binary log to advance to implement our own `BlockWait()` function, which is similar to `c.WaitUntilPos()`. We can't use `WaitUntilPos()` because it calls `FLUSH BINARY LOGS` which requires additional privileges.

We were previously injecting binlog noise to advance the binary log, but with this fix we shouldn't need to do that (and ideally `WaitUntilPos()` doesn't either, so it can catch bugs if statements are left off the list like this one.)