### PR TITLE
export EventCacheCount on Canal Config

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -462,6 +462,7 @@ func (c *Canal) prepareSyncer() error {
 		Logger:                  c.cfg.Logger,
 		Dialer:                  c.cfg.Dialer,
 		Localhost:               c.cfg.Localhost,
+		EventCacheCount:         c.cfg.EventCacheCount,
 		RowsEventDecodeFunc: func(event *replication.RowsEvent, data []byte) error {
 			pos, err := event.DecodeHeader(data)
 			if err != nil {

--- a/canal/config.go
+++ b/canal/config.go
@@ -107,6 +107,11 @@ type Config struct {
 
 	// Set Localhost
 	Localhost string
+
+	// EventCacheCount is the capacity of the BinlogStreamer internal event channel.
+	// the default value is 10240.
+	// if you table contain large columns, you can decrease this value to avoid OOM.
+	EventCacheCount int
 }
 
 func NewConfigWithFile(name string) (*Config, error) {


### PR DESCRIPTION
use `Canal` to sync binlog may get OOM if binlog contain large column, that because BinlogStreamer default internal channel too large, set EventCacheCount to small value can reduce memory usage, but it not exported on `canal.Config` struct.