### PR TITLE
Fix can't connect to MySQL 8.0 with long password

### DIFF
--- a/client/auth.go
+++ b/client/auth.go
@@ -115,11 +115,11 @@ func (c *Conn) readInitialHandshake() error {
 			// the first packet *must* have at least 20 bytes of a scramble.
 			// if a plugin provided less, we pad it to 20 with zeros
 			rest := int(authPluginDataLen) - 8
-			if max := 12 + 1; rest < max {
-				rest = max
+			if rest < 13 {
+				rest = 13
 			}
 
-			authPluginDataPart2 := data[pos : pos+rest]
+			authPluginDataPart2 := data[pos : pos+rest-1]
 			pos += rest
 
 			c.salt = append(c.salt, authPluginDataPart2...)

--- a/client/auth.go
+++ b/client/auth.go
@@ -119,7 +119,7 @@ func (c *Conn) readInitialHandshake() error {
 				rest = 13
 			}
 
-			authPluginDataPart2 := data[pos : pos+rest]
+			authPluginDataPart2 := data[pos : pos+rest-1]
 			pos += rest
 
 			c.salt = append(c.salt, authPluginDataPart2...)

--- a/client/auth.go
+++ b/client/auth.go
@@ -119,7 +119,7 @@ func (c *Conn) readInitialHandshake() error {
 				rest = 13
 			}
 
-			authPluginDataPart2 := data[pos : pos+rest-1]
+			authPluginDataPart2 := data[pos : pos+rest]
 			pos += rest
 
 			c.salt = append(c.salt, authPluginDataPart2...)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -528,9 +528,9 @@ INSERT INTO field_value_test VALUES (
 }
 
 func (s *clientTestSuite) TestLongPassword() {
-	_, err := s.c.Execute("DROP USER IF EXISTS 'test_long_password'@'localhost'")
+	_, err := s.c.Execute("DROP USER IF EXISTS 'test_long_password'@'%'")
 	require.NoError(s.T(), err)
-	_, err = s.c.Execute("CREATE USER 'test_long_password'@'localhost' IDENTIFIED BY '12345678901234567890'")
+	_, err = s.c.Execute("CREATE USER 'test_long_password'@'%' IDENTIFIED BY '12345678901234567890'")
 	require.NoError(s.T(), err)
 
 	addr := fmt.Sprintf("%s:%s", *test_util.MysqlHost, s.port)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -526,3 +526,16 @@ INSERT INTO field_value_test VALUES (
 		require.Equal(s.T(), expected[i], v.String())
 	}
 }
+
+func (s *clientTestSuite) TestLongPassword() {
+	_, err := s.c.Execute("DROP USER IF EXISTS 'test_long_password'@'localhost'")
+	require.NoError(s.T(), err)
+	_, err = s.c.Execute("CREATE USER 'test_long_password'@'localhost' IDENTIFIED BY '12345678901234567890'")
+	require.NoError(s.T(), err)
+
+	addr := fmt.Sprintf("%s:%s", *test_util.MysqlHost, s.port)
+	c, err := Connect(addr, "test_long_password", "12345678901234567890", "")
+	require.NoError(s.T(), err)
+	err = c.Close()
+	require.NoError(s.T(), err)
+}


### PR DESCRIPTION
close https://github.com/go-mysql-org/go-mysql/issues/911

Seems we should not use the ending zero in the scramble 