### PR TITLE
Ensure ACKs are sent after backup

### DIFF
--- a/replication/backup.go
+++ b/replication/backup.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"sync"
 	"time"
 
 	. "github.com/go-mysql-org/go-mysql/mysql"
@@ -41,77 +42,106 @@ func (b *BinlogSyncer) StartBackupWithHandler(p Position, timeout time.Duration,
 	// Force use raw mode
 	b.parser.SetRawMode(true)
 
+	// Set up the backup event handler
+	backupHandler := &BackupEventHandler{
+		handler: handler,
+	}
+
+	// Set the event handler in BinlogSyncer
+	b.SetEventHandler(backupHandler)
+
+	// Start syncing
 	s, err := b.StartSync(p)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	var filename string
-	var offset uint32
-
-	var w io.WriteCloser
 	defer func() {
-		var closeErr error
-		if w != nil {
-			closeErr = w.Close()
-		}
-		if retErr == nil {
-			retErr = closeErr
+		b.SetEventHandler(nil) // Reset the event handler
+		if backupHandler.w != nil {
+			closeErr := backupHandler.w.Close()
+			if retErr == nil {
+				retErr = closeErr
+			}
 		}
 	}()
 
-	for {
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		e, err := s.GetEvent(ctx)
-		cancel()
+	// Wait until the context is done or an error occurs
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 
-		if err == context.DeadlineExceeded {
-			return nil
+	select {
+	case <-ctx.Done():
+		return nil
+	case <-b.ctx.Done():
+		return nil
+	case err := <-s.ech:
+		return errors.Trace(err)
+	}
+}
+
+// BackupEventHandler handles writing events for backup
+type BackupEventHandler struct {
+	handler func(binlogFilename string) (io.WriteCloser, error)
+	w       io.WriteCloser
+	file    *os.File
+	mutex   sync.Mutex
+}
+
+func (h *BackupEventHandler) HandleEvent(e *BinlogEvent) error {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	switch e.Header.EventType {
+	case ROTATE_EVENT:
+		rotateEvent := e.Event.(*RotateEvent)
+		filename := string(rotateEvent.NextLogName)
+
+		// Close existing file if open
+		if h.w != nil {
+			if err := h.w.Close(); err != nil {
+				h.w = nil
+				return errors.Trace(err)
+			}
 		}
 
+		// Open new file
+		var err error
+		h.w, err = h.handler(filename)
 		if err != nil {
 			return errors.Trace(err)
 		}
 
-		offset = e.Header.LogPos
-
-		if e.Header.EventType == ROTATE_EVENT {
-			rotateEvent := e.Event.(*RotateEvent)
-			filename = string(rotateEvent.NextLogName)
-
-			if e.Header.Timestamp == 0 || offset == 0 {
-				// fake rotate event
-				continue
-			}
-		} else if e.Header.EventType == FORMAT_DESCRIPTION_EVENT {
-			// FormateDescriptionEvent is the first event in binlog, we will close old one and create a new
-
-			if w != nil {
-				if err = w.Close(); err != nil {
-					w = nil
-					return errors.Trace(err)
-				}
-			}
-
-			if len(filename) == 0 {
-				return errors.Errorf("empty binlog filename for FormateDescriptionEvent")
-			}
-
-			w, err = handler(filename)
-			if err != nil {
-				return errors.Trace(err)
-			}
-
-			// write binlog header fe'bin'
-			if _, err = w.Write(BinLogFileHeader); err != nil {
-				return errors.Trace(err)
-			}
+		// Ensure w is an *os.File to call Sync
+		if f, ok := h.w.(*os.File); ok {
+			h.file = f
+		} else {
+			return errors.New("handler did not return *os.File, cannot fsync")
 		}
 
-		if n, err := w.Write(e.RawData); err != nil {
+		// Write binlog header
+		if _, err := h.w.Write(BinLogFileHeader); err != nil {
+			return errors.Trace(err)
+		}
+
+		// fsync after writing header
+		if err := h.file.Sync(); err != nil {
+			return errors.Trace(err)
+		}
+
+	default:
+		// Write raw event data
+		if n, err := h.w.Write(e.RawData); err != nil {
 			return errors.Trace(err)
 		} else if n != len(e.RawData) {
 			return errors.Trace(io.ErrShortWrite)
 		}
+
+		// fsync after writing event
+		if err := h.file.Sync(); err != nil {
+			return errors.Trace(err)
+		}
 	}
+
+	return nil
 }

--- a/replication/backup_test.go
+++ b/replication/backup_test.go
@@ -2,7 +2,10 @@ package replication
 
 import (
 	"context"
+	"io"
 	"os"
+	"path"
+	"sync"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -32,18 +35,134 @@ func (t *testSyncerSuite) TestStartBackupEndInGivenTime() {
 
 	done := make(chan bool)
 
+	// Start the backup in a goroutine
 	go func() {
 		err := t.b.StartBackup(binlogDir, mysql.Position{Name: "", Pos: uint32(0)}, timeout)
 		require.NoError(t.T(), err)
 		done <- true
 	}()
+
+	// Wait for the backup to complete or timeout
 	failTimeout := 5 * timeout
 	ctx, cancel := context.WithTimeout(context.Background(), failTimeout)
 	defer cancel()
 	select {
 	case <-done:
+		// Backup completed; now verify the backup files
+		files, err := os.ReadDir(binlogDir)
+		require.NoError(t.T(), err)
+		require.NotEmpty(t.T(), files, "No binlog files were backed up")
+
+		for _, file := range files {
+			fileInfo, err := os.Stat(path.Join(binlogDir, file.Name()))
+			require.NoError(t.T(), err)
+			require.NotZero(t.T(), fileInfo.Size(), "Binlog file %s is empty", file.Name())
+		}
+
 		return
 	case <-ctx.Done():
 		t.T().Fatal("time out error")
 	}
+}
+
+type CountingEventHandler struct {
+	count int
+	mutex sync.Mutex
+}
+
+func (h *CountingEventHandler) HandleEvent(e *BinlogEvent) error {
+	h.mutex.Lock()
+	h.count++
+	h.mutex.Unlock()
+	return nil
+}
+
+func (t *testSyncerSuite) TestBackupEventHandlerInvocation() {
+	t.setupTest(mysql.MySQLFlavor)
+
+	// Define binlogDir and timeout
+	binlogDir := "./var"
+	os.RemoveAll(binlogDir)
+	timeout := 2 * time.Second
+
+	// Set up the CountingEventHandler
+	handler := &CountingEventHandler{}
+	t.b.SetEventHandler(handler)
+
+	// Start the backup
+	err := t.b.StartBackup(binlogDir, mysql.Position{Name: "", Pos: uint32(0)}, timeout)
+	require.NoError(t.T(), err)
+
+	// Verify that events were handled
+	handler.mutex.Lock()
+	eventCount := handler.count
+	handler.mutex.Unlock()
+	require.Greater(t.T(), eventCount, 0, "No events were handled by the EventHandler")
+}
+
+func (t *testSyncerSuite) TestACKSentAfterFsync() {
+	t.setupTest(mysql.MySQLFlavor)
+
+	// Define binlogDir and timeout
+	binlogDir := "./var"
+	os.RemoveAll(binlogDir)
+	timeout := 5 * time.Second
+
+	// Create channels for signaling
+	fsyncedChan := make(chan struct{}, 1)
+	ackedChan := make(chan struct{}, 1)
+
+	// Set up the BackupEventHandler with fsyncedChan
+	backupHandler := &BackupEventHandler{
+		handler: func(binlogFilename string) (io.WriteCloser, error) {
+			return os.OpenFile(path.Join(binlogDir, binlogFilename), os.O_CREATE|os.O_WRONLY, 0644)
+		},
+		fsyncedChan: fsyncedChan,
+	}
+
+	// Set the event handler in BinlogSyncer
+	t.b.SetEventHandler(backupHandler)
+
+	// Set the ackedChan in BinlogSyncer
+	t.b.ackedChan = ackedChan
+	t.b.cfg.SemiSyncEnabled = true // Ensure semi-sync is enabled
+
+	// Start syncing
+	pos := mysql.Position{Name: "", Pos: uint32(0)}
+	go func() {
+		// Start backup (this will block until timeout)
+		err := t.b.StartBackupWithHandler(pos, timeout, backupHandler.handler)
+		require.NoError(t.T(), err)
+	}()
+
+	// Wait briefly to ensure sync has started
+	time.Sleep(1 * time.Second)
+
+	// Execute a query to generate an event
+	t.testExecute("FLUSH LOGS")
+
+	// Wait for fsync signal
+	select {
+	case <-fsyncedChan:
+		// fsync completed
+	case <-time.After(2 * time.Second):
+		t.T().Fatal("fsync did not complete in time")
+	}
+
+	// Record the time when fsync completed
+	fsyncTime := time.Now()
+
+	// Wait for ACK signal
+	select {
+	case <-ackedChan:
+		// ACK sent
+	case <-time.After(2 * time.Second):
+		t.T().Fatal("ACK not sent in time")
+	}
+
+	// Record the time when ACK was sent
+	ackTime := time.Now()
+
+	// Assert that ACK was sent after fsync
+	require.True(t.T(), ackTime.After(fsyncTime), "ACK was sent before fsync completed")
 }


### PR DESCRIPTION
## Summary
This PR addresses an issue where acknowledgments (ACKs) were sometimes sent to the master before binlog events were fully written and fsynced to disk during backup operations. Sending ACKs prematurely in semi-synchronous replication could lead to data loss if the replica fails after sending the ACK but before persisting the event.
### ACK after backup
- Ensured that ACKs are sent only after the event has been fully processed and fsynced by sending the ACK *after* event handling
###  Event handling
- Introduced an `EventHandler` interface with a `HandleEvent` method for processing binlog events. This allows custom event handling logic to be injected into the replication stream
- Accordingly, added an `eventHandler` field and `SetEventHandler` method to `BinlogSyncer`.
- Implemented `BackupEventHandler` which writes binlog events to disk and ensures that each event is fsynced before returning. This ensures data durability before ACKs are sent.

### Separating parsing from handling
- Modified the `onStream` method in `BinlogSyncer` to separate event parsing (`parseEvent`) from event handling and ACK sending (`handleEventAndACK`). This adheres to the single-responsibility principle and makes the code cleaner
- Moved state updates (e.g., updating `b.nextPos`) and GTIDSet handling from `parseEvent` to `handleEventAndACK` to avoid side effects during parsing. Something called `parseEvent` should only be parsing, not modifying state or sending ACKs.

## Testing
Three new tests:
* `TestGTIDSetHandling` - This confirms the continued functionality of the existing GTIDSet logic after it was involved in a refactor
* `TestACKSentAfterFsync` - This confirms that ACKs are only send *after* the backup files are fsynced
* `TestBackupEventHandlerInvocation` -  This confirms that the (new) EventHandler works as expected

```
❯ go test
PASS
ok      github.com/go-mysql-org/go-mysql/replication    0.703s
```