### PR TITLE
client: Fix timeout reset during TLS handshake

### DIFF
--- a/client/auth.go
+++ b/client/auth.go
@@ -304,7 +304,7 @@ func (c *Conn) writeAuthHandshake() error {
 		}
 
 		currentSequence := c.Sequence
-		c.Conn = packet.NewBufferedConn(tlsConn, c.BufferSize)
+		c.Conn = packet.NewConnWithTimeout(tlsConn, c.ReadTimeout, c.WriteTimeout, c.BufferSize)
 		c.Sequence = currentSequence
 	}
 


### PR DESCRIPTION
This commit fixes `(*client.Conn).writeAuthHandshake()` to use `packet.NewConnWithTimeout` instead of `packet.NewBufferedConn` when recreating the packet connection after switching TLS on. This preserves the connection read/write timeout settings which would otherwise be reset to zero.

Since this code executes after some reads and writes have already taken place, and the packet connection code only sets a deadline when the timeout values are nonzero, the result was that previously when connecting using TLS and with a read and/or write timeout set, the connection would inevitably fail just one timeout-duration after being opened.

This use of `packet.NewBufferedConn` appears to be the only place in the `client` package where a packet connection was recreated without the timeout configuration being plumbed through.