### PR TITLE
replication: Log info about server

### DIFF
--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -404,6 +404,8 @@ func (b *BinlogSyncer) prepare() error {
 		return errors.Trace(err)
 	}
 
+	b.cfg.Logger.Infof("Connected to %s %s server", b.cfg.Flavor, b.c.GetServerVersion())
+
 	return nil
 }
 


### PR DESCRIPTION
```
$ ./bin/go-mysqlbinlog  | head
[2024/10/27 10:29:18] [info] binlogsyncer.go:189 create BinlogSyncer with config {ServerID:101 Flavor:mysql Host:127.0.0.1 Port:3306 User:root Password: Localhost: Charset: SemiSyncEnabled:false RawModeEnabled:false TLSConfig:<nil> ParseTime:false TimestampStringLocation:UTC UseDecimal:true RecvBufferSize:0 HeartbeatPeriod:0s ReadTimeout:0s MaxReconnectAttempts:0 DisableRetrySync:false VerifyChecksum:false DumpCommandFlag:0 Option:<nil> Logger:0xc00013c240 Dialer:0x6d1be0 RowsEventDecodeFunc:<nil> TableMapOptionalMetaDecodeFunc:<nil> DiscardGTIDSet:false EventCacheCount:10240 SynchronousEventHandler:<nil>}
[2024/10/27 10:29:18] [info] binlogsyncer.go:429 begin to sync binlog from position (, 4)
[2024/10/27 10:29:18] [info] binlogsyncer.go:407 Connected to mysql 9.1.0 server
[2024/10/27 10:29:18] [info] binlogsyncer.go:846 rotate to (binlog.000001, 4)
=== RotateEvent ===
Date: 1970-01-01 01:00:00
Log position: 0
Event size: 40
Position: 4
Next log name: binlog.000001
```

So this adds this:
```
[2024/10/27 10:29:18] [info] binlogsyncer.go:407 Connected to mysql 9.1.0 server
```