### PR TITLE
go-mysqldump: Add option to skip binlog position

### DIFF
--- a/cmd/go-mysqldump/main.go
+++ b/cmd/go-mysqldump/main.go
@@ -18,10 +18,11 @@ var (
 	execution = flag.String("exec", "mysqldump", "mysqldump execution path")
 	output    = flag.String("o", "", "dump output, empty for stdout")
 
-	dbs          = flag.String("dbs", "", "dump databases, separated by comma")
-	tables       = flag.String("tables", "", "dump tables, separated by comma, will overwrite dbs")
-	tableDB      = flag.String("table_db", "", "database for dump tables")
-	ignoreTables = flag.String("ignore_tables", "", "ignore tables, must be database.table format, separated by comma")
+	dbs           = flag.String("dbs", "", "dump databases, separated by comma")
+	tables        = flag.String("tables", "", "dump tables, separated by comma, will overwrite dbs")
+	tableDB       = flag.String("table_db", "", "database for dump tables")
+	ignoreTables  = flag.String("ignore_tables", "", "ignore tables, must be database.table format, separated by comma")
+	skipBinlogPos = flag.Bool("skip-binlog-pos", false, "skip fetching binlog position via --master-data/--source-data")
 )
 
 func main() {
@@ -32,6 +33,8 @@ func main() {
 		fmt.Printf("Create Dumper error %v\n", errors.ErrorStack(err))
 		os.Exit(1)
 	}
+
+	d.SkipMasterData(*skipBinlogPos)
 
 	if len(*ignoreTables) > 0 {
 		subs := strings.Split(*ignoreTables, ",")


### PR DESCRIPTION
Issue: ref #940 

When running against MariaDB 11.4 without binlogs enabled:

- `mysqldump` 9.1.0 fails to dump when called with `--source-data` due to the `SHOW BINARY LOG STATUS` not being supported by MariaDB.
- `mariadb-dump` 11.4 fails to dump when called with `--master-data` due to binlogs not being enabled.

Other situations where this can be useful:

- Permission issues