### PR TITLE
dump: use mariadb-dump when available

### DIFF
--- a/cmd/go-mysqldump/main.go
+++ b/cmd/go-mysqldump/main.go
@@ -15,7 +15,7 @@ var (
 	addr      = flag.String("addr", "127.0.0.1:3306", "MySQL addr")
 	user      = flag.String("user", "root", "MySQL user")
 	password  = flag.String("password", "", "MySQL password")
-	execution = flag.String("exec", "mysqldump", "mysqldump execution path")
+	execution = flag.String("exec", "", "mysqldump/mariadb-dump execution path")
 	output    = flag.String("o", "", "dump output, empty for stdout")
 
 	dbs           = flag.String("dbs", "", "dump databases, separated by comma")
@@ -30,7 +30,7 @@ func main() {
 
 	d, err := dump.NewDumper(*execution, *addr, *user, *password)
 	if err != nil {
-		fmt.Printf("Create Dumper error %v\n", errors.ErrorStack(err))
+		fmt.Printf("Create Dumper error: %v\n", errors.ErrorStack(err))
 		os.Exit(1)
 	}
 

--- a/dump/dumper.go
+++ b/dump/dumper.go
@@ -51,13 +51,23 @@ type Dumper struct {
 }
 
 func NewDumper(executionPath string, addr string, user string, password string) (*Dumper, error) {
-	if len(executionPath) == 0 {
-		return nil, nil
-	}
+	var path string
+	var err error
 
-	path, err := exec.LookPath(executionPath)
-	if err != nil {
-		return nil, errors.Trace(err)
+	if len(executionPath) == 0 { // No explicit path set
+		path, err = exec.LookPath("mysqldump")
+		if err != nil {
+			path, err = exec.LookPath("mariadb-dump")
+			if err != nil {
+				// Using a new error as `err` will only mention mariadb-dump and not mysqldump
+				return nil, errors.New("not able to find mysqldump or mariadb-dump in path")
+			}
+		}
+	} else {
+		path, err = exec.LookPath(executionPath)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	d := new(Dumper)


### PR DESCRIPTION
Issue: ref #940 closes #264

- Call `mariadb-dump` when there is no `mysqldump` in the execution path
- This also fixes the issue that `dump.NewDumper()` might return `nil, nil` and `go-mysqldump` not checking for that.