### PR TITLE
go-mysqlbinlog: set to retry only 10 times

### DIFF
--- a/cmd/go-mysqlbinlog/main.go
+++ b/cmd/go-mysqlbinlog/main.go
@@ -40,13 +40,14 @@ func main() {
 		ServerID: 101,
 		Flavor:   *flavor,
 
-		Host:            *host,
-		Port:            uint16(*port),
-		User:            *user,
-		Password:        *password,
-		RawModeEnabled:  *rawMode,
-		SemiSyncEnabled: *semiSync,
-		UseDecimal:      true,
+		Host:                 *host,
+		Port:                 uint16(*port),
+		User:                 *user,
+		Password:             *password,
+		RawModeEnabled:       *rawMode,
+		SemiSyncEnabled:      *semiSync,
+		UseDecimal:           true,
+		MaxReconnectAttempts: 10,
 	}
 
 	b := replication.NewBinlogSyncer(cfg)

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -749,12 +749,18 @@ func (b *BinlogSyncer) onStream(s *BinlogStreamer) {
 					b.retryCount++
 					if err = b.retrySync(); err != nil {
 						if b.cfg.MaxReconnectAttempts > 0 && b.retryCount >= b.cfg.MaxReconnectAttempts {
-							b.cfg.Logger.Errorf("retry sync err: %v, exceeded max retries (%d)", err, b.cfg.MaxReconnectAttempts)
+							b.cfg.Logger.Errorf(
+								"retry sync err: %v, exceeded max retries (%d)",
+								err, b.cfg.MaxReconnectAttempts,
+							)
 							s.closeWithError(err)
 							return
 						}
 
-						b.cfg.Logger.Errorf("retry sync err: %v, wait 1s and retry again", err)
+						b.cfg.Logger.Errorf(
+							"retry sync err: %v, wait 1s and retry again (retries: %d/%d)",
+							err, b.retryCount, b.cfg.MaxReconnectAttempts,
+						)
 						continue
 					}
 				}


### PR DESCRIPTION
1. Set `MaxReconnectAttempts: 10` for `go-mysqlbinlog`
2. Print retry nr & max on retry

```
...
=== MariadbBinLogCheckPointEvent ===
Date: 2024-11-08 14:05:51
Log position: 329
Event size: 44
Info: mysqld-bin.000002

[2024/11/08 14:05:56] [info] binlogsyncer.go:800 receive EOF packet, no more binlog event now.
[2024/11/08 14:05:56] [error] binlogsyncer.go:728 io.ReadFull(header) failed. err EOF: connection was bad
[2024/11/08 14:05:57] [info] binlogsyncer.go:659 begin to re-sync from (mysqld-bin.000002, 329)
[2024/11/08 14:05:57] [error] binlogsyncer.go:757 retry sync err: dial tcp 127.0.0.1:3307: connect: connection refused, wait 1s and retry again (retries: 1/10)
[2024/11/08 14:05:58] [info] binlogsyncer.go:659 begin to re-sync from (mysqld-bin.000002, 329)
[2024/11/08 14:05:58] [error] binlogsyncer.go:757 retry sync err: dial tcp 127.0.0.1:3307: connect: connection refused, wait 1s and retry again (retries: 2/10)
[2024/11/08 14:05:59] [info] binlogsyncer.go:659 begin to re-sync from (mysqld-bin.000002, 329)
[2024/11/08 14:05:59] [error] binlogsyncer.go:757 retry sync err: dial tcp 127.0.0.1:3307: connect: connection refused, wait 1s and retry again (retries: 3/10)
[2024/11/08 14:06:00] [info] binlogsyncer.go:659 begin to re-sync from (mysqld-bin.000002, 329)
[2024/11/08 14:06:00] [error] binlogsyncer.go:757 retry sync err: dial tcp 127.0.0.1:3307: connect: connection refused, wait 1s and retry again (retries: 4/10)
[2024/11/08 14:06:01] [info] binlogsyncer.go:659 begin to re-sync from (mysqld-bin.000002, 329)
[2024/11/08 14:06:01] [error] binlogsyncer.go:757 retry sync err: dial tcp 127.0.0.1:3307: connect: connection refused, wait 1s and retry again (retries: 5/10)
[2024/11/08 14:06:02] [info] binlogsyncer.go:659 begin to re-sync from (mysqld-bin.000002, 329)
[2024/11/08 14:06:02] [error] binlogsyncer.go:757 retry sync err: dial tcp 127.0.0.1:3307: connect: connection refused, wait 1s and retry again (retries: 6/10)
[2024/11/08 14:06:03] [info] binlogsyncer.go:659 begin to re-sync from (mysqld-bin.000002, 329)
[2024/11/08 14:06:03] [error] binlogsyncer.go:757 retry sync err: dial tcp 127.0.0.1:3307: connect: connection refused, wait 1s and retry again (retries: 7/10)
[2024/11/08 14:06:04] [info] binlogsyncer.go:659 begin to re-sync from (mysqld-bin.000002, 329)
[2024/11/08 14:06:04] [error] binlogsyncer.go:757 retry sync err: dial tcp 127.0.0.1:3307: connect: connection refused, wait 1s and retry again (retries: 8/10)
[2024/11/08 14:06:05] [info] binlogsyncer.go:659 begin to re-sync from (mysqld-bin.000002, 329)
[2024/11/08 14:06:05] [error] binlogsyncer.go:757 retry sync err: dial tcp 127.0.0.1:3307: connect: connection refused, wait 1s and retry again (retries: 9/10)
[2024/11/08 14:06:06] [info] binlogsyncer.go:659 begin to re-sync from (mysqld-bin.000002, 329)
[2024/11/08 14:06:06] [error] binlogsyncer.go:752 retry sync err: dial tcp 127.0.0.1:3307: connect: connection refused, exceeded max retries (10)
[2024/11/08 14:06:06] [error] binlogstreamer.go:78 close sync with err: dial tcp 127.0.0.1:3307: connect: connection refused
Get event error: dial tcp 127.0.0.1:3307: connect: connection refused
github.com/pingcap/errors.AddStack
	/home/dvaneeden/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20221009092201-b66cddb77c32/errors.go:174
github.com/pingcap/errors.Trace
	/home/dvaneeden/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20221009092201-b66cddb77c32/juju_adaptor.go:15
github.com/go-mysql-org/go-mysql/client.ConnectWithDialer
	/home/dvaneeden/dev/go-mysql/client/conn.go:118
github.com/go-mysql-org/go-mysql/replication.(*BinlogSyncer).newConnection
	/home/dvaneeden/dev/go-mysql/replication/binlogsyncer.go:946
github.com/go-mysql-org/go-mysql/replication.(*BinlogSyncer).registerSlave
	/home/dvaneeden/dev/go-mysql/replication/binlogsyncer.go:271
github.com/go-mysql-org/go-mysql/replication.(*BinlogSyncer).prepare
	/home/dvaneeden/dev/go-mysql/replication/binlogsyncer.go:399
github.com/go-mysql-org/go-mysql/replication.(*BinlogSyncer).prepareSyncPos
	/home/dvaneeden/dev/go-mysql/replication/binlogsyncer.go:674
github.com/go-mysql-org/go-mysql/replication.(*BinlogSyncer).retrySync
	/home/dvaneeden/dev/go-mysql/replication/binlogsyncer.go:660
github.com/go-mysql-org/go-mysql/replication.(*BinlogSyncer).onStream
	/home/dvaneeden/dev/go-mysql/replication/binlogsyncer.go:750
runtime.goexit
	/usr/lib/golang/src/runtime/asm_amd64.s:1700
```