### PR TITLE
replication: Add GTID_TAGGED_LOG_EVENT

### DIFF
--- a/replication/const.go
+++ b/replication/const.go
@@ -48,6 +48,9 @@ const (
 	BINLOG_MARIADB_FL_DDL                         /*32 - FL_DDL is set for event group containing DDL*/
 )
 
+// See `Log_event_type` in binlog_event.h
+// https://github.com/mysql/mysql-server/blob/trunk/libs/mysql/binlog/event/binlog_event.h
+
 type EventType byte
 
 const (
@@ -93,6 +96,7 @@ const (
 	PARTIAL_UPDATE_ROWS_EVENT
 	TRANSACTION_PAYLOAD_EVENT
 	HEARTBEAT_LOG_EVENT_V2
+	GTID_TAGGED_LOG_EVENT
 )
 
 const (
@@ -202,6 +206,8 @@ func (e EventType) String() string {
 		return "TransactionPayloadEvent"
 	case HEARTBEAT_LOG_EVENT_V2:
 		return "HeartbeatLogEventV2"
+	case GTID_TAGGED_LOG_EVENT:
+		return "Gtid_tagged_log_event"
 	case MARIADB_START_ENCRYPTION_EVENT:
 		return "MariadbStartEncryptionEvent"
 	case MARIADB_QUERY_COMPRESSED_EVENT:


### PR DESCRIPTION
Issue: ref #845 

The `GTID_TAGGED_LOG_EVENT` was added in MySQL 8.3

This only adds the `EventType`, but it doesn't yet do any decoding.

Example output from `go-mysqlbinlog`:
```
=== Gtid_tagged_log_event ===
Date: 2024-11-12 21:51:23
Log position: 220908
Event size: 83
Event data: 
00000000  02 78 00 00 00 02 aa aa  aa aa 88 88 66 66 44 44  |.x..........ffDD|
00000010  22 22 22 22 22 22 04 73  20 1b 06 14 73 65 63 6f  |"""""".s ...seco|
00000020  6e 64 74 65 73 74 08 c1  0e 0a d1 0e 0c 7f 23 35  |ndtest........#5|
00000030  48 61 bd 26 06 10 59 04  12 a3 ff 0a              |Ha.&..Y.....|
```