### PR TITLE
replication: Handle empty previous gtid

### DIFF
--- a/replication/event.go
+++ b/replication/event.go
@@ -238,7 +238,6 @@ func (e *PreviousGTIDsEvent) Decode(data []byte) error {
 		if len(data) == 8 {
 			return nil
 		}
-		return fmt.Errorf("uuidCount %d doesn't match data length %d", uuidCount, len(data))
 	}
 
 	previousGTIDSets := make([]string, uuidCount)

--- a/replication/event.go
+++ b/replication/event.go
@@ -238,7 +238,7 @@ func (e *PreviousGTIDsEvent) Decode(data []byte) error {
 		if len(data) == 8 {
 			return nil
 		}
-		fmt.Errorf("uuidCount %d doesn't match data length %d", uuidCount, len(data))
+		return fmt.Errorf("uuidCount %d doesn't match data length %d", uuidCount, len(data))
 	}
 
 	previousGTIDSets := make([]string, uuidCount)

--- a/replication/event.go
+++ b/replication/event.go
@@ -234,8 +234,18 @@ func (e *PreviousGTIDsEvent) Decode(data []byte) error {
 	uuidCount := binary.LittleEndian.Uint16(data[pos : pos+8])
 	pos += 8
 
+	if uuidCount <= 1 {
+		if len(data) == 8 {
+			return nil
+		}
+		fmt.Errorf("uuidCount %d doesn't match data length %d", uuidCount, len(data))
+	}
+
 	previousGTIDSets := make([]string, uuidCount)
 	for i := range previousGTIDSets {
+		if len(data) < pos+16 {
+			return fmt.Errorf("Failed to decode UUID")
+		}
 		uuid := e.decodeUuid(data[pos : pos+16])
 		pos += 16
 		sliceCount := binary.LittleEndian.Uint16(data[pos : pos+8])

--- a/replication/event_test.go
+++ b/replication/event_test.go
@@ -142,6 +142,7 @@ func TestIntVarEvent(t *testing.T) {
 }
 
 func TestPreviousGTIDEvent(t *testing.T) {
+	// uuidCount == 1
 	data := []byte{1, 0, 0, 0, 0, 0, 0, 1}
 	ev := PreviousGTIDsEvent{}
 	err := ev.Decode(data)

--- a/replication/event_test.go
+++ b/replication/event_test.go
@@ -140,3 +140,10 @@ func TestIntVarEvent(t *testing.T) {
 	require.Equal(t, INSERT_ID, ev.Type)
 	require.Equal(t, uint64(23), ev.Value)
 }
+
+func TestPreviousGTIDEvent(t *testing.T) {
+	data := []byte{1, 0, 0, 0, 0, 0, 0, 1}
+	ev := PreviousGTIDsEvent{}
+	err := ev.Decode(data)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
From `mysqlbinlog --read-from-remote-server --hexdump ...`:
```
# at 127
#241120 10:36:02 server id 1  end_log_pos 158 CRC32 0xa7f45443
# Position  Timestamp   Type   Source ID        Size      Source Pos    Flags
# 0000007f 82 ad 3d 67   23   01 00 00 00   1f 00 00 00   9e 00 00 00   80 00
# 00000092 01 00 00 00 00 00 00 01  43 54 f4 a7             |........CT..|
# 	Previous-GTIDs
# [empty]
```

This event is from MySQL 9.1.0
```
mysql-9.1.0> show binlog events from 127 limit 1;
+---------------+-----+----------------+-----------+-------------+------+
| Log_name      | Pos | Event_type     | Server_id | End_log_pos | Info |
+---------------+-----+----------------+-----------+-------------+------+
| binlog.000001 | 127 | Previous_gtids |         1 |         158 |      |
+---------------+-----+----------------+-----------+-------------+------+
1 row in set (0.00 sec)
```

So the `uuidCount` is 1 (from `01 00 00 00 00 00 00 01`)

Note that `43 54 f4 a7` is the `CRC32 0xa7f45443` checksum.

Without this, this happens:
```
[2024/11/20 10:37:40] [error] binlogstreamer.go:78 close sync with err: Err: runtime error: slice bounds out of range [:24] with capacity 12
 Stack: goroutine 8 [running]:
github.com/go-mysql-org/go-mysql/mysql.Pstack(...)
	/home/dvaneeden/go/pkg/mod/github.com/go-mysql-org/go-mysql@v1.10.0/mysql/util.go:25
github.com/go-mysql-org/go-mysql/replication.(*BinlogSyncer).onStream.func1()
	/home/dvaneeden/go/pkg/mod/github.com/go-mysql-org/go-mysql@v1.10.0/replication/binlogsyncer.go:730 +0x7e
panic({0x834dc0?, 0xc0000285e8?})
	/usr/lib/golang/src/runtime/panic.go:785 +0x132
github.com/go-mysql-org/go-mysql/replication.(*PreviousGTIDsEvent).Decode(0xc0000228a0, {0xc00002e8f4, 0x0?, 0xc})
	/home/dvaneeden/go/pkg/mod/github.com/go-mysql-org/go-mysql@v1.10.0/replication/event.go:239 +0x4ea
github.com/go-mysql-org/go-mysql/replication.(*BinlogParser).parseEvent(0xc0000d2190, 0xc0000285d0, {0xc00002e8f4, 0xc, 0xc}, {0xc00002e8e1?, 0xc00008de58?, 0x407f47?})
	/home/dvaneeden/go/pkg/mod/github.com/go-mysql-org/go-mysql@v1.10.0/replication/parser.go:328 +0x59f
github.com/go-mysql-org/go-mysql/replication.(*BinlogParser).Parse(0xc0000d2190, {0xc00002e8e1, 0x1f, 0x1f})
```

This is because it expects 8 bytes for the `uuidCount` an 16 bytes for the UUID, making 24 in total. But there is only 8 for the `uuidCount` and 4 for the checksum, resulting in a capacity of 12.