### PR TITLE
README: fix example for database/sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ import (
 func main() {
 	// dsn format: "user:password@addr?dbname"
 	dsn := "root@127.0.0.1:3306?test"
-	db, _ := sql.Open(dsn)
+	db, _ := sql.Open("mysql", dsn)
 	db.Close()
 }
 ```


### PR DESCRIPTION
Fix example

Otherwise this happens:
```
# command-line-arguments
./main.go:60:22: not enough arguments in call to sql.Open
	have (string)
	want (string, string)
```

See also https://pkg.go.dev/database/sql#Open