### PR TITLE
mysql field: expose API to modify field value

### DIFF
--- a/mysql/field.go
+++ b/mysql/field.go
@@ -44,6 +44,14 @@ const (
 	FieldValueTypeString
 )
 
+func NewFieldValue(t FieldValueType, v uint64, str []byte) FieldValue {
+	return FieldValue{
+		Type:  t,
+		value: v,
+		str:   str,
+	}
+}
+
 func (f *Field) Parse(p FieldData) (err error) {
 	f.Data = p
 


### PR DESCRIPTION
In my use case, I have a kind of MySQL proxy that can modify values for certain fields, but I couldn't find an API that allows this. So, I came up with this solution, which can be used as follows:

```
func (p *Proxy) HandleStmtExecute(context interface{}, query string, args []interface{}) (*mysql.Result, error) {
	var stmt *client.Stmt
        //...
	res, err := stmt.Execute(args...)
        //...
        res.Values[row][column] = mysql.NewFieldValue(mysql.FieldValueTypeUnsigned, rawGUID, []byte(fmt.Sprintf("%d", rawGUID)))
	return res, nil
}
```