### PR TITLE
Remove duplicate SIGINT in signal handling

### DIFF
--- a/cmd/go-canal/main.go
+++ b/cmd/go-canal/main.go
@@ -100,7 +100,6 @@ func main() {
 
 	sc := make(chan os.Signal, 1)
 	signal.Notify(sc,
-		syscall.SIGINT,
 		syscall.SIGHUP,
 		syscall.SIGINT,
 		syscall.SIGTERM,


### PR DESCRIPTION
1. Remove duplicate SIGINT from signal.Notify call
2. Keep other signal handlers (SIGHUP, SIGTERM, SIGQUIT) unchanged