### PR TITLE
*: don't use zero value of mysql.Result

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -185,6 +185,7 @@ func (s *clientTestSuite) TestConn_Insert() {
 	pkg, err := s.c.Execute(str)
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), uint64(1), pkg.AffectedRows)
+	require.EqualValues(s.T(), 0, pkg.ColumnNumber())
 }
 
 func (s *clientTestSuite) TestConn_Insert2() {

--- a/client/conn.go
+++ b/client/conn.go
@@ -343,10 +343,10 @@ func (c *Conn) ExecuteMultiple(query string, perResultCallback ExecPerResultCall
 	// streaming session
 	// if this would end up in WriteValue, it would just be ignored as all
 	// responses should have been handled in perResultCallback
-	return &Result{Resultset: &Resultset{
-		Streaming:     StreamingMultiple,
-		StreamingDone: true,
-	}}, nil
+	rs := NewResultset(0)
+	rs.Streaming = StreamingMultiple
+	rs.StreamingDone = true
+	return NewResult(rs), nil
 }
 
 // ExecuteSelectStreaming will call perRowCallback for every row in resultset

--- a/client/resp.go
+++ b/client/resp.go
@@ -39,7 +39,7 @@ func (c *Conn) handleOKPacket(data []byte) (*Result, error) {
 	var n int
 	var pos = 1
 
-	r := new(Result)
+	r := NewResultReserveResultset(0)
 
 	r.AffectedRows, _, n = LengthEncodedInt(data[pos:])
 	pos += n
@@ -283,9 +283,7 @@ func (c *Conn) readResultset(data []byte, binary bool) (*Result, error) {
 		return nil, ErrMalformPacket
 	}
 
-	result := &Result{
-		Resultset: NewResultset(int(count)),
-	}
+	result := NewResultReserveResultset(int(count))
 
 	if err := c.readResultColumns(result); err != nil {
 		return nil, errors.Trace(err)

--- a/mysql/result.go
+++ b/mysql/result.go
@@ -1,5 +1,7 @@
 package mysql
 
+// Result should be created by NewResultWithoutRows or NewResult. The zero value
+// of Result is invalid.
 type Result struct {
 	Status   uint16
 	Warnings uint16
@@ -8,6 +10,18 @@ type Result struct {
 	AffectedRows uint64
 
 	*Resultset
+}
+
+func NewResult(resultset *Resultset) *Result {
+	return &Result{
+		Resultset: resultset,
+	}
+}
+
+func NewResultReserveResultset(fieldCount int) *Result {
+	return &Result{
+		Resultset: NewResultset(fieldCount),
+	}
 }
 
 type Executer interface {

--- a/mysql/resultset.go
+++ b/mysql/resultset.go
@@ -22,6 +22,8 @@ const (
 	StreamingMultiple
 )
 
+// Resultset should be created with NewResultset to avoid nil pointer and reduce
+// GC pressure.
 type Resultset struct {
 	Fields     []*Field
 	FieldNames map[string]int
@@ -61,9 +63,7 @@ func (r *Resultset) Reset(fieldsCount int) {
 	r.RowDatas = r.RowDatas[:0]
 
 	if r.FieldNames != nil {
-		for k := range r.FieldNames {
-			delete(r.FieldNames, k)
-		}
+		clear(r.FieldNames)
 	} else {
 		r.FieldNames = make(map[string]int)
 	}
@@ -80,22 +80,12 @@ func (r *Resultset) Reset(fieldsCount int) {
 }
 
 // RowNumber is returning the number of rows in the [Resultset].
-//
-// For a nil [Resultset] 0 is returned.
 func (r *Resultset) RowNumber() int {
-	if r == nil {
-		return 0
-	}
 	return len(r.Values)
 }
 
 // ColumnNumber is returning the number of fields in the [Resultset].
-//
-// For a nil [Resultset] 0 is returned.
 func (r *Resultset) ColumnNumber() int {
-	if r == nil {
-		return 0
-	}
 	return len(r.Fields)
 }
 

--- a/mysql/resultset_helper.go
+++ b/mysql/resultset_helper.go
@@ -168,9 +168,7 @@ func formatField(field *Field, value interface{}) error {
 }
 
 func BuildSimpleTextResultset(names []string, values [][]interface{}) (*Resultset, error) {
-	r := new(Resultset)
-
-	r.Fields = make([]*Field, len(names))
+	r := NewResultset(len(names))
 
 	var b []byte
 
@@ -234,9 +232,7 @@ func BuildSimpleTextResultset(names []string, values [][]interface{}) (*Resultse
 }
 
 func BuildSimpleBinaryResultset(names []string, values [][]interface{}) (*Resultset, error) {
-	r := new(Resultset)
-
-	r.Fields = make([]*Field, len(names))
+	r := NewResultset(len(names))
 
 	var b []byte
 

--- a/server/command.go
+++ b/server/command.go
@@ -214,13 +214,7 @@ func (h EmptyHandler) HandleQuery(query string) (*Result, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &mysql.Result{
-			Status:       0,
-			Warnings:     0,
-			InsertId:     0,
-			AffectedRows: 0,
-			Resultset:    r,
-		}, nil
+		return mysql.NewResult(r), nil
 	}
 
 	return nil, fmt.Errorf("not supported now")

--- a/server/resp.go
+++ b/server/resp.go
@@ -10,7 +10,7 @@ import (
 
 func (c *Conn) writeOK(r *Result) error {
 	if r == nil {
-		r = &Result{}
+		r = NewResultReserveResultset(0)
 	}
 
 	r.Status |= c.status

--- a/server/stmt.go
+++ b/server/stmt.go
@@ -336,7 +336,7 @@ func (c *Conn) handleStmtReset(data []byte) (*Result, error) {
 
 	s.ResetParams()
 
-	return &Result{}, nil
+	return NewResultReserveResultset(0), nil
 }
 
 // stmt close command has no response


### PR DESCRIPTION
```
// Result should be created by NewResultWithoutRows or NewResult. The zero value
// of Result is invalid.
```

closes #964