### PR TITLE
mysql: Fix GetInt() with negative NEWDECIMAL result

### DIFF
--- a/mysql/resultset.go
+++ b/mysql/resultset.go
@@ -185,12 +185,45 @@ func (r *Resultset) GetUintByName(row int, name string) (uint64, error) {
 }
 
 func (r *Resultset) GetInt(row, column int) (int64, error) {
-	v, err := r.GetUint(row, column)
+	d, err := r.GetValue(row, column)
 	if err != nil {
 		return 0, err
 	}
 
-	return int64(v), nil
+	switch v := d.(type) {
+	case int:
+		return int64(v), nil
+	case int8:
+		return int64(v), nil
+	case int16:
+		return int64(v), nil
+	case int32:
+		return int64(v), nil
+	case int64:
+		return v, nil
+	case uint:
+		return int64(v), nil
+	case uint8:
+		return int64(v), nil
+	case uint16:
+		return int64(v), nil
+	case uint32:
+		return int64(v), nil
+	case uint64:
+		return int64(v), nil
+	case float32:
+		return int64(v), nil
+	case float64:
+		return int64(v), nil
+	case string:
+		return strconv.ParseInt(v, 10, 64)
+	case []byte:
+		return strconv.ParseInt(string(v), 10, 64)
+	case nil:
+		return 0, nil
+	default:
+		return 0, errors.Errorf("data type is %T", v)
+	}
 }
 
 func (r *Resultset) GetIntByName(row int, name string) (int64, error) {

--- a/mysql/resultset_test.go
+++ b/mysql/resultset_test.go
@@ -1,10 +1,24 @@
 package mysql
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestColumnNumber(t *testing.T) {
 	r := NewResultReserveResultset(0)
 	// Make sure ColumnNumber doesn't panic when constructing a Result with 0
 	// columns. https://github.com/go-mysql-org/go-mysql/issues/964
 	r.ColumnNumber()
+}
+
+// TestGetInt tests GetInt with a negative value
+func TestGetIntNeg(t *testing.T) {
+	r := NewResultset(1)
+	fv := NewFieldValue(FieldValueTypeString, 0, []uint8("-193"))
+	r.Values = [][]FieldValue{{fv}}
+	v, err := r.GetInt(0, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(-193), v)
 }


### PR DESCRIPTION
Example code:
```go
package main

import (
	"github.com/go-mysql-org/go-mysql/client"
)

func main() {
	conn, _ := client.Connect("127.0.0.1:3307", "root", "", "test")
	r, _ := conn.Execute(`SELECT SUM(-1)`)
	v, err := r.GetInt(0, 0)
	if err != nil {
		panic(err)
	}
	println(v)
}
```

Without this PR:
```
$ go run main.go 
panic: strconv.ParseUint: parsing "-1": invalid syntax

goroutine 1 [running]:
main.main()
	/tmp/getint/main.go:12 +0xb1
exit status 2
```

With this PR:
```
-1
```

From Wireshark:
![image](https://github.com/user-attachments/assets/ed1f4e70-763a-4546-9a1c-8ff0e7d0ea84)

From MySQL Client:
```
mysql-8.4.3> SELECT SUM(-1);
Field   1:  `SUM(-1)`
Catalog:    `def`
Database:   ``
Table:      ``
Org_table:  ``
Type:       NEWDECIMAL
Collation:  binary (63)
Length:     24
Max_length: 2
Decimals:   0
Flags:      BINARY NUM 


+---------+
| SUM(-1) |
+---------+
|      -1 |
+---------+
1 row in set (0.00 sec)
```