### PR TITLE
client,mysql: Add support for Query Attributes

### DIFF
--- a/client/auth.go
+++ b/client/auth.go
@@ -203,6 +203,7 @@ func (c *Conn) writeAuthHandshake() error {
 		CLIENT_LONG_PASSWORD | CLIENT_TRANSACTIONS | CLIENT_PLUGIN_AUTH
 	// Adjust client capability flags based on server support
 	capability |= c.capability & CLIENT_LONG_FLAG
+	capability |= c.capability & CLIENT_QUERY_ATTRIBUTES
 	// Adjust client capability flags on specific client requests
 	// Only flags that would make any sense setting and aren't handled elsewhere
 	// in the library are supported here

--- a/client/conn.go
+++ b/client/conn.go
@@ -508,7 +508,6 @@ func (c *Conn) exec_send(query string) error {
 			}
 			c.queryAttributes = append(c.queryAttributes, lineAttr)
 		}
-
 	}
 
 	if c.capability&CLIENT_QUERY_ATTRIBUTES > 0 {
@@ -675,6 +674,7 @@ func (c *Conn) StatusString() string {
 	return strings.Join(stats, "|")
 }
 
+// SetQueryAttributes sets the query attributes to be send along with the next query
 func (c *Conn) SetQueryAttributes(attrs ...QueryAttribute) error {
 	c.queryAttributes = attrs
 	return nil

--- a/client/conn.go
+++ b/client/conn.go
@@ -316,7 +316,7 @@ func (c *Conn) Execute(command string, args ...interface{}) (*Result, error) {
 // flag set to signal the server multiple queries are executed. Handling the responses
 // is up to the implementation of perResultCallback.
 func (c *Conn) ExecuteMultiple(query string, perResultCallback ExecPerResultCallback) (*Result, error) {
-	if err := c.exec_send(query); err != nil {
+	if err := c.execSend(query); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -369,7 +369,7 @@ func (c *Conn) ExecuteMultiple(query string, perResultCallback ExecPerResultCall
 //
 // ExecuteSelectStreaming should be used only for SELECT queries with a large response resultset for memory preserving.
 func (c *Conn) ExecuteSelectStreaming(command string, result *Result, perRowCallback SelectPerRowCallback, perResultCallback SelectPerResultCallback) error {
-	if err := c.exec_send(command); err != nil {
+	if err := c.execSend(command); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -497,7 +497,7 @@ func (c *Conn) ReadOKPacket() (*Result, error) {
 
 // Send COM_QUERY and read the result
 func (c *Conn) exec(query string) (*Result, error) {
-	err := c.exec_send(query)
+	err := c.execSend(query)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -506,7 +506,7 @@ func (c *Conn) exec(query string) (*Result, error) {
 
 // Sends COM_QUERY
 // https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_query.html
-func (c *Conn) exec_send(query string) error {
+func (c *Conn) execSend(query string) error {
 	var buf bytes.Buffer
 
 	if c.includeLine >= 0 {

--- a/client/conn.go
+++ b/client/conn.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"runtime"
-	"runtime/debug"
 	"strings"
 	"time"
 
@@ -105,13 +104,9 @@ func ConnectWithDialer(ctx context.Context, network, addr, user, password, dbNam
 	c := new(Conn)
 
 	c.BufferSize = defaultBufferSize
-	clientVersion := "unknown"
-	if buildInfo, ok := debug.ReadBuildInfo(); ok {
-		clientVersion = buildInfo.Main.Version
-	}
 	c.attributes = map[string]string{
-		"_client_name":     "go-mysql",
-		"_client_version":  clientVersion,
+		"_client_name": "go-mysql",
+		// "_client_version": "0.1",
 		"_os":              runtime.GOOS,
 		"_platform":        runtime.GOARCH,
 		"_runtime_version": runtime.Version(),

--- a/client/conn.go
+++ b/client/conn.go
@@ -105,9 +105,13 @@ func ConnectWithDialer(ctx context.Context, network, addr, user, password, dbNam
 	c := new(Conn)
 
 	c.BufferSize = defaultBufferSize
+	clientVersion := "unknown"
+	if buildInfo, ok := debug.ReadBuildInfo(); ok {
+		clientVersion = buildInfo.Main.Version
+	}
 	c.attributes = map[string]string{
-		"_client_name": "go-mysql",
-		// "_client_version": "0.1",
+		"_client_name":     "go-mysql",
+		"_client_version":  clientVersion,
 		"_os":              runtime.GOOS,
 		"_platform":        runtime.GOARCH,
 		"_runtime_version": runtime.Version(),

--- a/client/conn.go
+++ b/client/conn.go
@@ -497,9 +497,9 @@ func (c *Conn) ReadOKPacket() (*Result, error) {
 func (c *Conn) exec(query string) (*Result, error) {
 	err := c.exec_send(query)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
-	return c.readResult(false)
+	return errors.Trace(c.readResult(false))
 }
 
 // Sends COM_QUERY
@@ -689,7 +689,7 @@ func (c *Conn) SetQueryAttributes(attrs ...QueryAttribute) error {
 }
 
 // IncludeLine can be passed as option when connecting to include the file name and line number
-// of the caller as query attribute when sending queries.
+// of the caller as query attribute `_line` when sending queries.
 func (c *Conn) IncludeLine() {
 	c.includeLine = true
 }

--- a/client/conn.go
+++ b/client/conn.go
@@ -501,7 +501,7 @@ func (c *Conn) exec(query string) (*Result, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return errors.Trace(c.readResult(false))
+	return c.readResult(false)
 }
 
 // Sends COM_QUERY

--- a/client/conn_test.go
+++ b/client/conn_test.go
@@ -200,7 +200,13 @@ func (s *connTestSuite) TestSetQueryAttributes() {
 		Name:  "qattr1",
 		Value: "qattr1val",
 	}
-	s.c.SetQueryAttributes(qa)
-	expected := []mysql.QueryAttribute([]mysql.QueryAttribute{mysql.QueryAttribute{Name: "qattr1", Value: "qattr1val"}})
+	err := s.c.SetQueryAttributes(qa)
+	require.NoError(s.T(), err)
+	expected := []mysql.QueryAttribute{
+		mysql.QueryAttribute{
+			Name:  "qattr1",
+			Value: "qattr1val",
+		},
+	}
 	require.Equal(s.T(), expected, s.c.queryAttributes)
 }

--- a/client/conn_test.go
+++ b/client/conn_test.go
@@ -194,3 +194,13 @@ func (s *connTestSuite) TestAttributes() {
 	require.Equal(s.T(), "go-mysql", s.c.attributes["_client_name"])
 	require.Equal(s.T(), "attrvalue", s.c.attributes["attrtest"])
 }
+
+func (s *connTestSuite) TestSetQueryAttributes() {
+	qa := mysql.QueryAttribute{
+		Name:  "qattr1",
+		Value: "qattr1val",
+	}
+	s.c.SetQueryAttributes(qa)
+	expected := []mysql.QueryAttribute([]mysql.QueryAttribute{mysql.QueryAttribute{Name: "qattr1", Value: "qattr1val"}})
+	require.Equal(s.T(), expected, s.c.queryAttributes)
+}

--- a/client/stmt.go
+++ b/client/stmt.go
@@ -65,8 +65,8 @@ func (s *Stmt) write(args ...interface{}) error {
 		return fmt.Errorf("argument mismatch, need %d but got %d", s.params, len(args))
 	}
 
-	if s.conn.includeLine {
-		_, file, line, ok := runtime.Caller(2)
+	if s.conn.includeLine >= 0 {
+		_, file, line, ok := runtime.Caller(s.conn.includeLine)
 		if ok {
 			lineAttr := QueryAttribute{
 				Name:  "_line",

--- a/client/stmt.go
+++ b/client/stmt.go
@@ -119,23 +119,23 @@ func (s *Stmt) write(args ...interface{}) error {
 			paramValues[i] = Uint64ToBytes(uint64(v))
 		case uint8:
 			paramTypes[i] = []byte{MYSQL_TYPE_TINY}
-			paramFlags[i] = []byte{UNSIGNED_FLAG}
+			paramFlags[i] = []byte{BINARY_FLAG}
 			paramValues[i] = []byte{v}
 		case uint16:
 			paramTypes[i] = []byte{MYSQL_TYPE_SHORT}
-			paramFlags[i] = []byte{UNSIGNED_FLAG}
+			paramFlags[i] = []byte{BINARY_FLAG}
 			paramValues[i] = Uint16ToBytes(v)
 		case uint32:
 			paramTypes[i] = []byte{MYSQL_TYPE_LONG}
-			paramFlags[i] = []byte{UNSIGNED_FLAG}
+			paramFlags[i] = []byte{BINARY_FLAG}
 			paramValues[i] = Uint32ToBytes(v)
 		case uint:
 			paramTypes[i] = []byte{MYSQL_TYPE_LONGLONG}
-			paramFlags[i] = []byte{UNSIGNED_FLAG}
+			paramFlags[i] = []byte{BINARY_FLAG}
 			paramValues[i] = Uint64ToBytes(uint64(v))
 		case uint64:
 			paramTypes[i] = []byte{MYSQL_TYPE_LONGLONG}
-			paramFlags[i] = []byte{UNSIGNED_FLAG}
+			paramFlags[i] = []byte{BINARY_FLAG}
 			paramValues[i] = Uint64ToBytes(v)
 		case bool:
 			paramTypes[i] = []byte{MYSQL_TYPE_TINY}

--- a/client/stmt.go
+++ b/client/stmt.go
@@ -74,7 +74,6 @@ func (s *Stmt) write(args ...interface{}) error {
 			}
 			s.conn.queryAttributes = append(s.conn.queryAttributes, lineAttr)
 		}
-
 	}
 
 	qaLen := len(s.conn.queryAttributes)

--- a/client/stmt.go
+++ b/client/stmt.go
@@ -119,23 +119,23 @@ func (s *Stmt) write(args ...interface{}) error {
 			paramValues[i] = Uint64ToBytes(uint64(v))
 		case uint8:
 			paramTypes[i] = []byte{MYSQL_TYPE_TINY}
-			paramFlags[i] = []byte{BINARY_FLAG}
+			paramFlags[i] = []byte{PARAM_UNSIGNED}
 			paramValues[i] = []byte{v}
 		case uint16:
 			paramTypes[i] = []byte{MYSQL_TYPE_SHORT}
-			paramFlags[i] = []byte{BINARY_FLAG}
+			paramFlags[i] = []byte{PARAM_UNSIGNED}
 			paramValues[i] = Uint16ToBytes(v)
 		case uint32:
 			paramTypes[i] = []byte{MYSQL_TYPE_LONG}
-			paramFlags[i] = []byte{BINARY_FLAG}
+			paramFlags[i] = []byte{PARAM_UNSIGNED}
 			paramValues[i] = Uint32ToBytes(v)
 		case uint:
 			paramTypes[i] = []byte{MYSQL_TYPE_LONGLONG}
-			paramFlags[i] = []byte{BINARY_FLAG}
+			paramFlags[i] = []byte{PARAM_UNSIGNED}
 			paramValues[i] = Uint64ToBytes(uint64(v))
 		case uint64:
 			paramTypes[i] = []byte{MYSQL_TYPE_LONGLONG}
-			paramFlags[i] = []byte{BINARY_FLAG}
+			paramFlags[i] = []byte{PARAM_UNSIGNED}
 			paramValues[i] = Uint64ToBytes(v)
 		case bool:
 			paramTypes[i] = []byte{MYSQL_TYPE_TINY}

--- a/client/stmt.go
+++ b/client/stmt.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"runtime"
 
 	. "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/utils"
@@ -62,6 +63,18 @@ func (s *Stmt) write(args ...interface{}) error {
 
 	if len(args) != paramsNum {
 		return fmt.Errorf("argument mismatch, need %d but got %d", s.params, len(args))
+	}
+
+	if s.conn.includeLine {
+		_, file, line, ok := runtime.Caller(2)
+		if ok {
+			lineAttr := QueryAttribute{
+				Name:  "_line",
+				Value: fmt.Sprintf("%s:%d", file, line),
+			}
+			s.conn.queryAttributes = append(s.conn.queryAttributes, lineAttr)
+		}
+
 	}
 
 	qaLen := len(s.conn.queryAttributes)

--- a/client/stmt.go
+++ b/client/stmt.go
@@ -190,7 +190,7 @@ func (s *Stmt) write(args ...interface{}) error {
 	data.Write([]byte{byte(s.id), byte(s.id >> 8), byte(s.id >> 16), byte(s.id >> 24)})
 
 	flags := CURSOR_TYPE_NO_CURSOR
-	if s.conn.capability&CLIENT_QUERY_ATTRIBUTES > 0 && len(s.conn.queryAttributes) > 0 {
+	if paramsNum > 0 {
 		flags |= PARAMETER_COUNT_AVAILABLE
 	}
 	data.WriteByte(flags)

--- a/client/stmt.go
+++ b/client/stmt.go
@@ -147,7 +147,7 @@ func (s *Stmt) write(args ...interface{}) error {
 		default:
 			return fmt.Errorf("invalid argument type %T", args[i])
 		}
-		paramNames[i] = []byte{0} // lenght encoded, no name
+		paramNames[i] = []byte{0} // length encoded, no name
 		if paramFlags[i] == nil {
 			paramFlags[i] = []byte{0}
 		}

--- a/client/stmt.go
+++ b/client/stmt.go
@@ -94,6 +94,8 @@ func (s *Stmt) write(args ...interface{}) error {
 		if args[i] == nil {
 			nullBitmap[i/8] |= 1 << (uint(i) % 8)
 			paramTypes[i] = []byte{MYSQL_TYPE_NULL}
+			paramNames[i] = []byte{0} // length encoded, no name
+			paramFlags[i] = []byte{0}
 			continue
 		}
 

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -179,6 +179,10 @@ const (
 )
 
 const (
+	PARAM_UNSIGNED = 128
+)
+
+const (
 	DEFAULT_ADDR                  = "127.0.0.1:3306"
 	DEFAULT_IPV6_ADDR             = "[::1]:3306"
 	DEFAULT_USER                  = "root"

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -209,3 +209,12 @@ const (
 	MYSQL_COMPRESS_ZLIB
 	MYSQL_COMPRESS_ZSTD
 )
+
+// See enum_cursor_type in mysql.h
+const (
+	CURSOR_TYPE_NO_CURSOR     byte = 0x0
+	CURSOR_TYPE_READ_ONLY     byte = 0x1
+	CURSOR_TYPE_FOR_UPDATE    byte = 0x2
+	CURSOR_TYPE_SCROLLABLE    byte = 0x4
+	PARAMETER_COUNT_AVAILABLE byte = 0x8
+)

--- a/mysql/queryattributes.go
+++ b/mysql/queryattributes.go
@@ -1,0 +1,46 @@
+package mysql
+
+import (
+	"encoding/binary"
+
+	"github.com/siddontang/go-log/log"
+)
+
+// Query Attributes in MySQL are key/value pairs passed along with COM_QUERY or COM_STMT_EXECUTE
+//
+// Resources:
+// - https://dev.mysql.com/doc/refman/8.4/en/query-attributes.html
+// - https://github.com/mysql/mysql-server/blob/trunk/include/mysql/components/services/mysql_query_attributes.h
+// - https://archive.fosdem.org/2021/schedule/event/mysql_protocl/
+type QueryAttribute struct {
+	Name  string
+	Value interface{}
+}
+
+// TypeAndFlag returns the type MySQL field type of the value and the field flag.
+func (qa *QueryAttribute) TypeAndFlag() []byte {
+	switch v := qa.Value.(type) {
+	case string:
+		return []byte{MYSQL_TYPE_STRING, 0x0}
+	case uint64:
+		return []byte{MYSQL_TYPE_LONGLONG, UNSIGNED_FLAG}
+	default:
+		log.Warnf("query attribute with unsupported type %T", v)
+	}
+	return []byte{0x0, 0x0} // type 0x0, flag 0x0, to not break the protocol
+}
+
+// ValueBytes returns the encoded value
+func (qa *QueryAttribute) ValueBytes() []byte {
+	switch v := qa.Value.(type) {
+	case string:
+		return PutLengthEncodedString([]byte(v))
+	case uint64:
+		b := make([]byte, 8)
+		binary.LittleEndian.PutUint64(b, v)
+		return b
+	default:
+		log.Warnf("query attribute with unsupported type %T", v)
+	}
+	return []byte{0x0} // 0 length value to not break the protocol
+}

--- a/mysql/queryattributes.go
+++ b/mysql/queryattributes.go
@@ -23,7 +23,7 @@ func (qa *QueryAttribute) TypeAndFlag() []byte {
 	case string:
 		return []byte{MYSQL_TYPE_STRING, 0x0}
 	case uint64:
-		return []byte{MYSQL_TYPE_LONGLONG, UNSIGNED_FLAG}
+		return []byte{MYSQL_TYPE_LONGLONG, PARAM_UNSIGNED}
 	default:
 		log.Warnf("query attribute with unsupported type %T", v)
 	}

--- a/mysql/queryattributes.go
+++ b/mysql/queryattributes.go
@@ -8,6 +8,8 @@ import (
 
 // Query Attributes in MySQL are key/value pairs passed along with COM_QUERY or COM_STMT_EXECUTE
 //
+// Supported Value types: string, uint64
+//
 // Resources:
 // - https://dev.mysql.com/doc/refman/8.4/en/query-attributes.html
 // - https://github.com/mysql/mysql-server/blob/trunk/include/mysql/components/services/mysql_query_attributes.h

--- a/mysql/queryattributes_test.go
+++ b/mysql/queryattributes_test.go
@@ -1,0 +1,33 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTypeAndFlag_string(t *testing.T) {
+	qattr := QueryAttribute{
+		Name:  "attrname",
+		Value: "attrvalue",
+	}
+
+	tf := qattr.TypeAndFlag()
+	require.Equal(t, []byte{0xfe, 0x0}, tf)
+
+	vb := qattr.ValueBytes()
+	require.Equal(t, []byte{0x9, 0x61, 0x74, 0x74, 0x72, 0x76, 0x61, 0x6c, 0x75, 0x65}, vb)
+}
+
+func TestTypeAndFlag_uint64(t *testing.T) {
+	qattr := QueryAttribute{
+		Name:  "attrname",
+		Value: uint64(12345),
+	}
+
+	tf := qattr.TypeAndFlag()
+	require.Equal(t, []byte{0x08, 0x80}, tf)
+
+	vb := qattr.ValueBytes()
+	require.Equal(t, []byte{0x39, 0x30, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, vb)
+}

--- a/server/stmt.go
+++ b/server/stmt.go
@@ -118,16 +118,13 @@ func (c *Conn) handleStmtExecute(data []byte) (*Result, error) {
 
 	// Test for unsupported flags in the remaining 4 bits.
 	if flag&CURSOR_TYPE_READ_ONLY > 0 {
-		return nil, NewError(ER_UNKNOWN_ERROR,
-			fmt.Sprintf("unsupported flag %s", "CURSOR_TYPE_READ_ONLY"))
+		return nil, NewError(ER_UNKNOWN_ERROR, "unsupported flag CURSOR_TYPE_READ_ONLY")
 	}
 	if flag&CURSOR_TYPE_FOR_UPDATE > 0 {
-		return nil, NewError(ER_UNKNOWN_ERROR,
-			fmt.Sprintf("unsupported flag %s", "CURSOR_TYPE_FOR_UPDATE"))
+		return nil, NewError(ER_UNKNOWN_ERROR, "unsupported flag CURSOR_TYPE_FOR_UPDATE")
 	}
 	if flag&CURSOR_TYPE_SCROLLABLE > 0 {
-		return nil, NewError(ER_UNKNOWN_ERROR,
-			fmt.Sprintf("unsupported flag %s", "CURSOR_TYPE_SCROLLABLE"))
+		return nil, NewError(ER_UNKNOWN_ERROR, "unsupported flag CURSOR_TYPE_SCROLLABLE")
 	}
 
 	//skip iteration-count, always 1

--- a/server/stmt.go
+++ b/server/stmt.go
@@ -101,7 +101,7 @@ func (c *Conn) handleStmtExecute(data []byte) (*Result, error) {
 
 	s, ok := c.stmts[id]
 	if !ok {
-		return nil, NewDefaultError(ER_UNKNOWN_STMT_HANDLER,
+		return nil, NewDefaultError(ER_UNKNOWN_STMT_HANDLER, 5,
 			strconv.FormatUint(uint64(id), 10), "stmt_execute")
 	}
 
@@ -339,7 +339,7 @@ func (c *Conn) handleStmtReset(data []byte) (*Result, error) {
 
 	s, ok := c.stmts[id]
 	if !ok {
-		return nil, NewDefaultError(ER_UNKNOWN_STMT_HANDLER,
+		return nil, NewDefaultError(ER_UNKNOWN_STMT_HANDLER, 5,
 			strconv.FormatUint(uint64(id), 10), "stmt_reset")
 	}
 

--- a/server/stmt.go
+++ b/server/stmt.go
@@ -107,7 +107,6 @@ func (c *Conn) handleStmtExecute(data []byte) (*Result, error) {
 
 	flag := data[pos]
 	pos++
-
 	// Supported types:
 	// - CURSOR_TYPE_NO_CURSOR
 	// - PARAMETER_COUNT_AVAILABLE
@@ -126,7 +125,7 @@ func (c *Conn) handleStmtExecute(data []byte) (*Result, error) {
 		return nil, NewError(ER_UNKNOWN_ERROR,
 			fmt.Sprintf("unsupported flag %s", "CURSOR_TYPE_FOR_UPDATE"))
 	}
-	if flag&CURSOR_TYPE_READ_ONLY > 0 {
+	if flag&CURSOR_TYPE_SCROLLABLE > 0 {
 		return nil, NewError(ER_UNKNOWN_ERROR,
 			fmt.Sprintf("unsupported flag %s", "CURSOR_TYPE_SCROLLABLE"))
 	}

--- a/server/stmt_test.go
+++ b/server/stmt_test.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleStmtExecute(t *testing.T) {
+	c := Conn{}
+	c.stmts = map[uint32]*Stmt{
+		1: &Stmt{},
+	}
+	testcases := []struct {
+		data    []byte
+		errtext string
+	}{
+		{
+			[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+			"ERROR 1243 (HY000): Unknown prepared statement handler (0) given to stmt_execute",
+		},
+		{
+			[]byte{0x1, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0},
+			"ERROR 1105 (HY000): unsupported flags 0xff",
+		},
+		{
+			[]byte{0x1, 0x0, 0x0, 0x0, 0x01, 0x0, 0x0, 0x0, 0x0, 0x0},
+			"ERROR 1105 (HY000): unsupported flag CURSOR_TYPE_READ_ONLY",
+		},
+		{
+			[]byte{0x1, 0x0, 0x0, 0x0, 0x02, 0x0, 0x0, 0x0, 0x0, 0x0},
+			"ERROR 1105 (HY000): unsupported flag CURSOR_TYPE_FOR_UPDATE",
+		},
+		{
+			[]byte{0x1, 0x0, 0x0, 0x0, 0x04, 0x0, 0x0, 0x0, 0x0, 0x0},
+			"ERROR 1105 (HY000): unsupported flag CURSOR_TYPE_SCROLLABLE",
+		},
+	}
+
+	for _, tc := range testcases {
+		_, err := c.handleStmtExecute(tc.data)
+		if tc.errtext == "" {
+			require.NoError(t, err)
+		} else {
+			require.ErrorContains(t, err, tc.errtext)
+		}
+	}
+}


### PR DESCRIPTION
Just like connection attributes, there are also query attributes in MySQL. These allow one to pass key/value pairs along with queries. 

These can be used to add metadata about:
- The page being rendered
- The user for the proxy connection
- A trace ID for debugging
- A shard-id hint
- A follower-read setting
- An application stack listing
- The line of the application code sending the query

- https://dev.mysql.com/doc/refman/8.4/en/query-attributes.html
- https://archive.fosdem.org/2021/schedule/event/mysql_protocl/

In some other languages, etc:

## MySQL Client

```
mysql-9.2.0> query_attributes proxy_user myuser page index.html
mysql-9.2.0> SELECT mysql_query_attribute_string('proxy_user'), mysql_query_attribute_string('page');
+--------------------------------------------+--------------------------------------+
| mysql_query_attribute_string('proxy_user') | mysql_query_attribute_string('page') |
+--------------------------------------------+--------------------------------------+
| myuser                                     | index.html                           |
+--------------------------------------------+--------------------------------------+
1 row in set (0.00 sec)
```

## MySQL Connector/Python

```python
#!/bin/python3
import mysql.connector

c = mysql.connector.connect(host='127.0.0.1',user='root', ssl_disabled=True)

cur = c.cursor(prepared=True)
cur.add_attribute("proxy_user", "myuser")
cur.execute("SELECT ?, mysql_query_attribute_string('proxy_user')", ("hello",))
for row in cur:
    print(row)
cur.close()
c.close()
```

Output:
```
('hello', 'myuser')
```

## go-mysql with this PR

```go
package main

import (
	"fmt"

	"github.com/go-mysql-org/go-mysql/client"
	"github.com/go-mysql-org/go-mysql/mysql"
)

func main() {
	conn, err := client.Connect("127.0.0.1:3306", "root", "", "")
	if err != nil {
		panic(err)
	}
	defer conn.Quit()

	proxyAttr := mysql.QueryAttribute{
		Name:  "proxy_user",
		Value: "user1",
	}
	secondAttr := mysql.QueryAttribute{
		Name:  "attr2",
		Value: "value2",
	}
	conn.SetQueryAttributes(proxyAttr, secondAttr)

	fmt.Printf("Sending COM_QUERY \"SELECT mysql_query_attribute_string('proxy_user')\" with attributes: %v, %v\n", proxyAttr, secondAttr)
	r, err := conn.Execute("SELECT mysql_query_attribute_string('proxy_user')")
	if err != nil {
		panic(err)
	}
	defer r.Close()

	for _, row := range r.Values {
		if len(row) != 1 {
			panic("expecting exactly on column")
		}
		fmt.Printf("%s\n", row[0].Value())
	}

	fmt.Printf("Preparing 'SELECT mysql_query_attribute_string(?)' via COM_STMT_PREPARE\n")
	stmt, err := conn.Prepare("SELECT mysql_query_attribute_string(?)")
	if err != nil {
		panic(err)
	}
	defer stmt.Close()

	conn.SetQueryAttributes(proxyAttr)
	fmt.Printf("Sending COM_STMT_EXECUTE with arg: %s, attributes: %v\n", "proxy_user", proxyAttr)
	res, err := stmt.Execute("proxy_user")
	if err != nil {
		panic(err)
	}
	defer res.Close()
	for _, row := range res.Values {
		if len(row) != 1 {
			panic("expecting exactly on column")
		}
		fmt.Printf("%s\n", row[0].Value())
	}
}
```

Output:
```
Sending COM_QUERY "SELECT mysql_query_attribute_string('proxy_user')" with attributes: {proxy_user user1}, {attr2 value2}
user1
Preparing 'SELECT mysql_query_attribute_string(?)' via COM_STMT_PREPARE
Sending COM_STMT_EXECUTE with arg: proxy_user, attributes: {proxy_user user1}
user1
```