### PR TITLE
Change how we import the mysql package

### DIFF
--- a/client/auth.go
+++ b/client/auth.go
@@ -6,16 +6,16 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	. "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/packet"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/parser/charset"
 )
 
-const defaultAuthPluginName = AUTH_NATIVE_PASSWORD
+const defaultAuthPluginName = mysql.AUTH_NATIVE_PASSWORD
 
 // defines the supported auth plugins
-var supportedAuthPlugins = []string{AUTH_NATIVE_PASSWORD, AUTH_SHA256_PASSWORD, AUTH_CACHING_SHA2_PASSWORD}
+var supportedAuthPlugins = []string{mysql.AUTH_NATIVE_PASSWORD, mysql.AUTH_SHA256_PASSWORD, mysql.AUTH_CACHING_SHA2_PASSWORD}
 
 // helper function to determine what auth methods are allowed by this client
 func authPluginAllowed(pluginName string) bool {
@@ -38,12 +38,12 @@ func (c *Conn) readInitialHandshake() error {
 		return errors.Trace(err)
 	}
 
-	if data[0] == ERR_HEADER {
+	if data[0] == mysql.ERR_HEADER {
 		return errors.Annotate(c.handleErrorPacket(data), "read initial handshake error")
 	}
 
-	if data[0] != ClassicProtocolVersion {
-		if data[0] == XProtocolVersion {
+	if data[0] != mysql.ClassicProtocolVersion {
+		if data[0] == mysql.XProtocolVersion {
 			return errors.Errorf(
 				"invalid protocol version %d, expected 10. "+
 					"This might be X Protocol, make sure to connect to the right port",
@@ -75,10 +75,10 @@ func (c *Conn) readInitialHandshake() error {
 	// The lower 2 bytes of the Capabilities Flags
 	c.capability = uint32(binary.LittleEndian.Uint16(data[pos : pos+2]))
 	// check protocol
-	if c.capability&CLIENT_PROTOCOL_41 == 0 {
+	if c.capability&mysql.CLIENT_PROTOCOL_41 == 0 {
 		return errors.New("the MySQL server can not support protocol 41 and above required by the client")
 	}
-	if c.capability&CLIENT_SSL == 0 && c.tlsConfig != nil {
+	if c.capability&mysql.CLIENT_SSL == 0 && c.tlsConfig != nil {
 		return errors.New("the MySQL Server does not support TLS required by the client")
 	}
 	pos += 2
@@ -97,7 +97,7 @@ func (c *Conn) readInitialHandshake() error {
 
 		// length of the combined auth_plugin_data (scramble), if auth_plugin_data_len is > 0
 		authPluginDataLen := data[pos]
-		if (c.capability&CLIENT_PLUGIN_AUTH == 0) && (authPluginDataLen > 0) {
+		if (c.capability&mysql.CLIENT_PLUGIN_AUTH == 0) && (authPluginDataLen > 0) {
 			return errors.Errorf("invalid auth plugin data filler %d", authPluginDataLen)
 		}
 		pos++
@@ -105,7 +105,7 @@ func (c *Conn) readInitialHandshake() error {
 		// skip reserved (all [00] ?)
 		pos += 10
 
-		if c.capability&CLIENT_SECURE_CONNECTION != 0 {
+		if c.capability&mysql.CLIENT_SECURE_CONNECTION != 0 {
 			// Rest of the plugin provided data (scramble)
 
 			// https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_handshake_v10.html
@@ -125,7 +125,7 @@ func (c *Conn) readInitialHandshake() error {
 			c.salt = append(c.salt, authPluginDataPart2...)
 		}
 
-		if c.capability&CLIENT_PLUGIN_AUTH != 0 {
+		if c.capability&mysql.CLIENT_PLUGIN_AUTH != 0 {
 			c.authPluginName = string(data[pos : pos+bytes.IndexByte(data[pos:], 0x00)])
 			pos += len(c.authPluginName)
 
@@ -153,13 +153,13 @@ func (c *Conn) readInitialHandshake() error {
 func (c *Conn) genAuthResponse(authData []byte) ([]byte, bool, error) {
 	// password hashing
 	switch c.authPluginName {
-	case AUTH_NATIVE_PASSWORD:
-		return CalcPassword(authData[:20], []byte(c.password)), false, nil
-	case AUTH_CACHING_SHA2_PASSWORD:
-		return CalcCachingSha2Password(authData, c.password), false, nil
-	case AUTH_CLEAR_PASSWORD:
+	case mysql.AUTH_NATIVE_PASSWORD:
+		return mysql.CalcPassword(authData[:20], []byte(c.password)), false, nil
+	case mysql.AUTH_CACHING_SHA2_PASSWORD:
+		return mysql.CalcCachingSha2Password(authData, c.password), false, nil
+	case mysql.AUTH_CLEAR_PASSWORD:
 		return []byte(c.password), true, nil
-	case AUTH_SHA256_PASSWORD:
+	case mysql.AUTH_SHA256_PASSWORD:
 		if len(c.password) == 0 {
 			return nil, true, nil
 		}
@@ -186,10 +186,10 @@ func (c *Conn) genAttributes() []byte {
 
 	attrData := make([]byte, 0)
 	for k, v := range c.attributes {
-		attrData = append(attrData, PutLengthEncodedString([]byte(k))...)
-		attrData = append(attrData, PutLengthEncodedString([]byte(v))...)
+		attrData = append(attrData, mysql.PutLengthEncodedString([]byte(k))...)
+		attrData = append(attrData, mysql.PutLengthEncodedString([]byte(v))...)
 	}
-	return append(PutLengthEncodedInt(uint64(len(attrData))), attrData...)
+	return append(mysql.PutLengthEncodedInt(uint64(len(attrData))), attrData...)
 }
 
 // See: http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::HandshakeResponse
@@ -199,23 +199,23 @@ func (c *Conn) writeAuthHandshake() error {
 	}
 
 	// Set default client capabilities that reflect the abilities of this library
-	capability := CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION |
-		CLIENT_LONG_PASSWORD | CLIENT_TRANSACTIONS | CLIENT_PLUGIN_AUTH
+	capability := mysql.CLIENT_PROTOCOL_41 | mysql.CLIENT_SECURE_CONNECTION |
+		mysql.CLIENT_LONG_PASSWORD | mysql.CLIENT_TRANSACTIONS | mysql.CLIENT_PLUGIN_AUTH
 	// Adjust client capability flags based on server support
-	capability |= c.capability & CLIENT_LONG_FLAG
-	capability |= c.capability & CLIENT_QUERY_ATTRIBUTES
+	capability |= c.capability & mysql.CLIENT_LONG_FLAG
+	capability |= c.capability & mysql.CLIENT_QUERY_ATTRIBUTES
 	// Adjust client capability flags on specific client requests
 	// Only flags that would make any sense setting and aren't handled elsewhere
 	// in the library are supported here
-	capability |= c.ccaps&CLIENT_FOUND_ROWS | c.ccaps&CLIENT_IGNORE_SPACE |
-		c.ccaps&CLIENT_MULTI_STATEMENTS | c.ccaps&CLIENT_MULTI_RESULTS |
-		c.ccaps&CLIENT_PS_MULTI_RESULTS | c.ccaps&CLIENT_CONNECT_ATTRS |
-		c.ccaps&CLIENT_COMPRESS | c.ccaps&CLIENT_ZSTD_COMPRESSION_ALGORITHM |
-		c.ccaps&CLIENT_LOCAL_FILES
+	capability |= c.ccaps&mysql.CLIENT_FOUND_ROWS | c.ccaps&mysql.CLIENT_IGNORE_SPACE |
+		c.ccaps&mysql.CLIENT_MULTI_STATEMENTS | c.ccaps&mysql.CLIENT_MULTI_RESULTS |
+		c.ccaps&mysql.CLIENT_PS_MULTI_RESULTS | c.ccaps&mysql.CLIENT_CONNECT_ATTRS |
+		c.ccaps&mysql.CLIENT_COMPRESS | c.ccaps&mysql.CLIENT_ZSTD_COMPRESSION_ALGORITHM |
+		c.ccaps&mysql.CLIENT_LOCAL_FILES
 
 	// To enable TLS / SSL
 	if c.tlsConfig != nil {
-		capability |= CLIENT_SSL
+		capability |= mysql.CLIENT_SSL
 	}
 
 	auth, addNull, err := c.genAuthResponse(c.salt)
@@ -227,11 +227,11 @@ func (c *Conn) writeAuthHandshake() error {
 	// here we use the Length-Encoded-Integer(LEI) as the data length may not fit into one byte
 	// see: https://dev.mysql.com/doc/internals/en/integer.html#length-encoded-integer
 	var authRespLEIBuf [9]byte
-	authRespLEI := AppendLengthEncodedInteger(authRespLEIBuf[:0], uint64(len(auth)))
+	authRespLEI := mysql.AppendLengthEncodedInteger(authRespLEIBuf[:0], uint64(len(auth)))
 	if len(authRespLEI) > 1 {
 		// if the length can not be written in 1 byte, it must be written as a
 		// length encoded integer
-		capability |= CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA
+		capability |= mysql.CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA
 	}
 
 	// packet length
@@ -248,16 +248,16 @@ func (c *Conn) writeAuthHandshake() error {
 	}
 	// db name
 	if len(c.db) > 0 {
-		capability |= CLIENT_CONNECT_WITH_DB
+		capability |= mysql.CLIENT_CONNECT_WITH_DB
 		length += len(c.db) + 1
 	}
 	// connection attributes
 	attrData := c.genAttributes()
 	if len(attrData) > 0 {
-		capability |= CLIENT_CONNECT_ATTRS
+		capability |= mysql.CLIENT_CONNECT_ATTRS
 		length += len(attrData)
 	}
-	if c.ccaps&CLIENT_ZSTD_COMPRESSION_ALGORITHM > 0 {
+	if c.ccaps&mysql.CLIENT_ZSTD_COMPRESSION_ALGORITHM > 0 {
 		length++
 	}
 
@@ -279,7 +279,7 @@ func (c *Conn) writeAuthHandshake() error {
 	// use default collation id 255 here, is `utf8mb4_0900_ai_ci`
 	collationName := c.collation
 	if len(collationName) == 0 {
-		collationName = DEFAULT_COLLATION_NAME
+		collationName = mysql.DEFAULT_COLLATION_NAME
 	}
 	collation, err := charset.GetCollationByName(collationName)
 	if err != nil {
@@ -347,7 +347,7 @@ func (c *Conn) writeAuthHandshake() error {
 		pos += copy(data[pos:], attrData)
 	}
 
-	if c.ccaps&CLIENT_ZSTD_COMPRESSION_ALGORITHM > 0 {
+	if c.ccaps&mysql.CLIENT_ZSTD_COMPRESSION_ALGORITHM > 0 {
 		// zstd_compression_level
 		data[pos] = 0x03
 	}

--- a/client/resp.go
+++ b/client/resp.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/pingcap/errors"
 
-	. "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/utils"
 )
 
@@ -32,21 +32,21 @@ func (c *Conn) readUntilEOF() (err error) {
 }
 
 func (c *Conn) isEOFPacket(data []byte) bool {
-	return data[0] == EOF_HEADER && len(data) <= 5
+	return data[0] == mysql.EOF_HEADER && len(data) <= 5
 }
 
-func (c *Conn) handleOKPacket(data []byte) (*Result, error) {
+func (c *Conn) handleOKPacket(data []byte) (*mysql.Result, error) {
 	var n int
 	var pos = 1
 
-	r := NewResultReserveResultset(0)
+	r := mysql.NewResultReserveResultset(0)
 
-	r.AffectedRows, _, n = LengthEncodedInt(data[pos:])
+	r.AffectedRows, _, n = mysql.LengthEncodedInt(data[pos:])
 	pos += n
-	r.InsertId, _, n = LengthEncodedInt(data[pos:])
+	r.InsertId, _, n = mysql.LengthEncodedInt(data[pos:])
 	pos += n
 
-	if c.capability&CLIENT_PROTOCOL_41 > 0 {
+	if c.capability&mysql.CLIENT_PROTOCOL_41 > 0 {
 		r.Status = binary.LittleEndian.Uint16(data[pos:])
 		c.status = r.Status
 		pos += 2
@@ -54,7 +54,7 @@ func (c *Conn) handleOKPacket(data []byte) (*Result, error) {
 		//todo:strict_mode, check warnings as error
 		r.Warnings = binary.LittleEndian.Uint16(data[pos:])
 		// pos += 2
-	} else if c.capability&CLIENT_TRANSACTIONS > 0 {
+	} else if c.capability&mysql.CLIENT_TRANSACTIONS > 0 {
 		r.Status = binary.LittleEndian.Uint16(data[pos:])
 		c.status = r.Status
 		// pos += 2
@@ -67,14 +67,14 @@ func (c *Conn) handleOKPacket(data []byte) (*Result, error) {
 }
 
 func (c *Conn) handleErrorPacket(data []byte) error {
-	e := new(MyError)
+	e := new(mysql.MyError)
 
 	var pos = 1
 
 	e.Code = binary.LittleEndian.Uint16(data[pos:])
 	pos += 2
 
-	if c.capability&CLIENT_PROTOCOL_41 > 0 {
+	if c.capability&mysql.CLIENT_PROTOCOL_41 > 0 {
 		// skip '#'
 		pos++
 		e.State = utils.ByteSliceToString(data[pos : pos+5])
@@ -122,14 +122,14 @@ func (c *Conn) handleAuthResult() error {
 	}
 
 	// handle caching_sha2_password
-	if c.authPluginName == AUTH_CACHING_SHA2_PASSWORD {
+	if c.authPluginName == mysql.AUTH_CACHING_SHA2_PASSWORD {
 		if data == nil {
 			return nil // auth already succeeded
 		}
-		if data[0] == CACHE_SHA2_FAST_AUTH {
+		if data[0] == mysql.CACHE_SHA2_FAST_AUTH {
 			_, err = c.readOK()
 			return err
-		} else if data[0] == CACHE_SHA2_FULL_AUTH {
+		} else if data[0] == mysql.CACHE_SHA2_FULL_AUTH {
 			// need full authentication
 			if c.tlsConfig != nil || c.proto == "unix" {
 				if err = c.WriteClearAuthPacket(c.password); err != nil {
@@ -145,7 +145,7 @@ func (c *Conn) handleAuthResult() error {
 		} else {
 			return errors.Errorf("invalid packet %x", data[0])
 		}
-	} else if c.authPluginName == AUTH_SHA256_PASSWORD {
+	} else if c.authPluginName == mysql.AUTH_SHA256_PASSWORD {
 		if len(data) == 0 {
 			return nil // auth already succeeded
 		}
@@ -174,18 +174,18 @@ func (c *Conn) readAuthResult() ([]byte, string, error) {
 	// see: https://insidemysql.com/preparing-your-community-connector-for-mysql-8-part-2-sha256/
 	// packet indicator
 	switch data[0] {
-	case OK_HEADER:
+	case mysql.OK_HEADER:
 		_, err := c.handleOKPacket(data)
 		return nil, "", err
 
-	case MORE_DATE_HEADER:
+	case mysql.MORE_DATE_HEADER:
 		return data[1:], "", err
 
-	case EOF_HEADER:
+	case mysql.EOF_HEADER:
 		// server wants to switch auth
 		if len(data) < 1 {
 			// https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::OldAuthSwitchRequest
-			return nil, AUTH_MYSQL_OLD_PASSWORD, nil
+			return nil, mysql.AUTH_MYSQL_OLD_PASSWORD, nil
 		}
 		pluginEndIndex := bytes.IndexByte(data, 0x00)
 		if pluginEndIndex < 0 {
@@ -200,22 +200,22 @@ func (c *Conn) readAuthResult() ([]byte, string, error) {
 	}
 }
 
-func (c *Conn) readOK() (*Result, error) {
+func (c *Conn) readOK() (*mysql.Result, error) {
 	data, err := c.ReadPacket()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	if data[0] == OK_HEADER {
+	if data[0] == mysql.OK_HEADER {
 		return c.handleOKPacket(data)
-	} else if data[0] == ERR_HEADER {
+	} else if data[0] == mysql.ERR_HEADER {
 		return nil, c.handleErrorPacket(data)
 	} else {
 		return nil, errors.New("invalid ok packet")
 	}
 }
 
-func (c *Conn) readResult(binary bool) (*Result, error) {
+func (c *Conn) readResult(binary bool) (*mysql.Result, error) {
 	bs := utils.ByteSliceGet(16)
 	defer utils.ByteSlicePut(bs)
 	var err error
@@ -225,18 +225,18 @@ func (c *Conn) readResult(binary bool) (*Result, error) {
 	}
 
 	switch bs.B[0] {
-	case OK_HEADER:
+	case mysql.OK_HEADER:
 		return c.handleOKPacket(bs.B)
-	case ERR_HEADER:
+	case mysql.ERR_HEADER:
 		return nil, c.handleErrorPacket(bytes.Repeat(bs.B, 1))
-	case LocalInFile_HEADER:
-		return nil, ErrMalformPacket
+	case mysql.LocalInFile_HEADER:
+		return nil, mysql.ErrMalformPacket
 	default:
 		return c.readResultset(bs.B, binary)
 	}
 }
 
-func (c *Conn) readResultStreaming(binary bool, result *Result, perRowCb SelectPerRowCallback, perResCb SelectPerResultCallback) error {
+func (c *Conn) readResultStreaming(binary bool, result *mysql.Result, perRowCb SelectPerRowCallback, perResCb SelectPerResultCallback) error {
 	bs := utils.ByteSliceGet(16)
 	defer utils.ByteSlicePut(bs)
 	var err error
@@ -246,7 +246,7 @@ func (c *Conn) readResultStreaming(binary bool, result *Result, perRowCb SelectP
 	}
 
 	switch bs.B[0] {
-	case OK_HEADER:
+	case mysql.OK_HEADER:
 		// https://dev.mysql.com/doc/internals/en/com-query-response.html
 		// 14.6.4.1 COM_QUERY Response
 		// If the number of columns in the resultset is 0, this is a OK_Packet.
@@ -261,29 +261,29 @@ func (c *Conn) readResultStreaming(binary bool, result *Result, perRowCb SelectP
 		result.InsertId = okResult.InsertId
 		result.Warnings = okResult.Warnings
 		if result.Resultset == nil {
-			result.Resultset = NewResultset(0)
+			result.Resultset = mysql.NewResultset(0)
 		} else {
 			result.Reset(0)
 		}
 		return nil
-	case ERR_HEADER:
+	case mysql.ERR_HEADER:
 		return c.handleErrorPacket(bytes.Repeat(bs.B, 1))
-	case LocalInFile_HEADER:
-		return ErrMalformPacket
+	case mysql.LocalInFile_HEADER:
+		return mysql.ErrMalformPacket
 	default:
 		return c.readResultsetStreaming(bs.B, binary, result, perRowCb, perResCb)
 	}
 }
 
-func (c *Conn) readResultset(data []byte, binary bool) (*Result, error) {
+func (c *Conn) readResultset(data []byte, binary bool) (*mysql.Result, error) {
 	// column count
-	count, _, n := LengthEncodedInt(data)
+	count, _, n := mysql.LengthEncodedInt(data)
 
 	if n-len(data) != 0 {
-		return nil, ErrMalformPacket
+		return nil, mysql.ErrMalformPacket
 	}
 
-	result := NewResultReserveResultset(int(count))
+	result := mysql.NewResultReserveResultset(int(count))
 
 	if err := c.readResultColumns(result); err != nil {
 		return nil, errors.Trace(err)
@@ -296,22 +296,22 @@ func (c *Conn) readResultset(data []byte, binary bool) (*Result, error) {
 	return result, nil
 }
 
-func (c *Conn) readResultsetStreaming(data []byte, binary bool, result *Result, perRowCb SelectPerRowCallback, perResCb SelectPerResultCallback) error {
-	columnCount, _, n := LengthEncodedInt(data)
+func (c *Conn) readResultsetStreaming(data []byte, binary bool, result *mysql.Result, perRowCb SelectPerRowCallback, perResCb SelectPerResultCallback) error {
+	columnCount, _, n := mysql.LengthEncodedInt(data)
 
 	if n-len(data) != 0 {
-		return ErrMalformPacket
+		return mysql.ErrMalformPacket
 	}
 
 	if result.Resultset == nil {
-		result.Resultset = NewResultset(int(columnCount))
+		result.Resultset = mysql.NewResultset(int(columnCount))
 	} else {
 		// Reuse memory if can
 		result.Reset(int(columnCount))
 	}
 
 	// this is a streaming resultset
-	result.Resultset.Streaming = StreamingSelect
+	result.Resultset.Streaming = mysql.StreamingSelect
 
 	if err := c.readResultColumns(result); err != nil {
 		return errors.Trace(err)
@@ -333,7 +333,7 @@ func (c *Conn) readResultsetStreaming(data []byte, binary bool, result *Result, 
 	return nil
 }
 
-func (c *Conn) readResultColumns(result *Result) (err error) {
+func (c *Conn) readResultColumns(result *mysql.Result) (err error) {
 	var i = 0
 	var data []byte
 
@@ -347,7 +347,7 @@ func (c *Conn) readResultColumns(result *Result) (err error) {
 
 		// EOF Packet
 		if c.isEOFPacket(data) {
-			if c.capability&CLIENT_PROTOCOL_41 > 0 {
+			if c.capability&mysql.CLIENT_PROTOCOL_41 > 0 {
 				result.Warnings = binary.LittleEndian.Uint16(data[1:])
 				// todo add strict_mode, warning will be treat as error
 				result.Status = binary.LittleEndian.Uint16(data[3:])
@@ -355,14 +355,14 @@ func (c *Conn) readResultColumns(result *Result) (err error) {
 			}
 
 			if i != len(result.Fields) {
-				err = ErrMalformPacket
+				err = mysql.ErrMalformPacket
 			}
 
 			return err
 		}
 
 		if result.Fields[i] == nil {
-			result.Fields[i] = &Field{}
+			result.Fields[i] = &mysql.Field{}
 		}
 		err = result.Fields[i].Parse(data)
 		if err != nil {
@@ -375,7 +375,7 @@ func (c *Conn) readResultColumns(result *Result) (err error) {
 	}
 }
 
-func (c *Conn) readResultRows(result *Result, isBinary bool) (err error) {
+func (c *Conn) readResultRows(result *mysql.Result, isBinary bool) (err error) {
 	var data []byte
 
 	for {
@@ -388,7 +388,7 @@ func (c *Conn) readResultRows(result *Result, isBinary bool) (err error) {
 
 		// EOF Packet
 		if c.isEOFPacket(data) {
-			if c.capability&CLIENT_PROTOCOL_41 > 0 {
+			if c.capability&mysql.CLIENT_PROTOCOL_41 > 0 {
 				result.Warnings = binary.LittleEndian.Uint16(data[1:])
 				// todo add strict_mode, warning will be treat as error
 				result.Status = binary.LittleEndian.Uint16(data[3:])
@@ -398,7 +398,7 @@ func (c *Conn) readResultRows(result *Result, isBinary bool) (err error) {
 			break
 		}
 
-		if data[0] == ERR_HEADER {
+		if data[0] == mysql.ERR_HEADER {
 			return c.handleErrorPacket(data)
 		}
 
@@ -406,7 +406,7 @@ func (c *Conn) readResultRows(result *Result, isBinary bool) (err error) {
 	}
 
 	if cap(result.Values) < len(result.RowDatas) {
-		result.Values = make([][]FieldValue, len(result.RowDatas))
+		result.Values = make([][]mysql.FieldValue, len(result.RowDatas))
 	} else {
 		result.Values = result.Values[:len(result.RowDatas)]
 	}
@@ -422,10 +422,10 @@ func (c *Conn) readResultRows(result *Result, isBinary bool) (err error) {
 	return nil
 }
 
-func (c *Conn) readResultRowsStreaming(result *Result, isBinary bool, perRowCb SelectPerRowCallback) (err error) {
+func (c *Conn) readResultRowsStreaming(result *mysql.Result, isBinary bool, perRowCb SelectPerRowCallback) (err error) {
 	var (
 		data []byte
-		row  []FieldValue
+		row  []mysql.FieldValue
 	)
 
 	for {
@@ -436,7 +436,7 @@ func (c *Conn) readResultRowsStreaming(result *Result, isBinary bool, perRowCb S
 
 		// EOF Packet
 		if c.isEOFPacket(data) {
-			if c.capability&CLIENT_PROTOCOL_41 > 0 {
+			if c.capability&mysql.CLIENT_PROTOCOL_41 > 0 {
 				result.Warnings = binary.LittleEndian.Uint16(data[1:])
 				// todo add strict_mode, warning will be treat as error
 				result.Status = binary.LittleEndian.Uint16(data[3:])
@@ -446,12 +446,12 @@ func (c *Conn) readResultRowsStreaming(result *Result, isBinary bool, perRowCb S
 			break
 		}
 
-		if data[0] == ERR_HEADER {
+		if data[0] == mysql.ERR_HEADER {
 			return c.handleErrorPacket(data)
 		}
 
 		// Parse this row
-		row, err = RowData(data).Parse(result.Fields, isBinary, row)
+		row, err = mysql.RowData(data).Parse(result.Fields, isBinary, row)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/dump/dumper.go
+++ b/dump/dumper.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"strings"
 
-	. "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/errors"
 	"github.com/siddontang/go-log/log"
 	"github.com/siddontang/go-log/loggers"
@@ -81,7 +81,7 @@ func NewDumper(executionPath string, addr string, user string, password string) 
 	d.Password = password
 	d.Tables = make([]string, 0, 16)
 	d.Databases = make([]string, 0, 16)
-	d.Charset = DEFAULT_CHARSET
+	d.Charset = mysql.DEFAULT_CHARSET
 	d.IgnoreTables = make(map[string][]string)
 	d.ExtraOptions = make([]string, 0, 5)
 	d.masterDataSkipped = false

--- a/replication/backup.go
+++ b/replication/backup.go
@@ -8,12 +8,12 @@ import (
 	"sync"
 	"time"
 
-	. "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/errors"
 )
 
 // StartBackup starts the backup process for the binary log and writes to the backup directory.
-func (b *BinlogSyncer) StartBackup(backupDir string, p Position, timeout time.Duration) error {
+func (b *BinlogSyncer) StartBackup(backupDir string, p mysql.Position, timeout time.Duration) error {
 	err := os.MkdirAll(backupDir, 0755)
 	if err != nil {
 		return errors.Trace(err)
@@ -36,7 +36,7 @@ func (b *BinlogSyncer) StartBackup(backupDir string, p Position, timeout time.Du
 //   - timeout: The maximum duration to wait for new binlog events before stopping the backup process.
 //     If set to 0, a default very long timeout (30 days) is used instead.
 //   - handler: A function that takes a binlog filename and returns an WriteCloser for writing raw events to.
-func (b *BinlogSyncer) StartBackupWithHandler(p Position, timeout time.Duration,
+func (b *BinlogSyncer) StartBackupWithHandler(p mysql.Position, timeout time.Duration,
 	handler func(binlogFilename string) (io.WriteCloser, error)) (retErr error) {
 	if timeout == 0 {
 		// a very long timeout here
@@ -89,7 +89,7 @@ func (b *BinlogSyncer) StartBackupWithHandler(p Position, timeout time.Duration,
 }
 
 // StartSynchronousBackup starts the backup process using the SynchronousEventHandler in the BinlogSyncerConfig.
-func (b *BinlogSyncer) StartSynchronousBackup(p Position, timeout time.Duration) error {
+func (b *BinlogSyncer) StartSynchronousBackup(p mysql.Position, timeout time.Duration) error {
 	if b.cfg.SynchronousEventHandler == nil {
 		return errors.New("SynchronousEventHandler must be set in BinlogSyncerConfig to use StartSynchronousBackup")
 	}

--- a/replication/json_binary.go
+++ b/replication/json_binary.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/utils"
 	"github.com/goccy/go-json"
 	"github.com/pingcap/errors"
-
-	. "github.com/go-mysql-org/go-mysql/mysql"
 )
 
 const (
@@ -340,7 +339,7 @@ func (d *jsonBinaryDecoder) decodeInt16(data []byte) int16 {
 		return 0
 	}
 
-	v := ParseBinaryInt16(data[0:2])
+	v := mysql.ParseBinaryInt16(data[0:2])
 	return v
 }
 
@@ -349,7 +348,7 @@ func (d *jsonBinaryDecoder) decodeUint16(data []byte) uint16 {
 		return 0
 	}
 
-	v := ParseBinaryUint16(data[0:2])
+	v := mysql.ParseBinaryUint16(data[0:2])
 	return v
 }
 
@@ -358,7 +357,7 @@ func (d *jsonBinaryDecoder) decodeInt32(data []byte) int32 {
 		return 0
 	}
 
-	v := ParseBinaryInt32(data[0:4])
+	v := mysql.ParseBinaryInt32(data[0:4])
 	return v
 }
 
@@ -367,7 +366,7 @@ func (d *jsonBinaryDecoder) decodeUint32(data []byte) uint32 {
 		return 0
 	}
 
-	v := ParseBinaryUint32(data[0:4])
+	v := mysql.ParseBinaryUint32(data[0:4])
 	return v
 }
 
@@ -376,7 +375,7 @@ func (d *jsonBinaryDecoder) decodeInt64(data []byte) int64 {
 		return 0
 	}
 
-	v := ParseBinaryInt64(data[0:8])
+	v := mysql.ParseBinaryInt64(data[0:8])
 	return v
 }
 
@@ -385,7 +384,7 @@ func (d *jsonBinaryDecoder) decodeUint64(data []byte) uint64 {
 		return 0
 	}
 
-	v := ParseBinaryUint64(data[0:8])
+	v := mysql.ParseBinaryUint64(data[0:8])
 	return v
 }
 
@@ -394,7 +393,7 @@ func (d *jsonBinaryDecoder) decodeDouble(data []byte) float64 {
 		return 0
 	}
 
-	v := ParseBinaryFloat64(data[0:8])
+	v := mysql.ParseBinaryFloat64(data[0:8])
 	return v
 }
 
@@ -432,11 +431,11 @@ func (d *jsonBinaryDecoder) decodeOpaque(data []byte) interface{} {
 	data = data[n : l+n]
 
 	switch tp {
-	case MYSQL_TYPE_NEWDECIMAL:
+	case mysql.MYSQL_TYPE_NEWDECIMAL:
 		return d.decodeDecimal(data)
-	case MYSQL_TYPE_TIME:
+	case mysql.MYSQL_TYPE_TIME:
 		return d.decodeTime(data)
-	case MYSQL_TYPE_DATE, MYSQL_TYPE_DATETIME, MYSQL_TYPE_TIMESTAMP:
+	case mysql.MYSQL_TYPE_DATE, mysql.MYSQL_TYPE_DATETIME, mysql.MYSQL_TYPE_TIMESTAMP:
 		return d.decodeDateTime(data)
 	default:
 		return utils.ByteSliceToString(data)
@@ -554,7 +553,7 @@ func (e *RowsEvent) decodeJsonPartialBinary(data []byte) (*JsonDiff, error) {
 	}
 	data = data[1:]
 
-	pathLength, _, n := LengthEncodedInt(data)
+	pathLength, _, n := mysql.LengthEncodedInt(data)
 	data = data[n:]
 
 	path := data[:pathLength]
@@ -570,7 +569,7 @@ func (e *RowsEvent) decodeJsonPartialBinary(data []byte) (*JsonDiff, error) {
 		return diff, nil
 	}
 
-	valueLength, _, n := LengthEncodedInt(data)
+	valueLength, _, n := mysql.LengthEncodedInt(data)
 	data = data[n:]
 
 	d, err := e.decodeJsonBinary(data[:valueLength])

--- a/replication/transaction_payload_event.go
+++ b/replication/transaction_payload_event.go
@@ -6,9 +6,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/klauspost/compress/zstd"
-
-	. "github.com/go-mysql-org/go-mysql/mysql"
 )
 
 // On The Wire: Field Types
@@ -72,23 +71,23 @@ func (e *TransactionPayloadEvent) decodeFields(data []byte) error {
 	offset := uint64(0)
 
 	for {
-		fieldType := FixedLengthInt(data[offset : offset+1])
+		fieldType := mysql.FixedLengthInt(data[offset : offset+1])
 		offset++
 
 		if fieldType == OTW_PAYLOAD_HEADER_END_MARK {
 			e.Payload = data[offset:]
 			break
 		} else {
-			fieldLength := FixedLengthInt(data[offset : offset+1])
+			fieldLength := mysql.FixedLengthInt(data[offset : offset+1])
 			offset++
 
 			switch fieldType {
 			case OTW_PAYLOAD_SIZE_FIELD:
-				e.Size = FixedLengthInt(data[offset : offset+fieldLength])
+				e.Size = mysql.FixedLengthInt(data[offset : offset+fieldLength])
 			case OTW_PAYLOAD_COMPRESSION_TYPE_FIELD:
-				e.CompressionType = FixedLengthInt(data[offset : offset+fieldLength])
+				e.CompressionType = mysql.FixedLengthInt(data[offset : offset+fieldLength])
 			case OTW_PAYLOAD_UNCOMPRESSED_SIZE_FIELD:
-				e.UncompressedSize = FixedLengthInt(data[offset : offset+fieldLength])
+				e.UncompressedSize = mysql.FixedLengthInt(data[offset : offset+fieldLength])
 			}
 
 			offset += fieldLength

--- a/server/auth.go
+++ b/server/auth.go
@@ -9,7 +9,7 @@ import (
 	"crypto/tls"
 	"fmt"
 
-	. "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/errors"
 )
 
@@ -20,13 +20,13 @@ var (
 
 func (c *Conn) compareAuthData(authPluginName string, clientAuthData []byte) error {
 	switch authPluginName {
-	case AUTH_NATIVE_PASSWORD:
+	case mysql.AUTH_NATIVE_PASSWORD:
 		if err := c.acquirePassword(); err != nil {
 			return err
 		}
 		return c.compareNativePasswordAuthData(clientAuthData, c.password)
 
-	case AUTH_CACHING_SHA2_PASSWORD:
+	case mysql.AUTH_CACHING_SHA2_PASSWORD:
 		if err := c.compareCacheSha2PasswordAuthData(clientAuthData); err != nil {
 			return err
 		}
@@ -35,7 +35,7 @@ func (c *Conn) compareAuthData(authPluginName string, clientAuthData []byte) err
 		}
 		return nil
 
-	case AUTH_SHA256_PASSWORD:
+	case mysql.AUTH_SHA256_PASSWORD:
 		if err := c.acquirePassword(); err != nil {
 			return err
 		}
@@ -59,7 +59,7 @@ func (c *Conn) acquirePassword() error {
 		return err
 	}
 	if !found {
-		return NewDefaultError(ER_NO_SUCH_USER, c.user, c.RemoteAddr().String())
+		return mysql.NewDefaultError(mysql.ER_NO_SUCH_USER, c.user, c.RemoteAddr().String())
 	}
 	c.password = password
 	return nil
@@ -94,7 +94,7 @@ func scrambleValidation(cached, nonce, scramble []byte) bool {
 }
 
 func (c *Conn) compareNativePasswordAuthData(clientAuthData []byte, password string) error {
-	if bytes.Equal(CalcPassword(c.salt, []byte(password)), clientAuthData) {
+	if bytes.Equal(mysql.CalcPassword(c.salt, []byte(password)), clientAuthData) {
 		return nil
 	}
 	return errAccessDenied(password)
@@ -160,7 +160,7 @@ func (c *Conn) compareCacheSha2PasswordAuthData(clientAuthData []byte) error {
 		if err := c.acquirePassword(); err != nil {
 			return err
 		}
-		if bytes.Equal(CalcCachingSha2Password(c.salt, c.password), clientAuthData) {
+		if bytes.Equal(mysql.CalcCachingSha2Password(c.salt, c.password), clientAuthData) {
 			// 'fast' auth: write "More data" packet (first byte == 0x01) with the second byte = 0x03
 			return c.writeAuthMoreDataFastAuth()
 		}

--- a/server/auth_switch_response.go
+++ b/server/auth_switch_response.go
@@ -9,7 +9,7 @@ import (
 	"crypto/tls"
 	"fmt"
 
-	. "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/errors"
 )
 
@@ -20,13 +20,13 @@ func (c *Conn) handleAuthSwitchResponse() error {
 	}
 
 	switch c.authPluginName {
-	case AUTH_NATIVE_PASSWORD:
+	case mysql.AUTH_NATIVE_PASSWORD:
 		if err := c.acquirePassword(); err != nil {
 			return err
 		}
 		return c.compareNativePasswordAuthData(authData, c.password)
 
-	case AUTH_CACHING_SHA2_PASSWORD:
+	case mysql.AUTH_CACHING_SHA2_PASSWORD:
 		if !c.cachingSha2FullAuth {
 			// Switched auth method but no MoreData packet send yet
 			if err := c.compareCacheSha2PasswordAuthData(authData); err != nil {
@@ -45,7 +45,7 @@ func (c *Conn) handleAuthSwitchResponse() error {
 		c.writeCachingSha2Cache()
 		return nil
 
-	case AUTH_SHA256_PASSWORD:
+	case mysql.AUTH_SHA256_PASSWORD:
 		cont, err := c.handlePublicKeyRetrieval(authData)
 		if err != nil {
 			return err

--- a/server/conn.go
+++ b/server/conn.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"sync/atomic"
 
-	. "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/packet"
 )
 
@@ -57,7 +57,7 @@ func NewConn(conn net.Conn, user string, password string, h Handler) (*Conn, err
 		h:                  h,
 		connectionID:       atomic.AddUint32(&baseConnID, 1),
 		stmts:              make(map[uint32]*Stmt),
-		salt:               RandomBuf(20),
+		salt:               mysql.RandomBuf(20),
 	}
 	c.closed.Store(false)
 
@@ -85,7 +85,7 @@ func NewCustomizedConn(conn net.Conn, serverConf *Server, p CredentialProvider, 
 		h:                  h,
 		connectionID:       atomic.AddUint32(&baseConnID, 1),
 		stmts:              make(map[uint32]*Stmt),
-		salt:               RandomBuf(20),
+		salt:               mysql.RandomBuf(20),
 	}
 	c.closed.Store(false)
 
@@ -104,11 +104,12 @@ func (c *Conn) handshake() error {
 
 	if err := c.readHandshakeResponse(); err != nil {
 		if errors.Is(err, ErrAccessDenied) {
-			var usingPasswd uint16 = ER_YES
+			var usingPasswd uint16 = mysql.ER_YES
 			if errors.Is(err, ErrAccessDeniedNoPassword) {
-				usingPasswd = ER_NO
+				usingPasswd = mysql.ER_NO
 			}
-			err = NewDefaultError(ER_ACCESS_DENIED_ERROR, c.user, c.RemoteAddr().String(), MySQLErrName[usingPasswd])
+			err = mysql.NewDefaultError(mysql.ER_ACCESS_DENIED_ERROR, c.user,
+				c.RemoteAddr().String(), mysql.MySQLErrName[usingPasswd])
 		}
 		_ = c.writeError(err)
 		return err
@@ -167,19 +168,19 @@ func (c *Conn) ConnectionID() uint32 {
 }
 
 func (c *Conn) IsAutoCommit() bool {
-	return c.HasStatus(SERVER_STATUS_AUTOCOMMIT)
+	return c.HasStatus(mysql.SERVER_STATUS_AUTOCOMMIT)
 }
 
 func (c *Conn) IsInTransaction() bool {
-	return c.HasStatus(SERVER_STATUS_IN_TRANS)
+	return c.HasStatus(mysql.SERVER_STATUS_IN_TRANS)
 }
 
 func (c *Conn) SetInTransaction() {
-	c.SetStatus(SERVER_STATUS_IN_TRANS)
+	c.SetStatus(mysql.SERVER_STATUS_IN_TRANS)
 }
 
 func (c *Conn) ClearInTransaction() {
-	c.UnsetStatus(SERVER_STATUS_IN_TRANS)
+	c.UnsetStatus(mysql.SERVER_STATUS_IN_TRANS)
 }
 
 func (c *Conn) SetStatus(status uint16) {

--- a/server/handshake_resp.go
+++ b/server/handshake_resp.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/binary"
 
-	. "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/errors"
 )
 
@@ -39,7 +39,7 @@ func (c *Conn) readHandshakeResponse() error {
 	}
 
 	// read connection attributes
-	if c.capability&CLIENT_CONNECT_ATTRS > 0 {
+	if c.capability&mysql.CLIENT_CONNECT_ATTRS > 0 {
 		// readAttributes returns new position for further processing of data
 		_, err = c.readAttributes(data, pos)
 		if err != nil {
@@ -64,18 +64,18 @@ func (c *Conn) decodeFirstPart(data []byte) (newData []byte, pos int, err error)
 	// prevent 'panic: runtime error: index out of range' error
 	defer func() {
 		if recover() != nil {
-			err = NewDefaultError(ER_HANDSHAKE_ERROR)
+			err = mysql.NewDefaultError(mysql.ER_HANDSHAKE_ERROR)
 		}
 	}()
 
 	// check CLIENT_PROTOCOL_41
-	if uint32(binary.LittleEndian.Uint16(data[:2]))&CLIENT_PROTOCOL_41 == 0 {
+	if uint32(binary.LittleEndian.Uint16(data[:2]))&mysql.CLIENT_PROTOCOL_41 == 0 {
 		return nil, 0, errors.New("CLIENT_PROTOCOL_41 compatible client is required")
 	}
 
 	//capability
 	c.capability = binary.LittleEndian.Uint32(data[:4])
-	if c.capability&CLIENT_SECURE_CONNECTION == 0 {
+	if c.capability&mysql.CLIENT_SECURE_CONNECTION == 0 {
 		return nil, 0, errors.New("CLIENT_SECURE_CONNECTION compatible client is required")
 	}
 	pos += 4
@@ -92,7 +92,7 @@ func (c *Conn) decodeFirstPart(data []byte) (newData []byte, pos int, err error)
 
 	// is this a SSLRequest packet?
 	if len(data) == (4 + 4 + 1 + 23) {
-		if c.serverConf.capability&CLIENT_SSL == 0 {
+		if c.serverConf.capability&mysql.CLIENT_SSL == 0 {
 			return nil, 0, errors.Errorf("The host '%s' does not support SSL connections", c.RemoteAddr().String())
 		}
 		// switch to TLS
@@ -117,7 +117,7 @@ func (c *Conn) readUserName(data []byte, pos int) (int, error) {
 }
 
 func (c *Conn) readDb(data []byte, pos int) (int, error) {
-	if c.capability&CLIENT_CONNECT_WITH_DB != 0 {
+	if c.capability&mysql.CLIENT_CONNECT_WITH_DB != 0 {
 		if len(data[pos:]) == 0 {
 			return pos, nil
 		}
@@ -133,13 +133,13 @@ func (c *Conn) readDb(data []byte, pos int) (int, error) {
 }
 
 func (c *Conn) readPluginName(data []byte, pos int) int {
-	if c.capability&CLIENT_PLUGIN_AUTH != 0 {
+	if c.capability&mysql.CLIENT_PLUGIN_AUTH != 0 {
 		c.authPluginName = string(data[pos : pos+bytes.IndexByte(data[pos:], 0x00)])
 		pos += len(c.authPluginName) + 1
 	} else {
 		// The method used is Native Authentication if both CLIENT_PROTOCOL_41 and CLIENT_SECURE_CONNECTION are set,
 		// but CLIENT_PLUGIN_AUTH is not set, so we fallback to 'mysql_native_password'
-		c.authPluginName = AUTH_NATIVE_PASSWORD
+		c.authPluginName = mysql.AUTH_NATIVE_PASSWORD
 	}
 	return pos
 }
@@ -148,23 +148,24 @@ func (c *Conn) readAuthData(data []byte, pos int) (auth []byte, authLen int, new
 	// prevent 'panic: runtime error: index out of range' error
 	defer func() {
 		if recover() != nil {
-			err = NewDefaultError(ER_HANDSHAKE_ERROR)
+			err = mysql.NewDefaultError(mysql.ER_HANDSHAKE_ERROR)
 		}
 	}()
 
 	// length encoded data
-	if c.capability&CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA != 0 {
-		authData, isNULL, readBytes, err := LengthEncodedString(data[pos:])
+	if c.capability&mysql.CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA != 0 {
+		authData, isNULL, readBytes, err := mysql.LengthEncodedString(data[pos:])
 		if err != nil {
 			return nil, 0, 0, err
 		}
 		if isNULL {
 			// no auth length and no auth data, just \NUL, considered invalid auth data, and reject connection as MySQL does
-			return nil, 0, 0, NewDefaultError(ER_ACCESS_DENIED_ERROR, c.user, c.RemoteAddr().String(), MySQLErrName[ER_NO])
+			return nil, 0, 0, mysql.NewDefaultError(mysql.ER_ACCESS_DENIED_ERROR,
+				c.user, c.RemoteAddr().String(), mysql.MySQLErrName[mysql.ER_NO])
 		}
 		auth = authData
 		authLen = readBytes
-	} else if c.capability&CLIENT_SECURE_CONNECTION != 0 {
+	} else if c.capability&mysql.CLIENT_SECURE_CONNECTION != 0 {
 		// auth length and auth
 		authLen = int(data[pos])
 		pos++
@@ -183,8 +184,8 @@ func (c *Conn) readAuthData(data []byte, pos int) (auth []byte, authLen int, new
 func (c *Conn) handlePublicKeyRetrieval(authData []byte) (bool, error) {
 	// if the client use 'sha256_password' auth method, and request for a public key
 	// we send back a keyfile with Protocol::AuthMoreData
-	if c.authPluginName == AUTH_SHA256_PASSWORD && len(authData) == 1 && authData[0] == 0x01 {
-		if c.serverConf.capability&CLIENT_SSL == 0 {
+	if c.authPluginName == mysql.AUTH_SHA256_PASSWORD && len(authData) == 1 && authData[0] == 0x01 {
+		if c.serverConf.capability&mysql.CLIENT_SSL == 0 {
 			return false, errors.New("server does not support SSL: CLIENT_SSL not enabled")
 		}
 		if err := c.writeAuthMoreDataPubkey(); err != nil {
@@ -213,7 +214,7 @@ func (c *Conn) handleAuthMatch() (bool, error) {
 
 func (c *Conn) readAttributes(data []byte, pos int) (int, error) {
 	// read length of attribute data
-	attrLen, isNull, skip := LengthEncodedInt(data[pos:])
+	attrLen, isNull, skip := mysql.LengthEncodedInt(data[pos:])
 	pos += skip
 	if isNull {
 		return pos, nil
@@ -229,7 +230,7 @@ func (c *Conn) readAttributes(data []byte, pos int) (int, error) {
 
 	// read until end of data or NUL for atrribute key/values
 	for {
-		str, isNull, strLen, err := LengthEncodedString(data[pos:])
+		str, isNull, strLen, err := mysql.LengthEncodedString(data[pos:])
 		if err != nil {
 			return -1, err
 		}

--- a/server/resp.go
+++ b/server/resp.go
@@ -4,25 +4,25 @@ import (
 	"context"
 	"fmt"
 
-	. "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/replication"
 )
 
-func (c *Conn) writeOK(r *Result) error {
+func (c *Conn) writeOK(r *mysql.Result) error {
 	if r == nil {
-		r = NewResultReserveResultset(0)
+		r = mysql.NewResultReserveResultset(0)
 	}
 
 	r.Status |= c.status
 
 	data := make([]byte, 4, 32)
 
-	data = append(data, OK_HEADER)
+	data = append(data, mysql.OK_HEADER)
 
-	data = append(data, PutLengthEncodedInt(r.AffectedRows)...)
-	data = append(data, PutLengthEncodedInt(r.InsertId)...)
+	data = append(data, mysql.PutLengthEncodedInt(r.AffectedRows)...)
+	data = append(data, mysql.PutLengthEncodedInt(r.InsertId)...)
 
-	if c.capability&CLIENT_PROTOCOL_41 > 0 {
+	if c.capability&mysql.CLIENT_PROTOCOL_41 > 0 {
 		data = append(data, byte(r.Status), byte(r.Status>>8))
 		data = append(data, byte(r.Warnings), byte(r.Warnings>>8))
 	}
@@ -31,18 +31,18 @@ func (c *Conn) writeOK(r *Result) error {
 }
 
 func (c *Conn) writeError(e error) error {
-	var m *MyError
+	var m *mysql.MyError
 	var ok bool
-	if m, ok = e.(*MyError); !ok {
-		m = NewError(ER_UNKNOWN_ERROR, e.Error())
+	if m, ok = e.(*mysql.MyError); !ok {
+		m = mysql.NewError(mysql.ER_UNKNOWN_ERROR, e.Error())
 	}
 
 	data := make([]byte, 4, 16+len(m.Message))
 
-	data = append(data, ERR_HEADER)
+	data = append(data, mysql.ERR_HEADER)
 	data = append(data, byte(m.Code), byte(m.Code>>8))
 
-	if c.capability&CLIENT_PROTOCOL_41 > 0 {
+	if c.capability&mysql.CLIENT_PROTOCOL_41 > 0 {
 		data = append(data, '#')
 		data = append(data, m.State...)
 	}
@@ -55,8 +55,8 @@ func (c *Conn) writeError(e error) error {
 func (c *Conn) writeEOF() error {
 	data := make([]byte, 4, 9)
 
-	data = append(data, EOF_HEADER)
-	if c.capability&CLIENT_PROTOCOL_41 > 0 {
+	data = append(data, mysql.EOF_HEADER)
+	if c.capability&mysql.CLIENT_PROTOCOL_41 > 0 {
 		data = append(data, byte(c.warnings), byte(c.warnings>>8))
 		data = append(data, byte(c.status), byte(c.status>>8))
 	}
@@ -67,11 +67,11 @@ func (c *Conn) writeEOF() error {
 // see: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_auth_switch_request.html
 func (c *Conn) writeAuthSwitchRequest(newAuthPluginName string) error {
 	data := make([]byte, 4)
-	data = append(data, EOF_HEADER)
+	data = append(data, mysql.EOF_HEADER)
 	data = append(data, []byte(newAuthPluginName)...)
 	data = append(data, 0x00)
 	// new auth data
-	c.salt = RandomBuf(20)
+	c.salt = mysql.RandomBuf(20)
 	data = append(data, c.salt...)
 	// the online doc states it's a string.EOF, however, the actual MySQL server add a \NUL to the end, without it, the
 	// official MySQL client will fail.
@@ -94,26 +94,26 @@ func (c *Conn) readAuthSwitchRequestResponse() ([]byte, error) {
 
 func (c *Conn) writeAuthMoreDataPubkey() error {
 	data := make([]byte, 4)
-	data = append(data, MORE_DATE_HEADER)
+	data = append(data, mysql.MORE_DATE_HEADER)
 	data = append(data, c.serverConf.pubKey...)
 	return c.WritePacket(data)
 }
 
 func (c *Conn) writeAuthMoreDataFullAuth() error {
 	data := make([]byte, 4)
-	data = append(data, MORE_DATE_HEADER)
-	data = append(data, CACHE_SHA2_FULL_AUTH)
+	data = append(data, mysql.MORE_DATE_HEADER)
+	data = append(data, mysql.CACHE_SHA2_FULL_AUTH)
 	return c.WritePacket(data)
 }
 
 func (c *Conn) writeAuthMoreDataFastAuth() error {
 	data := make([]byte, 4)
-	data = append(data, MORE_DATE_HEADER)
-	data = append(data, CACHE_SHA2_FAST_AUTH)
+	data = append(data, mysql.MORE_DATE_HEADER)
+	data = append(data, mysql.CACHE_SHA2_FAST_AUTH)
 	return c.WritePacket(data)
 }
 
-func (c *Conn) writeResultset(r *Resultset) error {
+func (c *Conn) writeResultset(r *mysql.Resultset) error {
 	// for a streaming resultset, that handled rowdata separately in a callback
 	// of type SelectPerRowCallback, we can suffice by ending the stream with
 	// an EOF
@@ -121,14 +121,14 @@ func (c *Conn) writeResultset(r *Resultset) error {
 	// been taken care of already in the user-defined callback
 	if r.StreamingDone {
 		switch r.Streaming {
-		case StreamingMultiple:
+		case mysql.StreamingMultiple:
 			return nil
-		case StreamingSelect:
+		case mysql.StreamingSelect:
 			return c.writeEOF()
 		}
 	}
 
-	columnLen := PutLengthEncodedInt(uint64(len(r.Fields)))
+	columnLen := mysql.PutLengthEncodedInt(uint64(len(r.Fields)))
 
 	data := make([]byte, 4, 1024)
 
@@ -143,7 +143,7 @@ func (c *Conn) writeResultset(r *Resultset) error {
 
 	// streaming select resultsets handle rowdata in a separate callback of type
 	// SelectPerRowCallback so we're done here
-	if r.Streaming == StreamingSelect {
+	if r.Streaming == mysql.StreamingSelect {
 		return nil
 	}
 
@@ -162,7 +162,7 @@ func (c *Conn) writeResultset(r *Resultset) error {
 	return nil
 }
 
-func (c *Conn) writeFieldList(fs []*Field, data []byte) error {
+func (c *Conn) writeFieldList(fs []*mysql.Field, data []byte) error {
 	if data == nil {
 		data = make([]byte, 4, 1024)
 	}
@@ -181,18 +181,18 @@ func (c *Conn) writeFieldList(fs []*Field, data []byte) error {
 	return nil
 }
 
-func (c *Conn) writeFieldValues(fv []FieldValue) error {
+func (c *Conn) writeFieldValues(fv []mysql.FieldValue) error {
 	data := make([]byte, 4, 1024)
 	for _, v := range fv {
 		if v.Value() == nil {
 			// NULL value is encoded as 0xfb here
 			data = append(data, []byte{0xfb}...)
 		} else {
-			tv, err := FormatTextValue(v.Value())
+			tv, err := mysql.FormatTextValue(v.Value())
 			if err != nil {
 				return err
 			}
-			data = append(data, PutLengthEncodedString(tv)...)
+			data = append(data, mysql.PutLengthEncodedString(tv)...)
 		}
 	}
 
@@ -207,7 +207,7 @@ func (c *Conn) writeBinlogEvents(s *replication.BinlogStreamer) error {
 			return err
 		}
 		data := make([]byte, 4, 4+len(ev.RawData))
-		data = append(data, OK_HEADER)
+		data = append(data, mysql.OK_HEADER)
 
 		data = append(data, ev.RawData...)
 		if err := c.WritePacket(data); err != nil {
@@ -229,15 +229,15 @@ func (c *Conn) WriteValue(value interface{}) error {
 		return c.writeError(v)
 	case nil:
 		return c.writeOK(nil)
-	case *Result:
+	case *mysql.Result:
 		if v != nil && v.Resultset != nil {
 			return c.writeResultset(v.Resultset)
 		} else {
 			return c.writeOK(v)
 		}
-	case []*Field:
+	case []*mysql.Field:
 		return c.writeFieldList(v, nil)
-	case []FieldValue:
+	case []mysql.FieldValue:
 		return c.writeFieldValues(v)
 	case *replication.BinlogStreamer:
 		return c.writeBinlogEvents(v)

--- a/server/server_conf.go
+++ b/server/server_conf.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	. "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/mysql"
 )
 
 var defaultServer = NewDefaultServer()
@@ -50,11 +50,11 @@ func NewDefaultServer() *Server {
 	return &Server{
 		serverVersion:   "8.0.11",
 		protocolVersion: 10,
-		capability: CLIENT_LONG_PASSWORD | CLIENT_LONG_FLAG | CLIENT_CONNECT_WITH_DB | CLIENT_PROTOCOL_41 |
-			CLIENT_TRANSACTIONS | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH | CLIENT_SSL |
-			CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA | CLIENT_CONNECT_ATTRS,
-		collationId:       DEFAULT_COLLATION_ID,
-		defaultAuthMethod: AUTH_NATIVE_PASSWORD,
+		capability: mysql.CLIENT_LONG_PASSWORD | mysql.CLIENT_LONG_FLAG | mysql.CLIENT_CONNECT_WITH_DB | mysql.CLIENT_PROTOCOL_41 |
+			mysql.CLIENT_TRANSACTIONS | mysql.CLIENT_SECURE_CONNECTION | mysql.CLIENT_PLUGIN_AUTH | mysql.CLIENT_SSL |
+			mysql.CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA | mysql.CLIENT_CONNECT_ATTRS,
+		collationId:       mysql.DEFAULT_COLLATION_ID,
+		defaultAuthMethod: mysql.AUTH_NATIVE_PASSWORD,
 		pubKey:            getPublicKeyFromCert(certPem),
 		tlsConfig:         tlsConf,
 		cacheShaPassword:  new(sync.Map),
@@ -78,11 +78,11 @@ func NewServer(serverVersion string, collationId uint8, defaultAuthMethod string
 	//if !isAuthMethodAllowedByServer(defaultAuthMethod, allowedAuthMethods) {
 	//	panic(fmt.Sprintf("default auth method is not one of the allowed auth methods"))
 	//}
-	var capFlag = CLIENT_LONG_PASSWORD | CLIENT_LONG_FLAG | CLIENT_CONNECT_WITH_DB | CLIENT_PROTOCOL_41 |
-		CLIENT_TRANSACTIONS | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH | CLIENT_CONNECT_ATTRS |
-		CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA
+	var capFlag = mysql.CLIENT_LONG_PASSWORD | mysql.CLIENT_LONG_FLAG | mysql.CLIENT_CONNECT_WITH_DB | mysql.CLIENT_PROTOCOL_41 |
+		mysql.CLIENT_TRANSACTIONS | mysql.CLIENT_SECURE_CONNECTION | mysql.CLIENT_PLUGIN_AUTH | mysql.CLIENT_CONNECT_ATTRS |
+		mysql.CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA
 	if tlsConfig != nil {
-		capFlag |= CLIENT_SSL
+		capFlag |= mysql.CLIENT_SSL
 	}
 	return &Server{
 		serverVersion:     serverVersion,
@@ -97,7 +97,7 @@ func NewServer(serverVersion string, collationId uint8, defaultAuthMethod string
 }
 
 func isAuthMethodSupported(authMethod string) bool {
-	return authMethod == AUTH_NATIVE_PASSWORD || authMethod == AUTH_CACHING_SHA2_PASSWORD || authMethod == AUTH_SHA256_PASSWORD
+	return authMethod == mysql.AUTH_NATIVE_PASSWORD || authMethod == mysql.AUTH_CACHING_SHA2_PASSWORD || authMethod == mysql.AUTH_SHA256_PASSWORD
 }
 
 func (s *Server) InvalidateCache(username string, host string) {

--- a/server/stmt.go
+++ b/server/stmt.go
@@ -6,13 +6,13 @@ import (
 	"math"
 	"strconv"
 
-	. "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/errors"
 )
 
 var (
-	paramFieldData  = (&Field{Name: []byte("?")}).Dump()
-	columnFieldData = (&Field{}).Dump()
+	paramFieldData  = (&mysql.Field{Name: []byte("?")}).Dump()
+	columnFieldData = (&mysql.Field{}).Dump()
 )
 
 type Stmt struct {
@@ -44,11 +44,11 @@ func (c *Conn) writePrepare(s *Stmt) error {
 	//status ok
 	data = append(data, 0)
 	//stmt id
-	data = append(data, Uint32ToBytes(s.ID)...)
+	data = append(data, mysql.Uint32ToBytes(s.ID)...)
 	//number columns
-	data = append(data, Uint16ToBytes(uint16(s.Columns))...)
+	data = append(data, mysql.Uint16ToBytes(uint16(s.Columns))...)
 	//number params
-	data = append(data, Uint16ToBytes(uint16(s.Params))...)
+	data = append(data, mysql.Uint16ToBytes(uint16(s.Params))...)
 	//filter [00]
 	data = append(data, 0)
 	//warning count
@@ -90,9 +90,9 @@ func (c *Conn) writePrepare(s *Stmt) error {
 	return nil
 }
 
-func (c *Conn) handleStmtExecute(data []byte) (*Result, error) {
+func (c *Conn) handleStmtExecute(data []byte) (*mysql.Result, error) {
 	if len(data) < 9 {
-		return nil, ErrMalformPacket
+		return nil, mysql.ErrMalformPacket
 	}
 
 	pos := 0
@@ -101,7 +101,7 @@ func (c *Conn) handleStmtExecute(data []byte) (*Result, error) {
 
 	s, ok := c.stmts[id]
 	if !ok {
-		return nil, NewDefaultError(ER_UNKNOWN_STMT_HANDLER, 5,
+		return nil, mysql.NewDefaultError(mysql.ER_UNKNOWN_STMT_HANDLER, 5,
 			strconv.FormatUint(uint64(id), 10), "stmt_execute")
 	}
 
@@ -113,18 +113,18 @@ func (c *Conn) handleStmtExecute(data []byte) (*Result, error) {
 
 	// Make sure the first 4 bits are 0.
 	if flag>>4 != 0 {
-		return nil, NewError(ER_UNKNOWN_ERROR, fmt.Sprintf("unsupported flags 0x%x", flag))
+		return nil, mysql.NewError(mysql.ER_UNKNOWN_ERROR, fmt.Sprintf("unsupported flags 0x%x", flag))
 	}
 
 	// Test for unsupported flags in the remaining 4 bits.
-	if flag&CURSOR_TYPE_READ_ONLY > 0 {
-		return nil, NewError(ER_UNKNOWN_ERROR, "unsupported flag CURSOR_TYPE_READ_ONLY")
+	if flag&mysql.CURSOR_TYPE_READ_ONLY > 0 {
+		return nil, mysql.NewError(mysql.ER_UNKNOWN_ERROR, "unsupported flag CURSOR_TYPE_READ_ONLY")
 	}
-	if flag&CURSOR_TYPE_FOR_UPDATE > 0 {
-		return nil, NewError(ER_UNKNOWN_ERROR, "unsupported flag CURSOR_TYPE_FOR_UPDATE")
+	if flag&mysql.CURSOR_TYPE_FOR_UPDATE > 0 {
+		return nil, mysql.NewError(mysql.ER_UNKNOWN_ERROR, "unsupported flag CURSOR_TYPE_FOR_UPDATE")
 	}
-	if flag&CURSOR_TYPE_SCROLLABLE > 0 {
-		return nil, NewError(ER_UNKNOWN_ERROR, "unsupported flag CURSOR_TYPE_SCROLLABLE")
+	if flag&mysql.CURSOR_TYPE_SCROLLABLE > 0 {
+		return nil, mysql.NewError(mysql.ER_UNKNOWN_ERROR, "unsupported flag CURSOR_TYPE_SCROLLABLE")
 	}
 
 	//skip iteration-count, always 1
@@ -139,7 +139,7 @@ func (c *Conn) handleStmtExecute(data []byte) (*Result, error) {
 	if paramNum > 0 {
 		nullBitmapLen := (s.Params + 7) >> 3
 		if len(data) < (pos + nullBitmapLen + 1) {
-			return nil, ErrMalformPacket
+			return nil, mysql.ErrMalformPacket
 		}
 		nullBitmaps = data[pos : pos+nullBitmapLen]
 		pos += nullBitmapLen
@@ -148,7 +148,7 @@ func (c *Conn) handleStmtExecute(data []byte) (*Result, error) {
 		if data[pos] == 1 {
 			pos++
 			if len(data) < (pos + (paramNum << 1)) {
-				return nil, ErrMalformPacket
+				return nil, mysql.ErrMalformPacket
 			}
 
 			paramTypes = data[pos : pos+(paramNum<<1)]
@@ -162,7 +162,7 @@ func (c *Conn) handleStmtExecute(data []byte) (*Result, error) {
 		}
 	}
 
-	var r *Result
+	var r *mysql.Result
 	var err error
 	if r, err = c.h.HandleStmtExecute(s.Context, s.Query, s.Args); err != nil {
 		return nil, errors.Trace(err)
@@ -193,13 +193,13 @@ func (c *Conn) bindStmtArgs(s *Stmt, nullBitmap, paramTypes, paramValues []byte)
 		isUnsigned := (paramTypes[(i<<1)+1] & 0x80) > 0
 
 		switch tp {
-		case MYSQL_TYPE_NULL:
+		case mysql.MYSQL_TYPE_NULL:
 			args[i] = nil
 			continue
 
-		case MYSQL_TYPE_TINY:
+		case mysql.MYSQL_TYPE_TINY:
 			if len(paramValues) < (pos + 1) {
-				return ErrMalformPacket
+				return mysql.ErrMalformPacket
 			}
 
 			if isUnsigned {
@@ -211,9 +211,9 @@ func (c *Conn) bindStmtArgs(s *Stmt, nullBitmap, paramTypes, paramValues []byte)
 			pos++
 			continue
 
-		case MYSQL_TYPE_SHORT, MYSQL_TYPE_YEAR:
+		case mysql.MYSQL_TYPE_SHORT, mysql.MYSQL_TYPE_YEAR:
 			if len(paramValues) < (pos + 2) {
-				return ErrMalformPacket
+				return mysql.ErrMalformPacket
 			}
 
 			if isUnsigned {
@@ -224,9 +224,9 @@ func (c *Conn) bindStmtArgs(s *Stmt, nullBitmap, paramTypes, paramValues []byte)
 			pos += 2
 			continue
 
-		case MYSQL_TYPE_INT24, MYSQL_TYPE_LONG:
+		case mysql.MYSQL_TYPE_INT24, mysql.MYSQL_TYPE_LONG:
 			if len(paramValues) < (pos + 4) {
-				return ErrMalformPacket
+				return mysql.ErrMalformPacket
 			}
 
 			if isUnsigned {
@@ -237,9 +237,9 @@ func (c *Conn) bindStmtArgs(s *Stmt, nullBitmap, paramTypes, paramValues []byte)
 			pos += 4
 			continue
 
-		case MYSQL_TYPE_LONGLONG:
+		case mysql.MYSQL_TYPE_LONGLONG:
 			if len(paramValues) < (pos + 8) {
-				return ErrMalformPacket
+				return mysql.ErrMalformPacket
 			}
 
 			if isUnsigned {
@@ -250,35 +250,35 @@ func (c *Conn) bindStmtArgs(s *Stmt, nullBitmap, paramTypes, paramValues []byte)
 			pos += 8
 			continue
 
-		case MYSQL_TYPE_FLOAT:
+		case mysql.MYSQL_TYPE_FLOAT:
 			if len(paramValues) < (pos + 4) {
-				return ErrMalformPacket
+				return mysql.ErrMalformPacket
 			}
 
 			args[i] = math.Float32frombits(binary.LittleEndian.Uint32(paramValues[pos : pos+4]))
 			pos += 4
 			continue
 
-		case MYSQL_TYPE_DOUBLE:
+		case mysql.MYSQL_TYPE_DOUBLE:
 			if len(paramValues) < (pos + 8) {
-				return ErrMalformPacket
+				return mysql.ErrMalformPacket
 			}
 
 			args[i] = math.Float64frombits(binary.LittleEndian.Uint64(paramValues[pos : pos+8]))
 			pos += 8
 			continue
 
-		case MYSQL_TYPE_DECIMAL, MYSQL_TYPE_NEWDECIMAL, MYSQL_TYPE_VARCHAR,
-			MYSQL_TYPE_BIT, MYSQL_TYPE_ENUM, MYSQL_TYPE_SET, MYSQL_TYPE_TINY_BLOB,
-			MYSQL_TYPE_MEDIUM_BLOB, MYSQL_TYPE_LONG_BLOB, MYSQL_TYPE_BLOB,
-			MYSQL_TYPE_VAR_STRING, MYSQL_TYPE_STRING, MYSQL_TYPE_GEOMETRY,
-			MYSQL_TYPE_DATE, MYSQL_TYPE_NEWDATE,
-			MYSQL_TYPE_TIMESTAMP, MYSQL_TYPE_DATETIME, MYSQL_TYPE_TIME:
+		case mysql.MYSQL_TYPE_DECIMAL, mysql.MYSQL_TYPE_NEWDECIMAL, mysql.MYSQL_TYPE_VARCHAR,
+			mysql.MYSQL_TYPE_BIT, mysql.MYSQL_TYPE_ENUM, mysql.MYSQL_TYPE_SET, mysql.MYSQL_TYPE_TINY_BLOB,
+			mysql.MYSQL_TYPE_MEDIUM_BLOB, mysql.MYSQL_TYPE_LONG_BLOB, mysql.MYSQL_TYPE_BLOB,
+			mysql.MYSQL_TYPE_VAR_STRING, mysql.MYSQL_TYPE_STRING, mysql.MYSQL_TYPE_GEOMETRY,
+			mysql.MYSQL_TYPE_DATE, mysql.MYSQL_TYPE_NEWDATE,
+			mysql.MYSQL_TYPE_TIMESTAMP, mysql.MYSQL_TYPE_DATETIME, mysql.MYSQL_TYPE_TIME:
 			if len(paramValues) < (pos + 1) {
-				return ErrMalformPacket
+				return mysql.ErrMalformPacket
 			}
 
-			v, isNull, n, err = LengthEncodedString(paramValues[pos:])
+			v, isNull, n, err = mysql.LengthEncodedString(paramValues[pos:])
 			pos += n
 			if err != nil {
 				return errors.Trace(err)
@@ -330,22 +330,22 @@ func (c *Conn) handleStmtSendLongData(data []byte) error {
 	return nil
 }
 
-func (c *Conn) handleStmtReset(data []byte) (*Result, error) {
+func (c *Conn) handleStmtReset(data []byte) (*mysql.Result, error) {
 	if len(data) < 4 {
-		return nil, ErrMalformPacket
+		return nil, mysql.ErrMalformPacket
 	}
 
 	id := binary.LittleEndian.Uint32(data[0:4])
 
 	s, ok := c.stmts[id]
 	if !ok {
-		return nil, NewDefaultError(ER_UNKNOWN_STMT_HANDLER, 5,
+		return nil, mysql.NewDefaultError(mysql.ER_UNKNOWN_STMT_HANDLER, 5,
 			strconv.FormatUint(uint64(id), 10), "stmt_reset")
 	}
 
 	s.ResetParams()
 
-	return NewResultReserveResultset(0), nil
+	return mysql.NewResultReserveResultset(0), nil
 }
 
 // stmt close command has no response


### PR DESCRIPTION
The dot import might confuse both tools and users

Example:
https://pkg.go.dev/github.com/go-mysql-org/go-mysql@v1.11.0/client#Conn.Execute

![image](https://github.com/user-attachments/assets/dffd9ad0-af65-4174-a23d-4b8345812ba7)

With this PR (locally via godoc):

![image](https://github.com/user-attachments/assets/204bcdd7-ed6f-422d-8b6b-9224634ce4d9)

Note that it now is able to turn the `Result` in a link.

Resources:
- https://go.dev/wiki/CodeReviewComments#import-dot