### PR TITLE
server: Correct the check for Resultset

### DIFF
--- a/mysql/result.go
+++ b/mysql/result.go
@@ -34,3 +34,10 @@ func (r *Result) Close() {
 		r.Resultset = nil
 	}
 }
+
+func (r *Result) HasResultset() bool {
+	if r.Resultset != nil && len(r.Resultset.Fields) > 0 {
+		return true
+	}
+	return false
+}

--- a/mysql/result_test.go
+++ b/mysql/result_test.go
@@ -1,0 +1,19 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasResultset_false(t *testing.T) {
+	r := NewResultReserveResultset(0)
+	b := r.HasResultset()
+	require.Equal(t, false, b)
+}
+
+func TestHasResultset_true(t *testing.T) {
+	r := NewResultReserveResultset(1)
+	b := r.HasResultset()
+	require.Equal(t, true, b)
+}

--- a/server/resp.go
+++ b/server/resp.go
@@ -230,7 +230,7 @@ func (c *Conn) WriteValue(value interface{}) error {
 	case nil:
 		return c.writeOK(nil)
 	case *Result:
-		if v != nil && v.Resultset != nil {
+		if v != nil && v.HasResultset() {
 			return c.writeResultset(v.Resultset)
 		} else {
 			return c.writeOK(v)


### PR DESCRIPTION
This is likely a regression introduced by #969 

Found by running this code: https://github.com/go-mysql-org/go-mysql/issues/915#issuecomment-2640067648

Queries like `SELECT 1` were working correctly, but `DO 1` and `SET ...` were not as the code tried to write a resultset instead of an OK.

