### PR TITLE
server: Correctly handle COM_STMT_EXECUTE without rebind

### DIFF
--- a/server/stmt.go
+++ b/server/stmt.go
@@ -176,7 +176,10 @@ func (c *Conn) handleStmtExecute(data []byte) (*mysql.Result, error) {
 func (c *Conn) bindStmtArgs(s *Stmt, nullBitmap, paramTypes, paramValues []byte) error {
 	args := s.Args
 
-	// Every param should have a 1-byte type and a 1-byte flag
+	// Every param should have a type-and-flag of 2 bytes
+	// 0xfe80 == Type 0xfe and Flag 0x80
+	// The flag only has one bit and that indicates if it is unsigned or not.
+	// Types are 1 byte, but might grow into the 7 unused bits in the future.
 	if len(paramTypes)/2 != s.Params {
 		return mysql.ErrMalformPacket
 	}


### PR DESCRIPTION
Closes #915 

Tested with sysbench 1.0.20