### PR TITLE
CI: Update nolintlint config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,12 +96,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           args: --timeout=3m
-          problem-matchers: true
 
   platforms:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [ "1.23", "1.22" ]
+        go: [ "1.24", "1.23", "1.22" ]
         os: [ ubuntu-24.04, ubuntu-22.04 ]
     name: Tests Go ${{ matrix.go }} on ${{ matrix.os }} # This name is used in main branch protection rules
     runs-on: ${{ matrix.os }}
@@ -83,7 +83,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: stable
       - name: Run tests
         run: |
           # separate test to avoid RESET MASTER conflict
@@ -121,7 +121,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: stable
 
       - name: Build on ${{ matrix.os }}/${{ matrix.arch }}
         run: GOARCH=${{ matrix.arch }} GOOS=${{ matrix.os }} go build ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
         with:
           version: latest
           args: --timeout=3m
+          problem-matchers: true
 
   platforms:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: runTestsAndLinters
 on: [push, pull_request]
 
+permissions:
+  contents: read
+  # Write is needed for golangci-lint annotations
+  checks: write
+
 jobs:
   test:
     strategy:
@@ -17,11 +22,11 @@ jobs:
           echo -n "mysqldump -V: " ; mysqldump -V
 
           echo -e '[mysqld]\nserver-id=1\nlog-bin=mysql\nbinlog-format=row\ngtid-mode=ON\nenforce_gtid_consistency=ON\n' | sudo tee /etc/mysql/conf.d/replication.cnf
-          
+
           # bind to :: for dual-stack listening
           sudo sed -i 's/bind-address.*= 127.0.0.1/bind-address = ::/' /etc/mysql/mysql.conf.d/mysqld.cnf
           sudo sed -i 's/mysqlx-bind-address.*= 127.0.0.1/mysqlx-bind-address = ::/' /etc/mysql/mysql.conf.d/mysqld.cnf
-          
+
           sudo service mysql start
 
           # apply this for mysql5 & mysql8 compatibility
@@ -114,6 +119,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.23"
-          
+
       - name: Build on ${{ matrix.os }}/${{ matrix.arch }}
         run: GOARCH=${{ matrix.arch }} GOOS=${{ matrix.os }} go build ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,6 @@ linters:
 linters-settings:
   nolintlint:
     allow-unused: false
-    allow-leading-space: false
     require-specific: true
 
   govet:


### PR DESCRIPTION
`allow-leading-space: false` is not valid config anymore

```
$ golangci-lint config verify
jsonschema: "linters-settings.nolintlint" does not validate with "/properties/linters-settings/properties/nolintlint/additionalProperties": additionalProperties 'allow-leading-space' not allowed
Failed executing command with error: the configuration contains invalid elements
```

Also allow annotations:
https://github.com/golangci/golangci-lint-action/tree/v6/?tab=readme-ov-file#annotations

Needed for annotations to work:
- Permission
- setup-go (for the problem matcher)


Also set the Go version to 'stable' instead of a specific version and add 1.24 to the list.