### PR TITLE
replace time.After with Ticker

### DIFF
--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -756,14 +756,16 @@ func (b *BinlogSyncer) onStream(s *BinlogStreamer) {
 				return
 			}
 
+			ticker := time.NewTicker(time.Second)
+			defer ticker.Stop()
 			for {
 				select {
 				case <-b.ctx.Done():
 					s.close()
 					return
-				case <-time.After(time.Second):
+				case <-ticker.C:
 					b.retryCount++
-					if err = b.retrySync(); err != nil {
+					if err := b.retrySync(); err != nil {
 						if b.cfg.MaxReconnectAttempts > 0 && b.retryCount >= b.cfg.MaxReconnectAttempts {
 							b.cfg.Logger.Errorf(
 								"retry sync err: %v, exceeded max retries (%d)",


### PR DESCRIPTION
addresses #423 however as of 1.23 the issue is moot & this was never really leaking since the 1 second would generally pass

this does slightly reduce allocations, but this is on an error path, so not valuably

Implemented as proof of concept, #423 can be closed