### PR TITLE
Add BinlogEvent.ByteLen

### DIFF
--- a/replication/event.go
+++ b/replication/event.go
@@ -38,6 +38,11 @@ func (e *BinlogEvent) Dump(w io.Writer) {
 	e.Event.Dump(w)
 }
 
+// ByteLen returns the total size of the raw event data in bytes.
+func (e *BinlogEvent) ByteLen() int {
+	return len(e.RawData)
+}
+
 type Event interface {
 	// Dump Event, format like python-mysql-replication
 	Dump(w io.Writer)


### PR DESCRIPTION
Add a `.ByteLen()` method to `BinlogEvent` so we can match a `GTIDEvent`’s `TransactionLength` with the actual byte size of events.