### PR TITLE
replication: Set source_binlog_checksum as well

### DIFF
--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -319,13 +319,9 @@ func (b *BinlogSyncer) registerSlave() error {
 			// necessary checksummed.
 			// That preference is specified below.
 
-			if _, err = b.c.Execute(`SET @master_binlog_checksum='NONE'`); err != nil {
+			if _, err = b.c.Execute(`SET @master_binlog_checksum='NONE', @source_binlog_checksum='NONE'`); err != nil {
 				return errors.Trace(err)
 			}
-
-			// if _, err = b.c.Execute(`SET @master_binlog_checksum=@@global.binlog_checksum`); err != nil {
-			// 	return errors.Trace(err)
-			// }
 		}
 	}
 


### PR DESCRIPTION
See also: https://github.com/mysql/mysql-server/blob/6b6d3ed3d5c6591b446276184642d7d0504ecc86/libchangestreams/src/lib/mysql/cs/reader/binary/mysqlproto.cpp#L66

I noticed the difference when looking at packet captures with Wireshark