### PR TITLE
Give `RowsEvent` methods to inspect the underlying event type.

### DIFF
--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -1120,6 +1120,18 @@ func (e *RowsEvent) Decode(data []byte) error {
 	return e.DecodeData(pos, data)
 }
 
+func (e *RowsEvent) IsInsert() bool {
+	return e.eventType == WRITE_ROWS_EVENTv0 || e.eventType == WRITE_ROWS_EVENTv1 || e.eventType == WRITE_ROWS_EVENTv2 || e.eventType == MARIADB_WRITE_ROWS_COMPRESSED_EVENT_V1
+}
+
+func (e *RowsEvent) IsUpdate() bool {
+	return e.eventType == UPDATE_ROWS_EVENTv0 || e.eventType == UPDATE_ROWS_EVENTv1 || e.eventType == UPDATE_ROWS_EVENTv2 || e.eventType == MARIADB_UPDATE_ROWS_COMPRESSED_EVENT_V1
+}
+
+func (e *RowsEvent) IsDelete() bool {
+	return e.eventType == DELETE_ROWS_EVENTv0 || e.eventType == DELETE_ROWS_EVENTv1 || e.eventType == DELETE_ROWS_EVENTv2 || e.eventType == MARIADB_DELETE_ROWS_COMPRESSED_EVENT_V1
+}
+
 func isBitSet(bitmap []byte, i int) bool {
 	return bitmap[i>>3]&(1<<(uint(i)&7)) > 0
 }

--- a/replication/row_event_test.go
+++ b/replication/row_event_test.go
@@ -1176,6 +1176,42 @@ func TestRowsDataExtraData(t *testing.T) {
 	}
 }
 
+func TestRowsEventTypoe(t *testing.T) {
+	// _PLACEHOLDER_ := 0
+	testcases := []struct {
+		eventType EventType
+		isInsert  bool
+		isUpdate  bool
+		isDelete  bool
+	}{
+		{WRITE_ROWS_EVENTv0, true, false, false},
+		{WRITE_ROWS_EVENTv1, true, false, false},
+		{WRITE_ROWS_EVENTv2, true, false, false},
+		{MARIADB_WRITE_ROWS_COMPRESSED_EVENT_V1, true, false, false},
+		{UPDATE_ROWS_EVENTv0, false, true, false},
+		{UPDATE_ROWS_EVENTv1, false, true, false},
+		{UPDATE_ROWS_EVENTv2, false, true, false},
+		{MARIADB_UPDATE_ROWS_COMPRESSED_EVENT_V1, false, true, false},
+		{DELETE_ROWS_EVENTv0, false, false, true},
+		{DELETE_ROWS_EVENTv1, false, false, true},
+		{DELETE_ROWS_EVENTv2, false, false, true},
+		{MARIADB_DELETE_ROWS_COMPRESSED_EVENT_V1, false, false, true},
+
+		// Whoops, these are not rows events at all
+		{EXEC_LOAD_EVENT, false, false, false},
+		{HEARTBEAT_EVENT, false, false, false},
+	}
+
+	for _, tc := range testcases {
+		rev := new(RowsEvent)
+		rev.eventType = tc.eventType
+
+		require.Equal(t, tc.isInsert, rev.IsInsert())
+		require.Equal(t, tc.isUpdate, rev.IsUpdate())
+		require.Equal(t, tc.isDelete, rev.IsDelete())
+	}
+}
+
 func TestTableMapHelperMaps(t *testing.T) {
 	/*
 		CREATE TABLE `_types` (


### PR DESCRIPTION
It's currently impossible to figure out what kind of operation led to a `RowsEvent` :disappointed:
Multiple results indicate an `UPDATE`, but there's no way to differentiate an `INSERT` from a `DELETE`.

This PR implements dedicated methods to determine the event type, regardless of version and/or engine.