### PR TITLE
replication: add IsEmpty method to GTIDSet interface & implementations

### DIFF
--- a/mysql/gtid.go
+++ b/mysql/gtid.go
@@ -17,6 +17,9 @@ type GTIDSet interface {
 	Update(GTIDStr string) error
 
 	Clone() GTIDSet
+
+	// IsEmpty returns true if the given set is empty and false otherwise.
+	IsEmpty() bool
 }
 
 func ParseGTIDSet(flavor string, s string) (GTIDSet, error) {

--- a/mysql/mariadb_gtid.go
+++ b/mysql/mariadb_gtid.go
@@ -256,3 +256,7 @@ func (s *MariadbGTIDSet) Contain(o GTIDSet) bool {
 
 	return true
 }
+
+func (s *MariadbGTIDSet) IsEmpty() bool {
+	return len(s.Sets) == 0
+}

--- a/mysql/mariadb_gtid_test.go
+++ b/mysql/mariadb_gtid_test.go
@@ -243,3 +243,13 @@ func TestMariaDBGTIDSetSortedString(t *testing.T) {
 		require.Equal(t, strs[1], gtidSet.String())
 	}
 }
+
+func TestMariadbGTIDSetIsEmpty(t *testing.T) {
+	emptyGTIDSet := new(MariadbGTIDSet)
+	emptyGTIDSet.Sets = make(map[uint32]map[uint32]*MariadbGTID)
+	require.True(t, emptyGTIDSet.IsEmpty())
+
+	nonEmptyGTIDSet, err := ParseMariadbGTIDSet("0-1-2")
+	require.NoError(t, err)
+	require.False(t, nonEmptyGTIDSet.IsEmpty())
+}

--- a/mysql/mysql_gtid.go
+++ b/mysql/mysql_gtid.go
@@ -596,3 +596,7 @@ func (gtid *MysqlGTIDSet) Clone() GTIDSet {
 
 	return clone
 }
+
+func (s *MysqlGTIDSet) IsEmpty() bool {
+	return len(s.Sets) == 0
+}

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -360,3 +360,12 @@ func TestValidateFlavor(t *testing.T) {
 		}
 	}
 }
+
+func TestMysqlGTIDSetIsEmpty(t *testing.T) {
+	emptyGTIDSet := new(MysqlGTIDSet)
+	emptyGTIDSet.Sets = make(map[string]*UUIDSet)
+	require.True(t, emptyGTIDSet.IsEmpty())
+
+	nonEmptyGTIDSet := mysqlGTIDfromString(t, "de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2")
+	require.False(t, nonEmptyGTIDSet.IsEmpty())
+}


### PR DESCRIPTION
Small quality of life improvement. For some use cases (such as writing tests), it is common to want to check if a given GTID set is empty or not. Currently this requires using `Equal()` with an empty GTID set (which takes a decent amount of boilerplate) or else requires inspecting the `Set` field (which is specific to a single concrete implementation of the `GTIDSet` interface).

This commits adds a simple `IsEmpty() bool` method to the `GTIDSet` interface for this use case, as well as implementations for both `MysqlGTIDSet` and `MariadbGTIDSet`.