### PR TITLE
server: Rework NewConn/defaultServer

### DIFF
--- a/cmd/go-mysqlserver/main.go
+++ b/cmd/go-mysqlserver/main.go
@@ -26,7 +26,8 @@ func main() {
 
 	// Create a connection with user root and an empty password.
 	// You can use your own handler to handle command here.
-	conn, err := server.NewConn(c, "root", "", server.EmptyHandler{})
+	srv := server.NewDefaultServer()
+	conn, err := srv.NewConn(c, "root", "", server.EmptyHandler{})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/driver/driver_options_test.go
+++ b/driver/driver_options_test.go
@@ -275,6 +275,8 @@ func CreateMockServer(t *testing.T) *testServer {
 
 	handler := &mockHandler{}
 
+	s := server.NewDefaultServer()
+
 	go func() {
 		for {
 			conn, err := l.Accept()
@@ -283,7 +285,7 @@ func CreateMockServer(t *testing.T) *testServer {
 			}
 
 			go func() {
-				co, err := server.NewCustomizedConn(conn, defaultServer, inMemProvider, handler)
+				co, err := s.NewCustomizedConn(conn, inMemProvider, handler)
 				if err != nil {
 					return
 				}

--- a/server/conn.go
+++ b/server/conn.go
@@ -36,8 +36,10 @@ type Conn struct {
 	closed atomic.Bool
 }
 
-var baseConnID uint32 = 10000
-var defaultServer *Server
+var (
+	baseConnID    uint32 = 10000
+	defaultServer *Server
+)
 
 // NewConn: create connection with default server settings
 //

--- a/server/conn.go
+++ b/server/conn.go
@@ -41,7 +41,6 @@ var defaultServer *Server
  // NewConn: create connection with default server settings
 //
 // Deprecated: Use [Server.NewConn] instead.
-// Deprecated: Use [Server.NewConn] instead.
 func NewConn(conn net.Conn, user string, password string, h Handler) (*Conn, error) {
 	if defaultServer == nil {
 		defaultServer = NewDefaultServer()

--- a/server/conn.go
+++ b/server/conn.go
@@ -3,6 +3,7 @@ package server
 import (
 	"errors"
 	"net"
+	"sync"
 	"sync/atomic"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
@@ -38,17 +39,16 @@ type Conn struct {
 
 var (
 	baseConnID    uint32 = 10000
-	defaultServer *Server
+	defaultServer        = sync.OnceValue(func() *Server {
+		return NewDefaultServer()
+	})
 )
 
 // NewConn: create connection with default server settings
 //
 // Deprecated: Use [Server.NewConn] instead.
 func NewConn(conn net.Conn, user string, password string, h Handler) (*Conn, error) {
-	if defaultServer == nil {
-		defaultServer = NewDefaultServer()
-	}
-	return defaultServer.NewConn(conn, user, password, h)
+	return defaultServer().NewConn(conn, user, password, h)
 }
 
 // NewCustomizedConn: create connection with customized server settings

--- a/server/conn.go
+++ b/server/conn.go
@@ -48,7 +48,6 @@ func NewConn(conn net.Conn, user string, password string, h Handler) (*Conn, err
 // NewCustomizedConn: create connection with customized server settings
 //
 // Deprecated: Use [Server.NewConn] instead.
-
 // NewCustomizedConn: create connection with customized server settings
 // Deprecated: Use Server.NewConn instead.
 func NewCustomizedConn(conn net.Conn, serverConf *Server, p CredentialProvider, h Handler) (*Conn, error) {

--- a/server/conn.go
+++ b/server/conn.go
@@ -46,8 +46,9 @@ func NewConn(conn net.Conn, user string, password string, h Handler) (*Conn, err
 	if defaultServer == nil {
 		defaultServer = NewDefaultServer()
 	}
-	return defaultServer.NewConn(conn, user, password, h)
-}
+// NewCustomizedConn: create connection with customized server settings
+//
+// Deprecated: Use [Server.NewConn] instead.
 
 // NewCustomizedConn: create connection with customized server settings
 // Deprecated: Use Server.NewConn instead.

--- a/server/conn.go
+++ b/server/conn.go
@@ -37,12 +37,15 @@ type Conn struct {
 }
 
 var baseConnID uint32 = 10000
+var defaultServer *Server
 
 // NewConn: create connection with default server settings
 // Deprecated: Use Server.NewConn instead.
 func NewConn(conn net.Conn, user string, password string, h Handler) (*Conn, error) {
-	s := NewDefaultServer()
-	return s.NewConn(conn, user, password, h)
+	if defaultServer == nil {
+		defaultServer = NewDefaultServer()
+	}
+	return defaultServer.NewConn(conn, user, password, h)
 }
 
 // NewCustomizedConn: create connection with customized server settings

--- a/server/conn.go
+++ b/server/conn.go
@@ -40,8 +40,8 @@ var baseConnID uint32 = 10000
 var defaultServer *Server
  // NewConn: create connection with default server settings
 //
-// Deprecated: Use Server.NewConn instead.
-// Deprecated: Use Server.NewConn instead.
+// Deprecated: Use [Server.NewConn] instead.
+// Deprecated: Use [Server.NewConn] instead.
 func NewConn(conn net.Conn, user string, password string, h Handler) (*Conn, error) {
 	if defaultServer == nil {
 		defaultServer = NewDefaultServer()

--- a/server/conn.go
+++ b/server/conn.go
@@ -38,18 +38,19 @@ type Conn struct {
 
 var baseConnID uint32 = 10000
 var defaultServer *Server
- // NewConn: create connection with default server settings
+
+// NewConn: create connection with default server settings
 //
 // Deprecated: Use [Server.NewConn] instead.
 func NewConn(conn net.Conn, user string, password string, h Handler) (*Conn, error) {
 	if defaultServer == nil {
 		defaultServer = NewDefaultServer()
 	}
+}
+
 // NewCustomizedConn: create connection with customized server settings
 //
 // Deprecated: Use [Server.NewConn] instead.
-// NewCustomizedConn: create connection with customized server settings
-// Deprecated: Use Server.NewConn instead.
 func NewCustomizedConn(conn net.Conn, serverConf *Server, p CredentialProvider, h Handler) (*Conn, error) {
 	return serverConf.NewCustomizedConn(conn, p, h)
 }

--- a/server/conn.go
+++ b/server/conn.go
@@ -46,6 +46,7 @@ func NewConn(conn net.Conn, user string, password string, h Handler) (*Conn, err
 	if defaultServer == nil {
 		defaultServer = NewDefaultServer()
 	}
+	return defaultServer.NewConn(conn, user, password, h)
 }
 
 // NewCustomizedConn: create connection with customized server settings

--- a/server/conn.go
+++ b/server/conn.go
@@ -53,7 +53,7 @@ func NewConn(conn net.Conn, user string, password string, h Handler) (*Conn, err
 
 // NewCustomizedConn: create connection with customized server settings
 //
-// Deprecated: Use [Server.NewConn] instead.
+// Deprecated: Use [Server.NewCustomizedConn] instead.
 func NewCustomizedConn(conn net.Conn, serverConf *Server, p CredentialProvider, h Handler) (*Conn, error) {
 	return serverConf.NewCustomizedConn(conn, p, h)
 }

--- a/server/conn.go
+++ b/server/conn.go
@@ -38,8 +38,9 @@ type Conn struct {
 
 var baseConnID uint32 = 10000
 var defaultServer *Server
-
-// NewConn: create connection with default server settings
+ // NewConn: create connection with default server settings
+//
+// Deprecated: Use Server.NewConn instead.
 // Deprecated: Use Server.NewConn instead.
 func NewConn(conn net.Conn, user string, password string, h Handler) (*Conn, error) {
 	if defaultServer == nil {

--- a/server/server_conf.go
+++ b/server/server_conf.go
@@ -8,8 +8,6 @@ import (
 	"github.com/go-mysql-org/go-mysql/mysql"
 )
 
-var defaultServer = NewDefaultServer()
-
 // Defines a basic MySQL server with configs.
 //
 // We do not aim at implementing the whole MySQL connection suite to have the best compatibilities for the clients.


### PR DESCRIPTION
Closes #1020 

- De-duplicate `NewConn()` and `NewCustomizedConn()` code
- Only call `NewDefaultServer()` when needed