### PR TITLE
server: Fix formatting of credential provider note

### DIFF
--- a/server/credential_provider.go
+++ b/server/credential_provider.go
@@ -5,7 +5,9 @@ import "sync"
 // interface for user credential provider
 // hint: can be extended for more functionality
 //
-// Note: if the password in a third-party credential provider could be updated at runtime, we have to invalidate the caching
+// # Important Note
+//
+// if the password in a third-party credential provider could be updated at runtime, we have to invalidate the caching
 // for 'caching_sha2_password' by calling 'func (s *Server)InvalidateCache(string, string)'.
 type CredentialProvider interface {
 	// check if the user exists

--- a/server/credential_provider.go
+++ b/server/credential_provider.go
@@ -4,8 +4,8 @@ import "sync"
 
 // interface for user credential provider
 // hint: can be extended for more functionality
-// =================================IMPORTANT NOTE===============================
-// if the password in a third-party credential provider could be updated at runtime, we have to invalidate the caching
+//
+// Note: if the password in a third-party credential provider could be updated at runtime, we have to invalidate the caching
 // for 'caching_sha2_password' by calling 'func (s *Server)InvalidateCache(string, string)'.
 type CredentialProvider interface {
 	// check if the user exists


### PR DESCRIPTION
Fixes this:

![image](https://github.com/user-attachments/assets/1d07f78e-b661-4e3b-bf07-3f6c4681d95d)

An alternative:
```patch
diff --git a/server/credential_provider.go b/server/credential_provider.go
index 3d44eb0..5333f89 100644
--- a/server/credential_provider.go
+++ b/server/credential_provider.go
@@ -4,7 +4,9 @@ import "sync"
 
 // interface for user credential provider
 // hint: can be extended for more functionality
+//
 // =================================IMPORTANT NOTE===============================
+//
 // if the password in a third-party credential provider could be updated at runtime, we have to invalidate the caching
 // for 'caching_sha2_password' by calling 'func (s *Server)InvalidateCache(string, string)'.
 type CredentialProvider interface {
```