### PR TITLE
client: make CLIENT_QUERY_ATTRIBUTES opt-out to restore proxy compatibility

### DIFF
--- a/client/conn.go
+++ b/client/conn.go
@@ -45,7 +45,8 @@ type Conn struct {
 	capability uint32
 	// client-set capabilities only
 	ccaps uint32
-	dcaps uint32 // disabled capabilities
+	// Flags explicitly disabled via SetCapability/UnsetCapability
+	clientExplicitOffCaps uint32
 
 	attributes map[string]string
 
@@ -237,14 +238,14 @@ func (c *Conn) Ping() error {
 
 // SetCapability enables the use of a specific capability
 func (c *Conn) SetCapability(cap uint32) {
-	c.dcaps &^= cap
 	c.ccaps |= cap
+	c.clientExplicitOffCaps &^= cap
 }
 
 // UnsetCapability disables the use of a specific capability
 func (c *Conn) UnsetCapability(cap uint32) {
 	c.ccaps &^= cap
-	c.dcaps |= cap
+	c.clientExplicitOffCaps |= cap
 }
 
 // HasCapability returns true if the connection has the specific capability

--- a/client/conn.go
+++ b/client/conn.go
@@ -45,7 +45,8 @@ type Conn struct {
 	capability uint32
 	// client-set capabilities only
 	ccaps uint32
-	// Flags explicitly disabled via SetCapability/UnsetCapability
+	// Capability flags explicitly disabled by the client via UnsetCapability()
+	// These flags are removed from the final advertised capability set during handshake.
 	clientExplicitOffCaps uint32
 
 	attributes map[string]string
@@ -236,13 +237,14 @@ func (c *Conn) Ping() error {
 	return nil
 }
 
-// SetCapability enables the use of a specific capability
+// SetCapability marks the specified flag as explicitly enabled by the client.
 func (c *Conn) SetCapability(cap uint32) {
 	c.ccaps |= cap
 	c.clientExplicitOffCaps &^= cap
 }
 
-// UnsetCapability disables the use of a specific capability
+// UnsetCapability marks the specified flag as explicitly disabled by the client.
+// This disables the flag even if the server supports it.
 func (c *Conn) UnsetCapability(cap uint32) {
 	c.ccaps &^= cap
 	c.clientExplicitOffCaps |= cap

--- a/client/conn.go
+++ b/client/conn.go
@@ -45,6 +45,7 @@ type Conn struct {
 	capability uint32
 	// client-set capabilities only
 	ccaps uint32
+	dcaps uint32 // disabled capabilities
 
 	attributes map[string]string
 
@@ -236,12 +237,14 @@ func (c *Conn) Ping() error {
 
 // SetCapability enables the use of a specific capability
 func (c *Conn) SetCapability(cap uint32) {
+	c.dcaps &^= cap
 	c.ccaps |= cap
 }
 
 // UnsetCapability disables the use of a specific capability
 func (c *Conn) UnsetCapability(cap uint32) {
-	c.ccaps &= ^cap
+	c.ccaps &^= cap
+	c.dcaps |= cap
 }
 
 // HasCapability returns true if the connection has the specific capability


### PR DESCRIPTION
### Background — why proxies built with this SDK break

https://github.com/masahide/mysql8-audit-proxy/issues/8

A common architecture for a MySQL **audit / filter / router** built on *go-mysql* looks like this:

```
[application] -- go-mysql/server  -->  [proxy]  -- go-mysql/client -->  [mysqld]
```

* **Downstream side** (`go-mysql/server`)
  *Implements the old 5.7/8.0 protocol* and **does not recognise
  `CLIENT_QUERY_ATTRIBUTES`**.
  When an application connects, the handshake therefore has the bit **cleared**.

* **Upstream side** (`go-mysql/client` ≥ v1.12.0)
  In `writeAuthHandshake()` the client **automatically copies
  `CLIENT_QUERY_ATTRIBUTES` from the server greeting**, claiming the proxy
  will send query attributes.

* **Mismatch**
  The proxy simply forwards the raw `COM_QUERY` it received from the
  application.
  Because the downstream never added the attributes section, the packet sent
  upstream is missing mandatory fields → MySQL returns
  **`ERROR 1835 (HY000) Malformed communication packet.`**

### What the proxy author needs

A way to say **“don’t advertise `CLIENT_QUERY_ATTRIBUTES` on the upstream
connection even if the server supports it, because my downstream side can’t
handle that mode.”**

Currently that is impossible: `UnsetCapability()` removes the flag from
`ccaps`, but `writeAuthHandshake()` puts it back from the server’s flag set.

### Patch overview

1. **Add `dcaps` (“deny caps”)** to `client.Conn` to track flags explicitly
   disabled by the caller.

2. Modify `SetCapability` / `UnsetCapability`:

   ```go
   SetCapability(x): ccaps |= x ; dcaps &^= x
   UnsetCapability(x): ccaps &^= x ; dcaps |= x
   ```

3. In `writeAuthHandshake()`:

   ```go
   inherit := c.capability &^ c.dcaps          // server flags minus explicit denies
   // ...
   // Advertise QUERY_ATTRIBUTES only if:
   //   a) caller opted-in  OR
   //   b) server supports it AND caller did NOT opt-out
   ```

4. Store the final negotiated set back into `c.capability` for later use.

### Resulting behaviour

| Scenario                | Downstream (server pkg) | Proxy call                                 | Upstream handshake |
| ----------------------- | ----------------------- | ------------------------------------------ | ------------------ |
| **Default**             | no support              | none                                       | bit **set** (auto) |
| Proxy wants legacy mode | no support              | `UnsetCapability(CLIENT_QUERY_ATTRIBUTES)` | bit **cleared**    |
| Force new mode anyway   | anything                | `SetCapability(CLIENT_QUERY_ATTRIBUTES)`   | bit **set**        |

### Example — disabling the flag in a proxy

```go
backend, _ := client.Connect(
    upstreamAddr, user, pass, db,
    func(c *client.Conn) error {
        c.UnsetCapability(mysql.CLIENT_QUERY_ATTRIBUTES)
        return nil
    },
)
```

With this one-liner the proxy once again works with both modern MySQL servers
and the existing `go-mysql/server` front end.

### Safety & compatibility

* **No API break** – existing code compiles; only behaviour changes when the
  caller explicitly opts out.
* Maintains the convenient “auto-enable” path for direct clients.
* Restores plug-and-play compatibility for every proxy built on
  *go-mysql/server*.


