### PR TITLE
Checks if there is an error in the streamer.

### DIFF
--- a/replication/binlogstreamer.go
+++ b/replication/binlogstreamer.go
@@ -118,3 +118,13 @@ func (s *BinlogStreamer) AddErrorToStreamer(err error) bool {
 		return false
 	}
 }
+
+// IsErrorInStreamer checks if there is an error in the streamer.
+func (s *BinlogStreamer) IsErrorInStreamer() bool {
+	select {
+	case err := <-s.ech:
+		return err != nil
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
Hi there. I have a scenario when I'd like to stop my app after this error appears in the logs:
```
[error] binlogstreamer.go:78 close sync with err: ERROR 1236 (HY000): Could not find first log file name in binary log index file
```
I see **BinlogStreamer** has all the necessary private fields, but I can't access them from the outside:
```go
type BinlogStreamer struct {
	ch  chan *BinlogEvent
	ech chan error
	err error
}
```
So, as a possible solution I implemented a new one public method (getter) to fetch the actual state of streamer:
```go
func (s *BinlogStreamer) IsErrorInStreamer() bool {
	select {
	case err := <-s.ech:
		return err != nil
	default:
		return false
	}
}
```
There maybe a more appropriate approach to achieve this goal, but this one seems good to me. What do you think?
Thanks.