### PR TITLE
Preserve type for binary protocol parameters in prepared statements

### DIFF
--- a/client/stmt.go
+++ b/client/stmt.go
@@ -156,6 +156,9 @@ func (s *Stmt) write(args ...interface{}) error {
 		case []byte:
 			paramTypes[i] = []byte{mysql.MYSQL_TYPE_STRING}
 			paramValues[i] = append(mysql.PutLengthEncodedInt(uint64(len(v))), v...)
+		case mysql.TypedBytes:
+			paramTypes[i] = []byte{v.Type}
+			paramValues[i] = append(mysql.PutLengthEncodedInt(uint64(len(v.Bytes))), v.Bytes...)
 		case json.RawMessage:
 			paramTypes[i] = []byte{mysql.MYSQL_TYPE_STRING}
 			paramValues[i] = append(mysql.PutLengthEncodedInt(uint64(len(v))), v...)

--- a/mysql/typed_bytes.go
+++ b/mysql/typed_bytes.go
@@ -1,0 +1,8 @@
+package mysql
+
+// TypedBytes preserves the original MySQL type alongside the raw bytes
+// for binary protocol parameters that are length-encoded.
+type TypedBytes struct {
+	Type  byte   // Original MySQL type
+	Bytes []byte // Raw bytes
+}

--- a/server/stmt.go
+++ b/server/stmt.go
@@ -300,7 +300,7 @@ func (c *Conn) bindStmtArgs(s *Stmt, nullBitmap, paramTypes, paramValues []byte)
 			}
 
 			if !isNull {
-				args[i] = v
+				args[i] = mysql.TypedBytes{Type: tp, Bytes: v}
 				continue
 			} else {
 				args[i] = nil


### PR DESCRIPTION
When `bindStmtArgs` parses binary protocol parameters, the MySQL type is available in `paramTypes`. However, the library loses this type information when passing the parsed values to the `Handler.HandleStmtExecute` callback: it converts length-encoded parameters (datetime, varchar, blob, etc.) to plain `[]byte` and drops the type.

This creates problems for proxies: when forwarding these parameters to a backend, the client sees `[]byte` and sends them as `MYSQL_TYPE_STRING`, even if the original type was `MYSQL_TYPE_DATETIME` or another type. Some server implementations strictly validate parameter types and reject this mismatch.

This PR introduces a simple `TypedBytes` struct that preserves the original MySQL type alongside the raw bytes. `Handler.HandleStmtExecute` callback now receives this struct instead of `[]byte` for length-encoded parameters, and `client.Stmt` also handles `TypedBytes` by using the preserved type when sending to servers.