### PR TITLE
Handle empty password from broader set of MySQL clients

### DIFF
--- a/server/auth_switch_response.go
+++ b/server/auth_switch_response.go
@@ -71,7 +71,7 @@ func (c *Conn) handleCachingSha2PasswordFullAuth(authData []byte) error {
 }
 
 func (c *Conn) checkSha2CacheCredentials(clientAuthData []byte, credential Credential) error {
-	if len(clientAuthData) == 0 {
+	if isEmptyPassword(clientAuthData) {
 		if credential.hasEmptyPassword() {
 			return nil
 		}

--- a/server/auth_switch_response_test.go
+++ b/server/auth_switch_response_test.go
@@ -25,6 +25,18 @@ func TestCheckSha2CacheCredentials_EmptyPassword(t *testing.T) {
 			serverPassword: "secret",
 			wantErr:        ErrAccessDeniedNoPassword,
 		},
+		{
+			name:           "null byte client auth, empty server password",
+			clientAuthData: []byte{0x00},
+			serverPassword: "",
+			wantErr:        nil,
+		},
+		{
+			name:           "null byte client auth, non-empty server password",
+			clientAuthData: []byte{0x00},
+			serverPassword: "secret",
+			wantErr:        ErrAccessDeniedNoPassword,
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -32,6 +32,18 @@ func TestCompareNativePasswordAuthData_EmptyPassword(t *testing.T) {
 			serverPassword: "secret",
 			wantErr:        ErrAccessDeniedNoPassword,
 		},
+		{
+			name:           "null byte client auth, empty server password",
+			clientAuthData: []byte{0x00},
+			serverPassword: "",
+			wantErr:        nil,
+		},
+		{
+			name:           "null byte client auth, non-empty server password",
+			clientAuthData: []byte{0x00},
+			serverPassword: "secret",
+			wantErr:        ErrAccessDeniedNoPassword,
+		},
 	}
 
 	for _, tt := range tests {
@@ -68,6 +80,18 @@ func TestCompareSha256PasswordAuthData_EmptyPassword(t *testing.T) {
 			serverPassword: "secret",
 			wantErr:        ErrAccessDeniedNoPassword,
 		},
+		{
+			name:           "null byte client auth, empty server password",
+			clientAuthData: []byte{0x00},
+			serverPassword: "",
+			wantErr:        nil,
+		},
+		{
+			name:           "null byte client auth, non-empty server password",
+			clientAuthData: []byte{0x00},
+			serverPassword: "secret",
+			wantErr:        ErrAccessDeniedNoPassword,
+		},
 	}
 
 	for _, tt := range tests {
@@ -101,6 +125,18 @@ func TestCompareCacheSha2PasswordAuthData_EmptyPassword(t *testing.T) {
 		{
 			name:           "empty client auth, non-empty server password",
 			clientAuthData: []byte{},
+			serverPassword: "secret",
+			wantErr:        ErrAccessDeniedNoPassword,
+		},
+		{
+			name:           "null byte client auth, empty server password",
+			clientAuthData: []byte{0x00},
+			serverPassword: "",
+			wantErr:        nil,
+		},
+		{
+			name:           "null byte client auth, non-empty server password",
+			clientAuthData: []byte{0x00},
 			serverPassword: "secret",
 			wantErr:        ErrAccessDeniedNoPassword,
 		},


### PR DESCRIPTION
Some MySQL clients (e.g. libmysql) send a single null byte to indicate an empty password, while others (e.g. mariadb) send an empty packet. This matches MySQL server's own handling:

```c
if (!pkt_len || (pkt_len == 1 && *pkt == 0))
```

(Source: https://github.com/mysql/mysql-server/blob/8.0/sql/auth/sha2_password.cc)
