### PR TITLE
Decouple RSA auth key from TLS config

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -118,7 +118,10 @@ func (c *Conn) compareSha256PasswordAuthData(clientAuthData []byte, credential C
 	} else {
 		// client should send encrypted password
 		// decrypt
-		dbytes, err := rsa.DecryptOAEP(sha1.New(), rand.Reader, (c.serverConf.tlsConfig.Certificates[0].PrivateKey).(*rsa.PrivateKey), clientAuthData, nil)
+		if c.serverConf.rsaPrivateKey == nil {
+			return errors.New("RSA key not configured; non-TLS connections are not supported for this authentication method")
+		}
+		dbytes, err := rsa.DecryptOAEP(sha1.New(), rand.Reader, c.serverConf.rsaPrivateKey, clientAuthData, nil)
 		if err != nil {
 			return err
 		}

--- a/server/auth_switch_response.go
+++ b/server/auth_switch_response.go
@@ -51,7 +51,10 @@ func (c *Conn) handleCachingSha2PasswordFullAuth(authData []byte) error {
 		}
 		// the encrypted password
 		// decrypt
-		dbytes, err := rsa.DecryptOAEP(sha1.New(), rand.Reader, (c.serverConf.tlsConfig.Certificates[0].PrivateKey).(*rsa.PrivateKey), authData, nil)
+		if c.serverConf.rsaPrivateKey == nil {
+			return errors.New("RSA key not configured; non-TLS connections are not supported for this authentication method")
+		}
+		dbytes, err := rsa.DecryptOAEP(sha1.New(), rand.Reader, c.serverConf.rsaPrivateKey, authData, nil)
 		if err != nil {
 			return err
 		}

--- a/server/caching_sha2_cache_test.go
+++ b/server/caching_sha2_cache_test.go
@@ -28,7 +28,7 @@ func TestCachingSha2Cache(t *testing.T) {
 		InMemoryAuthenticationHandler: NewInMemoryAuthenticationHandler(),
 	}
 	require.NoError(t, remoteProvider.AddUser(*testUser, *testPassword))
-	cacheServer := NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_CACHING_SHA2_PASSWORD, test_keys.PubPem, tlsConf)
+	cacheServer := NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_CACHING_SHA2_PASSWORD, test_keys.RSAKey(), tlsConf)
 
 	// no TLS
 	suite.Run(t, &cacheTestSuite{
@@ -43,7 +43,7 @@ func TestCachingSha2CacheTLS(t *testing.T) {
 		InMemoryAuthenticationHandler: NewInMemoryAuthenticationHandler(),
 	}
 	require.NoError(t, remoteProvider.AddUser(*testUser, *testPassword))
-	cacheServer := NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_CACHING_SHA2_PASSWORD, test_keys.PubPem, tlsConf)
+	cacheServer := NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_CACHING_SHA2_PASSWORD, test_keys.RSAKey(), tlsConf)
 
 	// TLS
 	suite.Run(t, &cacheTestSuite{

--- a/server/resp.go
+++ b/server/resp.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
@@ -94,9 +95,12 @@ func (c *Conn) readAuthSwitchRequestResponse() ([]byte, error) {
 }
 
 func (c *Conn) writeAuthMoreDataPubkey() error {
+	if len(c.serverConf.rsaPublicKeyBytes) == 0 {
+		return errors.New("RSA key not configured; non-TLS connections are not supported for this authentication method")
+	}
 	data := make([]byte, 4)
 	data = append(data, mysql.MORE_DATE_HEADER)
-	data = append(data, c.serverConf.pubKey...)
+	data = append(data, c.serverConf.rsaPublicKeyBytes...)
 	return c.WritePacket(data)
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -35,25 +35,25 @@ func prepareServerConf() []*Server {
 		NewDefaultServer(),
 		// for key exchange, CLIENT_SSL must be enabled for the server and if the connection is not secured with TLS
 		// server permits MYSQL_NATIVE_PASSWORD only
-		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_NATIVE_PASSWORD, test_keys.PubPem, tlsConf),
-		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_NATIVE_PASSWORD, test_keys.PubPem, tlsConf),
+		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_NATIVE_PASSWORD, test_keys.RSAKey(), tlsConf),
+		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_NATIVE_PASSWORD, test_keys.RSAKey(), tlsConf),
 		// server permits SHA256_PASSWORD only
-		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_SHA256_PASSWORD, test_keys.PubPem, tlsConf),
+		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_SHA256_PASSWORD, test_keys.RSAKey(), tlsConf),
 		// server permits CACHING_SHA2_PASSWORD only
-		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_CACHING_SHA2_PASSWORD, test_keys.PubPem, tlsConf),
+		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_CACHING_SHA2_PASSWORD, test_keys.RSAKey(), tlsConf),
 
 		// test auth switch: server permits SHA256_PASSWORD only but sent different method MYSQL_NATIVE_PASSWORD in handshake response
-		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_NATIVE_PASSWORD, test_keys.PubPem, tlsConf),
+		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_NATIVE_PASSWORD, test_keys.RSAKey(), tlsConf),
 		// test auth switch: server permits CACHING_SHA2_PASSWORD only but sent different method MYSQL_NATIVE_PASSWORD in handshake response
-		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_NATIVE_PASSWORD, test_keys.PubPem, tlsConf),
+		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_NATIVE_PASSWORD, test_keys.RSAKey(), tlsConf),
 		// test auth switch: server permits CACHING_SHA2_PASSWORD only but sent different method SHA256_PASSWORD in handshake response
-		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_SHA256_PASSWORD, test_keys.PubPem, tlsConf),
+		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_SHA256_PASSWORD, test_keys.RSAKey(), tlsConf),
 		// test auth switch: server permits MYSQL_NATIVE_PASSWORD only but sent different method SHA256_PASSWORD in handshake response
-		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_SHA256_PASSWORD, test_keys.PubPem, tlsConf),
+		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_SHA256_PASSWORD, test_keys.RSAKey(), tlsConf),
 		// test auth switch: server permits SHA256_PASSWORD only but sent different method CACHING_SHA2_PASSWORD in handshake response
-		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_CACHING_SHA2_PASSWORD, test_keys.PubPem, tlsConf),
+		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_CACHING_SHA2_PASSWORD, test_keys.RSAKey(), tlsConf),
 		// test auth switch: server permits MYSQL_NATIVE_PASSWORD only but sent different method CACHING_SHA2_PASSWORD in handshake response
-		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_CACHING_SHA2_PASSWORD, test_keys.PubPem, tlsConf),
+		NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_CACHING_SHA2_PASSWORD, test_keys.RSAKey(), tlsConf),
 	}
 	return servers
 }

--- a/test_util/test_keys/keys.go
+++ b/test_util/test_keys/keys.go
@@ -1,5 +1,11 @@
 package test_keys
 
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+)
+
 // here we put the testing encryption keys here
 // NOTE THIS IS FOR TESTING ONLY, DO NOT USE THEM IN PRODUCTION!
 
@@ -83,3 +89,16 @@ cAQGzzYpbUCIv7ciSB93cKkU73fQLZVy5ZBy1+oAa1V9U4cb4G/20/PDmT+G3Gxz
 pEjeDKtz8XINoWgA2cSdfAhNZt5vqJaCIZ8qN0z6C7SUKwUBderERUMLUXdhUldC
 KTVHyEPvd0aULd5S5vEpKCnHcQmFcLdoN8t9k9pR9ZgwqXbyJHlxWFo=
 -----END CERTIFICATE-----`)
+
+// RSAKey returns the parsed RSA private key from KeyPem
+func RSAKey() *rsa.PrivateKey {
+	block, _ := pem.Decode(KeyPem)
+	if block == nil {
+		panic("failed to decode KeyPem")
+	}
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		panic(err)
+	}
+	return key
+}


### PR DESCRIPTION
Decouple the RSA private key used for `caching_sha2_password` authentication from the TLS configuration by accepting it as a separate parameter.

Without this PR, the RSA key is always extracted from `tlsConfig.Certificates[0]`. This coupling causes issues when using GetCertificate for dynamic certificate loading (e.g., certificate rotation, or serving different certs per connection):

- Go's TLS only calls `GetCertificate` when `Certificates` is empty OR the client sends SNI
- MySQL clients don't send SNI during the TLS handshake
- Therefore, if `Certificates` was populated (to provide the RSA key), the server would serve that certificate instead of calling `GetCertificate`

This is particularly problematic when the TLS certificate uses ECDSA (common with modern CAs like Let's Encrypt and ZeroSSL) but RSA is still needed for the `caching_sha2_password` authentication flow over non-TLS connections.

To fix this, we pass the RSA private key directly to `NewServerWithAuth`. It allows users to:
- Use `GetCertificate` for TLS without populating `Certificates`
- Use ECDSA certificates for TLS while still supporting `caching_sha2_password` non-TLS connections
- Rotate TLS certificates dynamically without affecting authentication

Note: I can add a new constructor if you don't want to break the API on existing ones.
