### PR TITLE
replication: binlog event flags

### DIFF
--- a/replication/const.go
+++ b/replication/const.go
@@ -290,3 +290,13 @@ const (
 	OTW_HB_LOG_FILENAME_FIELD
 	OTW_HB_LOG_POSITION_FIELD
 )
+
+// Constants for binlog event flags
+// Source: https://github.com/mysql/mysql-server/blob/447eb26e094b444a88c532028647e48228c3c04f/libs/mysql/binlog/event/rows_event.h#L891-L910
+const (
+	STMT_END_F = 1 << iota
+	NO_FOREIGN_KEY_CHECKS_F
+	RELAXED_UNIQUE_CHECKS_F
+	COMPLETE_ROWS_F
+	USE_SQL_FOREIGN_KEY_F
+)


### PR DESCRIPTION
This is how they look in `mysqlbinlog`:

```
# at 744
#260204 17:50:51 server id 123  end_log_pos 794 CRC32 0xec1db56b 
# Position  Timestamp   Type   Source ID        Size      Source Pos    Flags 
# 000002e8 eb 78 83 69   1e   7b 00 00 00   32 00 00 00   1a 03 00 00   00 00
# 000002fb 5a 00 00 00 00 00 11 00  02 00 01 ff 00 01 00 00 |Z...............|
# 0000030b 00 00 02 00 00 00 00 03  00 00 00 6b b5 1d ec    |...........k...|
# 	Write_rows: table id 90 flags: STMT_END_F USE_SQL_FOREIGN_KEY_F
```

Note that `USE_SQL_FOREIGN_KEY_F` seems to be new (9.6.0) and related to this: https://blogs.oracle.com/mysql/no-more-hidden-changes-how-mysql-9-6-transforms-foreign-key-management