### PR TITLE
replication: decode unsigned integer types correctly in RowsEvent

### DIFF
--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -1188,6 +1188,7 @@ func (e *RowsEvent) decodeImage(data []byte, bitmap []byte, rowImageType EnumRow
 	}
 
 	row := make([]any, e.ColumnCount)
+	unsignedMap := e.Table.UnsignedMap()
 
 	// refer: https://github.com/alibaba/canal/blob/c3e38e50e269adafdd38a48c63a1740cde304c67/dbsync/src/main/java/com/taobao/tddl/dbsync/binlog/event/RowsLogBuffer.java#L63
 	count := 0
@@ -1230,7 +1231,7 @@ func (e *RowsEvent) decodeImage(data []byte, bitmap []byte, rowImageType EnumRow
 
 		var n int
 		var err error
-		row[i], n, err = e.decodeValue(data[pos:], e.Table.ColumnType[i], e.Table.ColumnMeta[i], isPartial)
+		row[i], n, err = e.decodeValue(data[pos:], e.Table.ColumnType[i], e.Table.ColumnMeta[i], isPartial, unsignedMap[i])
 		if err != nil {
 			return 0, err
 		}
@@ -1258,7 +1259,7 @@ func (e *RowsEvent) parseFracTime(t any) any {
 }
 
 // see mysql sql/log_event.cc log_event_print_value
-func (e *RowsEvent) decodeValue(data []byte, tp byte, meta uint16, isPartial bool) (v any, n int, err error) {
+func (e *RowsEvent) decodeValue(data []byte, tp byte, meta uint16, isPartial bool, isUnsigned bool) (v any, n int, err error) {
 	length := 0
 
 	if tp == mysql.MYSQL_TYPE_STRING {
@@ -1283,19 +1284,39 @@ func (e *RowsEvent) decodeValue(data []byte, tp byte, meta uint16, isPartial boo
 		return nil, 0, nil
 	case mysql.MYSQL_TYPE_LONG:
 		n = 4
-		v = mysql.ParseBinaryInt32(data)
+		if isUnsigned {
+			v = mysql.ParseBinaryUint32(data)
+		} else {
+			v = mysql.ParseBinaryInt32(data)
+		}
 	case mysql.MYSQL_TYPE_TINY:
 		n = 1
-		v = mysql.ParseBinaryInt8(data)
+		if isUnsigned {
+			v = mysql.ParseBinaryUint8(data)
+		} else {
+			v = mysql.ParseBinaryInt8(data)
+		}
 	case mysql.MYSQL_TYPE_SHORT:
 		n = 2
-		v = mysql.ParseBinaryInt16(data)
+		if isUnsigned {
+			v = mysql.ParseBinaryUint16(data)
+		} else {
+			v = mysql.ParseBinaryInt16(data)
+		}
 	case mysql.MYSQL_TYPE_INT24:
 		n = 3
-		v = mysql.ParseBinaryInt24(data)
+		if isUnsigned {
+			v = mysql.ParseBinaryUint24(data)
+		} else {
+			v = mysql.ParseBinaryInt24(data)
+		}
 	case mysql.MYSQL_TYPE_LONGLONG:
 		n = 8
-		v = mysql.ParseBinaryInt64(data)
+		if isUnsigned {
+			v = mysql.ParseBinaryUint64(data)
+		} else {
+			v = mysql.ParseBinaryInt64(data)
+		}
 	case mysql.MYSQL_TYPE_NEWDECIMAL:
 		prec := uint8(meta >> 8)
 		scale := uint8(meta & 0xFF)

--- a/replication/row_event_test.go
+++ b/replication/row_event_test.go
@@ -1520,7 +1520,7 @@ func BenchmarkUseDecimal(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, d := range decimalData {
-			_, _, _ = e.decodeValue(d.dumpData, mysql.MYSQL_TYPE_NEWDECIMAL, d.meta, false)
+			_, _, _ = e.decodeValue(d.dumpData, mysql.MYSQL_TYPE_NEWDECIMAL, d.meta, false, false)
 		}
 	}
 }
@@ -1530,7 +1530,7 @@ func BenchmarkNotUseDecimal(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, d := range decimalData {
-			_, _, _ = e.decodeValue(d.dumpData, mysql.MYSQL_TYPE_NEWDECIMAL, d.meta, false)
+			_, _, _ = e.decodeValue(d.dumpData, mysql.MYSQL_TYPE_NEWDECIMAL, d.meta, false, false)
 		}
 	}
 }
@@ -1539,14 +1539,14 @@ func TestDecimal(t *testing.T) {
 	e := &RowsEvent{useDecimal: true}
 	e2 := &RowsEvent{useDecimal: false}
 	for _, d := range decimalData {
-		v, _, err := e.decodeValue(d.dumpData, mysql.MYSQL_TYPE_NEWDECIMAL, d.meta, false)
+		v, _, err := e.decodeValue(d.dumpData, mysql.MYSQL_TYPE_NEWDECIMAL, d.meta, false, false)
 		require.NoError(t, err)
 		// no trailing zero
 		dec, err := decimal.NewFromString(d.num)
 		require.NoError(t, err)
 		require.True(t, dec.Equal(v.(decimal.Decimal)))
 
-		v, _, err = e2.decodeValue(d.dumpData, mysql.MYSQL_TYPE_NEWDECIMAL, d.meta, false)
+		v, _, err = e2.decodeValue(d.dumpData, mysql.MYSQL_TYPE_NEWDECIMAL, d.meta, false, false)
 		require.NoError(t, err)
 		require.Equal(t, d.num, v.(string))
 	}
@@ -1567,12 +1567,111 @@ var intData = [][]byte{
 	{12, 0, 0, 0},
 }
 
+func TestDecodeUnsignedIntegers(t *testing.T) {
+	e := &RowsEvent{}
+
+	t.Run("TINY", func(t *testing.T) {
+		testcases := []struct {
+			data     []byte
+			expected uint8
+		}{
+			{[]byte{0x00}, 0},
+			{[]byte{0x01}, 1},
+			{[]byte{0x7F}, 127}, // math.MaxInt8
+			{[]byte{0x80}, 128}, // math.MaxInt8 + 1
+			{[]byte{0xFF}, 255}, // math.MaxUint8
+		}
+		for _, tc := range testcases {
+			v, n, err := e.decodeValue(tc.data, mysql.MYSQL_TYPE_TINY, 0, false, true)
+			require.NoError(t, err)
+			require.Equal(t, 1, n)
+			require.Equal(t, tc.expected, v.(uint8))
+		}
+	})
+
+	t.Run("SHORT", func(t *testing.T) {
+		testcases := []struct {
+			data     []byte
+			expected uint16
+		}{
+			{[]byte{0x00, 0x00}, 0},
+			{[]byte{0x01, 0x00}, 1},
+			{[]byte{0xFF, 0x7F}, 32767}, // math.MaxInt16
+			{[]byte{0x00, 0x80}, 32768}, // math.MaxInt16 + 1
+			{[]byte{0xFF, 0xFF}, 65535}, // math.MaxUint16
+		}
+		for _, tc := range testcases {
+			v, n, err := e.decodeValue(tc.data, mysql.MYSQL_TYPE_SHORT, 0, false, true)
+			require.NoError(t, err)
+			require.Equal(t, 2, n)
+			require.Equal(t, tc.expected, v.(uint16))
+		}
+	})
+
+	t.Run("INT24", func(t *testing.T) {
+		testcases := []struct {
+			data     []byte
+			expected uint32
+		}{
+			{[]byte{0x00, 0x00, 0x00}, 0},
+			{[]byte{0x01, 0x00, 0x00}, 1},
+			{[]byte{0xFF, 0xFF, 0x7F}, 8388607},  // math.MaxInt24
+			{[]byte{0x00, 0x00, 0x80}, 8388608},  // math.MaxInt24 + 1
+			{[]byte{0xFF, 0xFF, 0xFF}, 16777215}, // math.MaxUint24
+		}
+		for _, tc := range testcases {
+			v, n, err := e.decodeValue(tc.data, mysql.MYSQL_TYPE_INT24, 0, false, true)
+			require.NoError(t, err)
+			require.Equal(t, 3, n)
+			require.Equal(t, tc.expected, v.(uint32))
+		}
+	})
+
+	t.Run("LONG", func(t *testing.T) {
+		testcases := []struct {
+			data     []byte
+			expected uint32
+		}{
+			{[]byte{0x00, 0x00, 0x00, 0x00}, 0},
+			{[]byte{0x01, 0x00, 0x00, 0x00}, 1},
+			{[]byte{0xFF, 0xFF, 0xFF, 0x7F}, 2147483647}, // math.MaxInt32
+			{[]byte{0x00, 0x00, 0x00, 0x80}, 2147483648}, // math.MaxInt32 + 1
+			{[]byte{0xFF, 0xFF, 0xFF, 0xFF}, 4294967295}, // math.MaxUint32
+		}
+		for _, tc := range testcases {
+			v, n, err := e.decodeValue(tc.data, mysql.MYSQL_TYPE_LONG, 0, false, true)
+			require.NoError(t, err)
+			require.Equal(t, 4, n)
+			require.Equal(t, tc.expected, v.(uint32))
+		}
+	})
+
+	t.Run("LONGLONG", func(t *testing.T) {
+		testcases := []struct {
+			data     []byte
+			expected uint64
+		}{
+			{[]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, 0},
+			{[]byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, 1},
+			{[]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F}, 9223372036854775807},  // math.MaxInt64
+			{[]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80}, 9223372036854775808},  // math.MaxInt64 + 1
+			{[]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, 18446744073709551615}, // math.MaxUint64
+		}
+		for _, tc := range testcases {
+			v, n, err := e.decodeValue(tc.data, mysql.MYSQL_TYPE_LONGLONG, 0, false, true)
+			require.NoError(t, err)
+			require.Equal(t, 8, n)
+			require.Equal(t, tc.expected, v.(uint64))
+		}
+	})
+}
+
 func BenchmarkInt(b *testing.B) {
 	e := &RowsEvent{}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, d := range intData {
-			_, _, _ = e.decodeValue(d, mysql.MYSQL_TYPE_LONG, 0, false)
+			_, _, _ = e.decodeValue(d, mysql.MYSQL_TYPE_LONG, 0, false, false)
 		}
 	}
 }


### PR DESCRIPTION
decodeValue now accepts an isUnsigned flag and returns the appropriate unsigned Go type (uint8/uint16/uint32/uint64) for TINY/SHORT/INT24/LONG/ LONGLONG columns. decodeImage derives the flag per column from the TableMapEvent UnsignedMap so values above the signed maximum are no longer misrepresented as negative numbers.