### PR TITLE
mysql: Parsing UUIDSet with tags (alternative implementation)

### DIFF
--- a/mysql/const.go
+++ b/mysql/const.go
@@ -270,3 +270,10 @@ const (
 	SESSION_TRACK_TRANSACTION_CHARACTERISTICS
 	SESSION_TRACK_TRANSACTION_STATE
 )
+
+type GtidFormat int
+
+const (
+	GtidFormatClassic GtidFormat = iota
+	GtidFormatTagged
+)

--- a/mysql/mysql_gtid.go
+++ b/mysql/mysql_gtid.go
@@ -4,10 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"io"
-	"math"
-	"sort"
-	"strconv"
+	"slices"
 	"strings"
 
 	"github.com/go-mysql-org/go-mysql/utils"
@@ -15,374 +12,16 @@ import (
 	"github.com/pingcap/errors"
 )
 
-// Like MySQL GTID Interval struct, [start, stop), left closed and right open
-// See MySQL rpl_gtid.h
-type Interval struct {
-	// The first GID of this interval.
-	Start int64
-	// The first GID after this interval.
-	Stop int64
-}
-
-// Interval is [start, stop), but the GTID string's format is [n] or [n1-n2], closed interval
-func parseInterval(str string) (i Interval, err error) {
-	p := strings.Split(str, "-")
-	switch len(p) {
-	case 1:
-		i.Start, err = strconv.ParseInt(p[0], 10, 64)
-		i.Stop = i.Start + 1
-	case 2:
-		i.Start, err = strconv.ParseInt(p[0], 10, 64)
-		if err == nil {
-			i.Stop, err = strconv.ParseInt(p[1], 10, 64)
-			i.Stop++
-		}
-	default:
-		err = errors.Errorf("invalid interval format, must n[-n]")
-	}
-
-	if err != nil {
-		return i, err
-	}
-
-	if i.Stop <= i.Start {
-		err = errors.Errorf("invalid interval format, must n[-n] and the end must >= start")
-	}
-
-	return i, err
-}
-
-func (i Interval) String() string {
-	if i.Stop == i.Start+1 {
-		return fmt.Sprintf("%d", i.Start)
-	} else {
-		return fmt.Sprintf("%d-%d", i.Start, i.Stop-1)
-	}
-}
-
-type IntervalSlice []Interval
-
-func (s IntervalSlice) Len() int {
-	return len(s)
-}
-
-func (s IntervalSlice) Less(i, j int) bool {
-	if s[i].Start < s[j].Start {
-		return true
-	} else if s[i].Start > s[j].Start {
-		return false
-	} else {
-		return s[i].Stop < s[j].Stop
-	}
-}
-
-func (s IntervalSlice) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-func (s IntervalSlice) Sort() {
-	sort.Sort(s)
-}
-
-func (s IntervalSlice) Normalize() IntervalSlice {
-	var n IntervalSlice
-	if len(s) == 0 {
-		return n
-	}
-
-	s.Sort()
-
-	n = append(n, s[0])
-
-	for i := 1; i < len(s); i++ {
-		last := n[len(n)-1]
-		if s[i].Start > last.Stop {
-			n = append(n, s[i])
-			continue
-		} else {
-			stop := max(last.Stop, s[i].Stop)
-			n[len(n)-1] = Interval{last.Start, stop}
-		}
-	}
-
-	return n
-}
-
-func (s *IntervalSlice) InsertInterval(interval Interval) {
-	var (
-		count int
-		i     int
-	)
-
-	*s = append(*s, interval)
-	total := len(*s)
-	for i = total - 1; i > 0; i-- {
-		if (*s)[i].Stop < (*s)[i-1].Start {
-			(*s)[i], (*s)[i-1] = (*s)[i-1], (*s)[i]
-		} else if (*s)[i].Start > (*s)[i-1].Stop {
-			break
-		} else {
-			(*s)[i-1].Start = min((*s)[i-1].Start, (*s)[i].Start)
-			(*s)[i-1].Stop = max((*s)[i-1].Stop, (*s)[i].Stop)
-			count++
-		}
-	}
-	if count > 0 {
-		i++
-		if i+count < total {
-			copy((*s)[i:], (*s)[i+count:])
-		}
-		*s = (*s)[:total-count]
-	}
-}
-
-// Contain returns true if sub in s
-func (s IntervalSlice) Contain(sub IntervalSlice) bool {
-	j := 0
-	for i := range sub {
-		for ; j < len(s); j++ {
-			if sub[i].Start > s[j].Stop {
-				continue
-			} else {
-				break
-			}
-		}
-		if j == len(s) {
-			return false
-		}
-
-		if sub[i].Start < s[j].Start || sub[i].Stop > s[j].Stop {
-			return false
-		}
-	}
-
-	return true
-}
-
-func (s IntervalSlice) Equal(o IntervalSlice) bool {
-	if len(s) != len(o) {
-		return false
-	}
-
-	for i := range s {
-		if s[i].Start != o[i].Start || s[i].Stop != o[i].Stop {
-			return false
-		}
-	}
-
-	return true
-}
-
-func (s IntervalSlice) Compare(o IntervalSlice) int {
-	if s.Equal(o) {
-		return 0
-	} else if s.Contain(o) {
-		return 1
-	} else {
-		return -1
-	}
-}
-
-// Refer http://dev.mysql.com/doc/refman/5.6/en/replication-gtids-concepts.html
-type UUIDSet struct {
-	SID uuid.UUID
-
-	Intervals IntervalSlice
-}
-
-func ParseUUIDSet(str string) (*UUIDSet, error) {
-	str = strings.TrimSpace(str)
-	sep := strings.Split(str, ":")
-	if len(sep) < 2 {
-		return nil, errors.Errorf("invalid GTID format, must UUID:interval[:interval]")
-	}
-
-	var err error
-	s := new(UUIDSet)
-	if s.SID, err = uuid.Parse(sep[0]); err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	// Handle interval
-	for i := 1; i < len(sep); i++ {
-		if in, err := parseInterval(sep[i]); err != nil {
-			return nil, errors.Trace(err)
-		} else {
-			s.Intervals = append(s.Intervals, in)
-		}
-	}
-
-	s.Intervals = s.Intervals.Normalize()
-
-	return s, nil
-}
-
-func NewUUIDSet(sid uuid.UUID, in ...Interval) *UUIDSet {
-	s := new(UUIDSet)
-	s.SID = sid
-
-	s.Intervals = in
-	s.Intervals = s.Intervals.Normalize()
-
-	return s
-}
-
-func (s *UUIDSet) Contain(sub *UUIDSet) bool {
-	if s.SID != sub.SID {
-		return false
-	}
-
-	return s.Intervals.Contain(sub.Intervals)
-}
-
-func (s *UUIDSet) Bytes() []byte {
-	var buf bytes.Buffer
-
-	buf.WriteString(s.SID.String())
-
-	for _, i := range s.Intervals {
-		buf.WriteString(":")
-		buf.WriteString(i.String())
-	}
-
-	return buf.Bytes()
-}
-
-func (s *UUIDSet) AddInterval(in IntervalSlice) {
-	s.Intervals = append(s.Intervals, in...)
-	s.Intervals = s.Intervals.Normalize()
-}
-
-func (s *UUIDSet) MinusInterval(in IntervalSlice) {
-	var n IntervalSlice
-	in = in.Normalize()
-
-	i, j := 0, 0
-	var minuend Interval
-	var subtrahend Interval
-	for i < len(s.Intervals) {
-		if minuend.Stop != s.Intervals[i].Stop { // `i` changed?
-			minuend = s.Intervals[i]
-		}
-		if j < len(in) {
-			subtrahend = in[j]
-		} else {
-			subtrahend = Interval{math.MaxInt64, math.MaxInt64}
-		}
-
-		if minuend.Stop <= subtrahend.Start {
-			// no overlapping
-			n = append(n, minuend)
-			i++
-		} else if minuend.Start >= subtrahend.Stop {
-			// no overlapping
-			j++
-		} else {
-			if minuend.Start < subtrahend.Start && minuend.Stop <= subtrahend.Stop {
-				n = append(n, Interval{minuend.Start, subtrahend.Start})
-				i++
-			} else if minuend.Start >= subtrahend.Start && minuend.Stop > subtrahend.Stop {
-				minuend = Interval{subtrahend.Stop, minuend.Stop}
-				j++
-			} else if minuend.Start >= subtrahend.Start && minuend.Stop <= subtrahend.Stop {
-				// minuend is completely removed
-				i++
-			} else if minuend.Start < subtrahend.Start && minuend.Stop > subtrahend.Stop {
-				n = append(n, Interval{minuend.Start, subtrahend.Start})
-				minuend = Interval{subtrahend.Stop, minuend.Stop}
-				j++
-			} else {
-				panic("should never be here")
-			}
-		}
-	}
-
-	s.Intervals = n.Normalize()
-}
-
-func (s *UUIDSet) String() string {
-	return utils.ByteSliceToString(s.Bytes())
-}
-
-func (s *UUIDSet) encode(w io.Writer) {
-	b, _ := s.SID.MarshalBinary()
-
-	_, _ = w.Write(b)
-	n := int64(len(s.Intervals))
-
-	_ = binary.Write(w, binary.LittleEndian, n)
-
-	for _, i := range s.Intervals {
-		_ = binary.Write(w, binary.LittleEndian, i.Start)
-		_ = binary.Write(w, binary.LittleEndian, i.Stop)
-	}
-}
-
-func (s *UUIDSet) Encode() []byte {
-	var buf bytes.Buffer
-
-	s.encode(&buf)
-
-	return buf.Bytes()
-}
-
-func (s *UUIDSet) decode(data []byte) (int, error) {
-	if len(data) < 24 {
-		return 0, errors.Errorf("invalid uuid set buffer, less 24")
-	}
-
-	pos := 0
-	var err error
-	if s.SID, err = uuid.FromBytes(data[0:16]); err != nil {
-		return 0, err
-	}
-	pos += 16
-
-	n := int64(binary.LittleEndian.Uint64(data[pos : pos+8]))
-	pos += 8
-	if len(data) < int(16*n)+pos {
-		return 0, errors.Errorf("invalid uuid set buffer, must %d, but %d", pos+int(16*n), len(data))
-	}
-
-	s.Intervals = make([]Interval, 0, n)
-
-	var in Interval
-	for range n {
-		in.Start = int64(binary.LittleEndian.Uint64(data[pos : pos+8]))
-		pos += 8
-		in.Stop = int64(binary.LittleEndian.Uint64(data[pos : pos+8]))
-		pos += 8
-		s.Intervals = append(s.Intervals, in)
-	}
-
-	return pos, nil
-}
-
-func (s *UUIDSet) Decode(data []byte) error {
-	n, err := s.decode(data)
-	if n != len(data) {
-		return errors.Errorf("invalid uuid set buffer, must %d, but %d", n, len(data))
-	}
-	return err
-}
-
-func (s *UUIDSet) Clone() *UUIDSet {
-	clone := new(UUIDSet)
-	clone.SID = s.SID
-	clone.Intervals = make([]Interval, len(s.Intervals))
-	copy(clone.Intervals, s.Intervals)
-	return clone
-}
-
+// MysqlGTIDSet has a TSID (UUID+Tag) as key
 type MysqlGTIDSet struct {
-	Sets map[string]*UUIDSet
+	Sets map[TSID]*UUIDSet
 }
 
 var _ GTIDSet = &MysqlGTIDSet{}
 
 func ParseMysqlGTIDSet(str string) (GTIDSet, error) {
 	s := new(MysqlGTIDSet)
-	s.Sets = make(map[string]*UUIDSet)
+	s.Sets = make(map[TSID]*UUIDSet)
 	if str == "" {
 		return s, nil
 	}
@@ -391,10 +30,10 @@ func ParseMysqlGTIDSet(str string) (GTIDSet, error) {
 
 	// todo, handle redundant same uuid
 	for i := range sp {
-		if set, err := ParseUUIDSet(sp[i]); err != nil {
+		if sets, err := ParseUUIDSets(sp[i]); err != nil {
 			return nil, errors.Trace(err)
 		} else {
-			s.AddSet(set)
+			s.AddSets(sets)
 		}
 	}
 	return s, nil
@@ -404,17 +43,19 @@ func DecodeMysqlGTIDSet(data []byte) (*MysqlGTIDSet, error) {
 	s := new(MysqlGTIDSet)
 
 	if len(data) < 8 {
-		return nil, errors.Errorf("invalid gtid set buffer, less 4")
+		return nil, errors.Errorf("invalid gtid set buffer, expected 8 or more but got %d", len(data))
 	}
 
-	n := int(binary.LittleEndian.Uint64(data))
-	s.Sets = make(map[string]*UUIDSet, n)
-
+	format, n := DecodeSid(data)
+	s.Sets = make(map[TSID]*UUIDSet, n)
 	pos := 8
 
 	for range n {
+		if format == GtidFormatTagged && pos >= len(data) {
+			break
+		}
 		set := new(UUIDSet)
-		if n, err := set.decode(data[pos:]); err != nil {
+		if n, err := set.decode(data[pos:], format); err != nil {
 			return nil, errors.Trace(err)
 		} else {
 			pos += n
@@ -429,12 +70,25 @@ func (s *MysqlGTIDSet) AddSet(set *UUIDSet) {
 	if set == nil {
 		return
 	}
-	sid := set.SID.String()
-	o, ok := s.Sets[sid]
+	o, ok := s.Sets[set.TSID]
 	if ok {
 		o.AddInterval(set.Intervals)
 	} else {
-		s.Sets[sid] = set
+		s.Sets[set.TSID] = set
+	}
+}
+
+func (s *MysqlGTIDSet) AddSets(sets []UUIDSet) {
+	if sets == nil {
+		return
+	}
+	for _, set := range sets {
+		o, ok := s.Sets[set.TSID]
+		if ok {
+			o.AddInterval(set.Intervals)
+		} else {
+			s.Sets[set.TSID] = &set
+		}
 	}
 }
 
@@ -442,12 +96,11 @@ func (s *MysqlGTIDSet) MinusSet(set *UUIDSet) {
 	if set == nil {
 		return
 	}
-	sid := set.SID.String()
-	uuidSet, ok := s.Sets[sid]
+	uuidSet, ok := s.Sets[set.TSID]
 	if ok {
 		uuidSet.MinusInterval(set.Intervals)
 		if uuidSet.Intervals == nil {
-			delete(s.Sets, sid)
+			delete(s.Sets, set.TSID)
 		}
 	}
 }
@@ -464,12 +117,15 @@ func (s *MysqlGTIDSet) Update(GTIDStr string) error {
 }
 
 func (s *MysqlGTIDSet) AddGTID(uuid uuid.UUID, gno int64) {
-	sid := uuid.String()
-	o, ok := s.Sets[sid]
+	s.AddGTIDWithTag(TSID{SID: uuid}, gno)
+}
+
+func (s *MysqlGTIDSet) AddGTIDWithTag(tsid TSID, gno int64) {
+	o, ok := s.Sets[tsid]
 	if ok {
 		o.Intervals.InsertInterval(Interval{gno, gno + 1})
 	} else {
-		s.Sets[sid] = &UUIDSet{uuid, IntervalSlice{Interval{gno, gno + 1}}}
+		s.Sets[tsid] = &UUIDSet{tsid, IntervalSlice{Interval{gno, gno + 1}}}
 	}
 }
 
@@ -540,30 +196,60 @@ func (s *MysqlGTIDSet) String() string {
 	}
 
 	// sort multi set
-	var buf bytes.Buffer
 	sets := make([]string, 0, len(s.Sets))
 	for _, set := range s.Sets {
 		sets = append(sets, set.String())
 	}
-	sort.Strings(sets)
+	slices.Sort(sets)
 
+	var buf bytes.Buffer
 	sep := ""
-	for _, set := range sets {
-		buf.WriteString(sep)
-		buf.WriteString(set)
-		sep = ","
+	for i, set := range sets {
+		if i > 0 && sets[i-1][1:36] == set[i:36] {
+			sep = ":"
+			buf.WriteString(sep)
+			buf.WriteString(set[37:])
+			sep = ","
+		} else {
+			buf.WriteString(sep)
+			buf.WriteString(set)
+			sep = ","
+		}
 	}
 
 	return utils.ByteSliceToString(buf.Bytes())
 }
 
+// Encode is encoding the GTID Set in the format of COM_BINLOG_DUMP_GTID
 func (s *MysqlGTIDSet) Encode() []byte {
 	var buf bytes.Buffer
 
-	_ = binary.Write(&buf, binary.LittleEndian, uint64(len(s.Sets)))
+	format := GtidFormatClassic
+	for _, set := range s.Sets {
+		if set.TSID.Tag != "" {
+			format = GtidFormatTagged
+		}
+	}
+	sidcount := uint64(len(s.Sets))
+	sid := encodeSid(format, sidcount)
+	buf.Write(sid)
 
-	for i := range s.Sets {
-		s.Sets[i].encode(&buf)
+	sets := make([]TSID, 0, len(s.Sets))
+	for k := range s.Sets {
+		sets = append(sets, k)
+	}
+	slices.SortFunc(sets, func(a, b TSID) int {
+		abin, _ := a.SID.MarshalBinary()
+		bbin, _ := b.SID.MarshalBinary()
+		bcmp := bytes.Compare(abin, bbin)
+		if bcmp == 0 {
+			return strings.Compare(a.Tag, b.Tag)
+		}
+		return bcmp
+	})
+
+	for _, tsid := range sets {
+		s.Sets[tsid].encode(format, &buf)
 	}
 
 	return buf.Bytes()
@@ -571,10 +257,10 @@ func (s *MysqlGTIDSet) Encode() []byte {
 
 func (gtid *MysqlGTIDSet) Clone() GTIDSet {
 	clone := &MysqlGTIDSet{
-		Sets: make(map[string]*UUIDSet),
+		Sets: make(map[TSID]*UUIDSet),
 	}
-	for sid, uuidSet := range gtid.Sets {
-		clone.Sets[sid] = uuidSet.Clone()
+	for tsid, uuidSet := range gtid.Sets {
+		clone.Sets[tsid] = uuidSet.Clone()
 	}
 
 	return clone
@@ -582,4 +268,55 @@ func (gtid *MysqlGTIDSet) Clone() GTIDSet {
 
 func (s *MysqlGTIDSet) IsEmpty() bool {
 	return len(s.Sets) == 0
+}
+
+// Decode the number of sids (source identifiers) and if it is using
+// tagged GTIDs or classic (non-tagged) GTIDs.
+//
+// Note that each gtid tag increases the sidno here, so a single UUID
+// might turn up multiple times if there are multipl tags.
+//
+// see also:
+// decode_nsids_format in mysql/mysql-server
+// https://github.com/mysql/mysql-server/blob/61a3a1d8ef15512396b4c2af46e922a19bf2b174/sql/rpl_gtid_set.cc#L1363-L1378
+func DecodeSid(data []byte) (format GtidFormat, sidnr uint64) {
+	if len(data) < 8 {
+		// input too short, the function signature doesn't allow us to return an error here.
+		return format, sidnr
+	}
+	if data[7] == 0x1 {
+		format = GtidFormatTagged
+	}
+
+	if format == GtidFormatTagged {
+		masked := make([]byte, 8)
+		copy(masked, data[1:7])
+		sidnr = binary.LittleEndian.Uint64(masked)
+		return format, sidnr
+	}
+	sidnr = binary.LittleEndian.Uint64(data[:8])
+	return format, sidnr
+}
+
+func encodeSid(format GtidFormat, sidnr uint64) []byte {
+	sid := make([]byte, 8)
+	if format == GtidFormatClassic {
+		_, _ = binary.Encode(sid, binary.LittleEndian, sidnr)
+		return sid
+	}
+	_, _ = binary.Encode(sid, binary.LittleEndian, sidnr<<8)
+
+	sid[0] = 0x01
+	sid[7] = 0x01 // Format marker
+	return sid
+}
+
+func (f GtidFormat) String() string {
+	switch f {
+	case GtidFormatClassic:
+		return "GtidFormatClassic"
+	case GtidFormatTagged:
+		return "GtidFormatTagged"
+	}
+	return fmt.Sprintf("GtidFormat{%d}", int(f))
 }

--- a/mysql/mysql_gtid_test.go
+++ b/mysql/mysql_gtid_test.go
@@ -1,0 +1,473 @@
+package mysql
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mysqlGTIDfromString(t *testing.T, gtidStr string) MysqlGTIDSet {
+	gtid, err := ParseMysqlGTIDSet(gtidStr)
+	require.NoError(t, err)
+
+	return *gtid.(*MysqlGTIDSet)
+}
+
+func TestDecodeSid(t *testing.T) {
+	testcases := []struct {
+		input      []byte
+		gtidFormat GtidFormat
+		uuidCount  uint64
+	}{
+		{[]byte{1, 2, 0, 0, 0, 0, 0, 1}, GtidFormatTagged, 2},
+		{[]byte{1, 1, 0, 0, 0, 0, 0, 1}, GtidFormatTagged, 1},
+		{[]byte{1, 0, 0, 0, 0, 0, 0, 1}, GtidFormatTagged, 0},
+		{[]byte{1, 0, 0, 0, 0, 0, 0, 0}, GtidFormatClassic, 1},
+	}
+
+	for _, tc := range testcases {
+		format, uuidCount := DecodeSid(tc.input)
+		assert.Equal(t, tc.gtidFormat, format)
+		assert.Equal(t, tc.uuidCount, uuidCount)
+	}
+}
+
+func FuzzDecodeSid(f *testing.F) {
+	testcases := [][]byte{
+		{1, 2, 0, 0, 0, 0, 0, 1},
+		{1, 1, 0, 0, 0, 0, 0, 1},
+		{1, 0, 0, 0, 0, 0, 0, 1},
+		{1, 0, 0, 0, 0, 0, 0, 0},
+	}
+
+	for _, tc := range testcases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, input []byte) {
+		fmt, sidnr := DecodeSid(input)
+		enc := encodeSid(fmt, sidnr)
+		if len(input) >= 8 {
+			if fmt == GtidFormatTagged {
+				// If the first byte is always encoded as 0x1
+				require.Equal(t, input[1:7], enc[1:7])
+			} else {
+				require.Equal(t, input[0:7], enc[0:7])
+			}
+		}
+	})
+}
+
+func TestGtidFormat_String(t *testing.T) {
+	require.Equal(t, GtidFormat(3).String(), "GtidFormat{3}")
+}
+
+func TestParseMysqlGTIDSet(t *testing.T) {
+	_, err := ParseMysqlGTIDSet("")
+	require.NoError(t, err)
+
+	_, err = ParseMysqlGTIDSet(",")
+	require.Error(t, err)
+
+	_, err = ParseMysqlGTIDSet("de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2:foo:bar:1-2")
+	require.Error(t, err)
+}
+
+func TestDecodeMysqlGTIDSet(t *testing.T) {
+	_, err := DecodeMysqlGTIDSet([]byte{0, 0, 0, 0, 0, 0, 0}) // 7 byte
+	require.Error(t, err)
+
+	// Not sure if this should be legal
+	_, err = DecodeMysqlGTIDSet([]byte{0, 0, 0, 0, 0, 0, 0, 0})
+	require.NoError(t, err)
+
+	_, err = DecodeMysqlGTIDSet([]byte{1, 0, 0, 0, 0, 0, 0, 0})
+	require.Error(t, err)
+}
+
+func TestMysqlGTIDSet(t *testing.T) {
+	gs, err := ParseMysqlGTIDSet("de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2,de278ad0-2106-11e4-9f8e-6edd0ca20948:1-2")
+	require.NoError(t, err)
+
+	buf := gs.Encode()
+	o, err := DecodeMysqlGTIDSet(buf)
+	require.NoError(t, err)
+	require.Equal(t, gs, o)
+
+	ts, err := ParseMysqlGTIDSet("de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2:mytag:1-10:12-14:16:18-20,de278ad0-2106-11e4-9f8e-6edd0ca20948:1-2")
+	require.NoError(t, err)
+	buf = ts.Encode()
+	o, err = DecodeMysqlGTIDSet(buf)
+	require.NoError(t, err)
+	require.Equal(t, ts, o)
+
+	setstr := "de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2:mytag:1-10:12-14:16:18-20"
+	ts2, err := ParseMysqlGTIDSet(setstr)
+	require.NoError(t, err)
+	require.Equal(t, setstr, ts2.String())
+	buf = ts2.Encode()
+	// From Wireshark
+	// mysqlbinlog --read-from-remote-source=BINLOG-DUMP-GTIDS -h 127.0.0.1 -u root --stop-never --exclude-gtids 'de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2:mytag:1-10:12-14:16:18-20' --ssl-mode=disabled mysql-bin.000001 --connection-server-id=876
+	// Then for the Send Binlog GTID packet:
+	// Select mysql.binlog.gtid_data and then use the "Copy...as Go literal"
+	// Unmodified, except for splitting it into multiple lines and adding annotations.
+	dat := []byte{
+		0x1, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, // format marker: tagged, sidnr: 0x2
+		0xde, 0x27, 0x8a, 0xd0, 0x21, 0x6, 0x11, 0xe4, 0x9f, 0x8e, 0x6e, 0xdd, 0xc, 0xa2, 0x9, 0x47, // uuid
+		0x0,                                    // tag length: 0
+		0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // intervals: 1
+		0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // start: 1
+		0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // stop: 3
+		0xde, 0x27, 0x8a, 0xd0, 0x21, 0x6, 0x11, 0xe4, 0x9f, 0x8e, 0x6e, 0xdd, 0xc, 0xa2, 0x9, 0x47, // uuid
+		0xa,                          // tag length 0xa>>1 = 5
+		0x6d, 0x79, 0x74, 0x61, 0x67, // tag
+		0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // intervals: 4
+		0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // start:  1
+		0xb, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // stop: 11
+		0xc, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // start: 12
+		0xf, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // stop: 15
+		0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // start: 16
+		0x11, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // stop: 17
+		0x12, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // start: 18
+		0x15, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // stop: 21
+	}
+	require.Equal(t, dat, buf)
+	o, err = DecodeMysqlGTIDSet(buf)
+	require.NoError(t, err)
+	require.Equal(t, ts2, o)
+}
+
+func TestMysqlGTIDSet_Add(t *testing.T) {
+	testCases := []struct {
+		left, right, expected string
+	}{
+		// simple cases works:
+		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:23", "3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23:28-57"},
+		// summ is associative operation
+		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23:28-57"},
+		// merge intervals:
+		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:23-27", "3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23-57"},
+	}
+
+	for _, tc := range testCases {
+		m1 := mysqlGTIDfromString(t, tc.left)
+		m2 := mysqlGTIDfromString(t, tc.right)
+		err := m1.Add(m2)
+		require.NoError(t, err)
+		one := fmt.Sprintf("%s + %s = %s", tc.left, tc.right, strings.ToUpper(m1.String()))
+		other := fmt.Sprintf("%s + %s = %s", tc.left, tc.right, tc.expected)
+		require.Equal(t, other, one)
+	}
+}
+
+func TestMysqlGTIDSet_AddGTID(t *testing.T) {
+	g, err := ParseMysqlGTIDSet("3E11FA47-71CA-11E1-9E33-C80AA9429562:21-57")
+	require.NoError(t, err)
+
+	g1 := g.(*MysqlGTIDSet)
+
+	u, err := uuid.Parse("3E11FA47-71CA-11E1-9E33-C80AA9429562")
+	require.NoError(t, err)
+
+	g1.AddGTID(u, 58)
+	require.Equal(t, "3E11FA47-71CA-11E1-9E33-C80AA9429562:21-58", strings.ToUpper(g1.String()))
+
+	g1.AddGTID(u, 60)
+	require.Equal(t, "3E11FA47-71CA-11E1-9E33-C80AA9429562:21-58:60", strings.ToUpper(g1.String()))
+
+	g1.AddGTID(u, 59)
+	require.Equal(t, "3E11FA47-71CA-11E1-9E33-C80AA9429562:21-60", strings.ToUpper(g1.String()))
+
+	u2, err := uuid.Parse("519CE70F-A893-11E9-A95A-B32DC65A7026")
+	require.NoError(t, err)
+	g1.AddGTID(u2, 58)
+	g2, err := ParseMysqlGTIDSet(`
+	3E11FA47-71CA-11E1-9E33-C80AA9429562:21-60,
+	519CE70F-A893-11E9-A95A-B32DC65A7026:58
+`)
+	require.NoError(t, err)
+	require.True(t, g2.Equal(g1))
+}
+
+func TestMysqlGTIDSet_AddSet(t *testing.T) {
+	g, err := ParseMysqlGTIDSet("3E11FA47-71CA-11E1-9E33-C80AA9429562:21-57")
+	require.NoError(t, err)
+
+	if gset, ok := g.(*MysqlGTIDSet); ok {
+		gset.AddSet(nil)
+	}
+}
+
+func TestMysqlGTIDSet_Clone(t *testing.T) {
+	g1, err := ParseMysqlGTIDSet("3E11FA47-71CA-11E1-9E33-C80AA9429562:23")
+	require.NoError(t, err)
+
+	g2 := g1.Clone()
+	require.Equal(t, g1, g2)
+}
+
+func TestMysqlGTIDSet_Contain(t *testing.T) {
+	g1, err := ParseMysqlGTIDSet("3E11FA47-71CA-11E1-9E33-C80AA9429562:23")
+	require.NoError(t, err)
+
+	g2, err := ParseMysqlGTIDSet("3E11FA47-71CA-11E1-9E33-C80AA9429562:21-57")
+	require.NoError(t, err)
+
+	require.True(t, g2.Contain(g1))
+	require.False(t, g1.Contain(g2))
+
+	g3, err := ParseGTIDSet(MariaDBFlavor, "0-1-2")
+	require.NoError(t, err)
+	require.False(t, g1.Contain(g3))
+}
+
+func TestMysqlGTIDSet_Encode(t *testing.T) {
+	cases := []struct {
+		set    MysqlGTIDSet
+		result []byte
+	}{
+		{
+			MysqlGTIDSet{
+				Sets: map[TSID]*UUIDSet{
+					{
+						SID: uuid.MustParse("071a4ecc-1bf9-11f1-a838-e6dd1807d029"),
+					}: NewUUIDSet(
+						TSID{
+							SID: uuid.MustParse("071a4ecc-1bf9-11f1-a838-e6dd1807d029"),
+						},
+						Interval{Start: 1, Stop: 3},
+					),
+				},
+			},
+			[]byte{
+				// Classic format, not tagged
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // nr of sids + format tag
+				0x7, 0x1a, 0x4e, 0xcc, 0x1b, 0xf9, 0x11, 0xf1, 0xa8, 0x38, 0xe6, 0xdd, 0x18, 0x7, 0xd0, 0x29, // uuid
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // intervals
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // start
+				0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // stop
+			},
+		},
+		{
+			MysqlGTIDSet{
+				Sets: map[TSID]*UUIDSet{
+					{
+						SID: uuid.MustParse("071a4ecc-1bf9-11f1-a838-e6dd1807d029"),
+						Tag: "mytagabcdef",
+					}: NewUUIDSet(
+						TSID{SID: uuid.MustParse("071a4ecc-1bf9-11f1-a838-e6dd1807d029"), Tag: "mytagabcdef"},
+						Interval{Start: 1, Stop: 2},
+					),
+				},
+			},
+			[]byte{
+				// Tagged format
+				0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, // nr of sids + format tag
+				0x7, 0x1a, 0x4e, 0xcc, 0x1b, 0xf9, 0x11, 0xf1, 0xa8, 0x38, 0xe6, 0xdd, 0x18, 0x7, 0xd0, 0x29, // uuid
+				0x16,                                                             // tag length (needs >>1)
+				0x6d, 0x79, 0x74, 0x61, 0x67, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, // tag
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // intervals
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // start
+				0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // stop
+			},
+		},
+		{
+			MysqlGTIDSet{
+				Sets: map[TSID]*UUIDSet{
+					{
+						SID: uuid.MustParse("071a4ecc-1bf9-11f1-a838-e6dd1807d029"),
+					}: NewUUIDSet(
+						TSID{SID: uuid.MustParse("071a4ecc-1bf9-11f1-a838-e6dd1807d029")},
+						Interval{Start: 1, Stop: 3},
+					),
+					{
+						SID: uuid.MustParse("071a4ecc-1bf9-11f1-a838-e6dd1807d029"),
+						Tag: "mytagabcdef",
+					}: NewUUIDSet(
+						TSID{SID: uuid.MustParse("071a4ecc-1bf9-11f1-a838-e6dd1807d029"), Tag: "mytagabcdef"},
+						Interval{Start: 1, Stop: 2},
+					),
+				},
+			},
+			[]byte{
+				// Tagged format
+				0x1, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, // nr of sids + format tag
+				0x7, 0x1a, 0x4e, 0xcc, 0x1b, 0xf9, 0x11, 0xf1, 0xa8, 0x38, 0xe6, 0xdd, 0x18, 0x7, 0xd0, 0x29, // uuid
+				0x0,                                    // tag length (no tag)
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // intervals
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // start
+				0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // stop
+				0x7, 0x1a, 0x4e, 0xcc, 0x1b, 0xf9, 0x11, 0xf1, 0xa8, 0x38, 0xe6, 0xdd, 0x18, 0x7, 0xd0, 0x29, // uuid
+				0x16,                                                             // tag length (needs >>1)
+				0x6d, 0x79, 0x74, 0x61, 0x67, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, // tag
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // intervals
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // start
+				0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // stop
+			},
+		},
+		{
+			// Same as the one above, but with the Sets in a different order to test sorting.
+			MysqlGTIDSet{
+				Sets: map[TSID]*UUIDSet{
+					{
+						SID: uuid.MustParse("071a4ecc-1bf9-11f1-a838-e6dd1807d029"),
+						Tag: "mytagabcdef",
+					}: NewUUIDSet(
+						TSID{SID: uuid.MustParse("071a4ecc-1bf9-11f1-a838-e6dd1807d029"), Tag: "mytagabcdef"},
+						Interval{Start: 1, Stop: 2},
+					),
+					{
+						SID: uuid.MustParse("071a4ecc-1bf9-11f1-a838-e6dd1807d029"),
+					}: NewUUIDSet(
+						TSID{SID: uuid.MustParse("071a4ecc-1bf9-11f1-a838-e6dd1807d029")},
+						Interval{Start: 1, Stop: 3},
+					),
+				},
+			},
+			[]byte{
+				// Tagged format
+				0x1, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, // nr of sids + format tag
+				0x7, 0x1a, 0x4e, 0xcc, 0x1b, 0xf9, 0x11, 0xf1, 0xa8, 0x38, 0xe6, 0xdd, 0x18, 0x7, 0xd0, 0x29, // uuid
+				0x0,                                    // tag length (no tag)
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // intervals
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // start
+				0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // stop
+				0x7, 0x1a, 0x4e, 0xcc, 0x1b, 0xf9, 0x11, 0xf1, 0xa8, 0x38, 0xe6, 0xdd, 0x18, 0x7, 0xd0, 0x29, // uuid
+				0x16,                                                             // tag length (needs >>1)
+				0x6d, 0x79, 0x74, 0x61, 0x67, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, // tag
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // intervals
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // start
+				0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // stop
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		require.Equal(t, tc.result, tc.set.Encode(), "case %d", i)
+	}
+}
+
+func TestMysqlGTIDSet_Equal(t *testing.T) {
+	g1, err := ParseMysqlGTIDSet("3E11FA47-71CA-11E1-9E33-C80AA9429562:23")
+	require.NoError(t, err)
+
+	g2, err := ParseMysqlGTIDSet("3E11FA47-71CA-11E1-9E33-C80AA9429562:21-57")
+	require.NoError(t, err)
+
+	require.False(t, g2.Equal(g1))
+	require.False(t, g1.Equal(g2))
+	require.True(t, g1.Equal(g1))
+
+	g3, err := ParseGTIDSet(MariaDBFlavor, "0-1-2")
+	require.NoError(t, err)
+	require.False(t, g1.Equal(g3))
+
+	g4, err := ParseMysqlGTIDSet("3E11FA47-71CA-11E1-9E33-C80AA9429562:21-57,3E11FA47-71CA-11E1-9E33-C80AA9429563:11-17")
+	require.NoError(t, err)
+	require.False(t, g1.Equal(g4))
+}
+
+func TestMysqlGTIDSet_IsEmpty(t *testing.T) {
+	emptyGTIDSet := new(MysqlGTIDSet)
+	emptyGTIDSet.Sets = make(map[TSID]*UUIDSet)
+	require.True(t, emptyGTIDSet.IsEmpty())
+
+	nonEmptyGTIDSet := mysqlGTIDfromString(t, "de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2")
+	require.False(t, nonEmptyGTIDSet.IsEmpty())
+}
+
+func TestMysqlGTIDSet_Minus(t *testing.T) {
+	testCases := []struct {
+		left, right, expected string
+	}{
+		// Minuses that doesn't affect original value:
+		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:23", "3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23"},
+		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23", "3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57"},
+		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:23", "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-22:24-57", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23"},
+		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:23", "ABCDEF12-1234-5678-9012-345678901234:1-1000", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23"},
+		// Minuses that change original value:
+		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:20-57:60-90", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23", "3E11FA47-71CA-11E1-9E33-C80AA9429562:20-22:24-57:60-90"},
+		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:20-57:60-90", "3E11FA47-71CA-11E1-9E33-C80AA9429562:22-70", "3E11FA47-71CA-11E1-9E33-C80AA9429562:20-21:71-90"},
+		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57", "3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57", ""},
+		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:20-21", "3E11FA47-71CA-11E1-9E33-C80AA9429562:21", "3E11FA47-71CA-11E1-9E33-C80AA9429562:20"},
+		{"582A11ED-786C-11EC-ACCC-E0356662B76E:1-209692", "582A11ED-786C-11EC-ACCC-E0356662B76E:1-146519", "582A11ED-786C-11EC-ACCC-E0356662B76E:146520-209692"},
+		{"582A11ED-786C-11EC-ACCC-E0356662B76E:1-209692", "582A11ED-786C-11EC-ACCC-E0356662B76E:2-146519", "582A11ED-786C-11EC-ACCC-E0356662B76E:1:146520-209692"},
+	}
+
+	for _, tc := range testCases {
+		m1 := mysqlGTIDfromString(t, tc.left)
+		m2 := mysqlGTIDfromString(t, tc.right)
+		err := m1.Minus(m2)
+		require.NoError(t, err)
+		one := fmt.Sprintf("%s - %s = %s", tc.left, tc.right, strings.ToUpper(m1.String()))
+		other := fmt.Sprintf("%s - %s = %s", tc.left, tc.right, tc.expected)
+		require.Equal(t, other, one)
+	}
+}
+
+func TestMysqlGTIDSet_Update(t *testing.T) {
+	g1, err := ParseMysqlGTIDSet("3E11FA47-71CA-11E1-9E33-C80AA9429562:21-57")
+	require.NoError(t, err)
+
+	err = g1.Update("3E11FA47-71CA-11E1-9E33-C80AA9429562:21-58")
+	require.NoError(t, err)
+
+	require.Equal(t, "3E11FA47-71CA-11E1-9E33-C80AA9429562:21-58", strings.ToUpper(g1.String()))
+
+	g1, err = ParseMysqlGTIDSet(`
+		519CE70F-A893-11E9-A95A-B32DC65A7026:1-1154661,
+		5C9CA52B-9F11-11E9-8EAF-3381EC1CC790:1-244,
+		802D69FD-A3B6-11E9-B1EA-50BAB55BA838:1-1221371,
+		F2B50559-A891-11E9-B646-884FF0CA2043:1-479261
+	`)
+	require.NoError(t, err)
+
+	err = g1.Update(`
+		802D69FD-A3B6-11E9-B1EA-50BAB55BA838:1221110-1221371,
+		F2B50559-A891-11E9-B646-884FF0CA2043:478509-479266
+	`)
+	require.NoError(t, err)
+
+	g2, err := ParseMysqlGTIDSet(`
+		519CE70F-A893-11E9-A95A-B32DC65A7026:1-1154661,
+		5C9CA52B-9F11-11E9-8EAF-3381EC1CC790:1-244,
+		802D69FD-A3B6-11E9-B1EA-50BAB55BA838:1-1221371,
+		F2B50559-A891-11E9-B646-884FF0CA2043:1-479266
+	`)
+	require.NoError(t, err)
+	require.True(t, g1.Equal(g2))
+}
+
+func TestMysqlGTIDSet_String(t *testing.T) {
+	cases := []struct {
+		input  string
+		output string
+	}{
+		{
+			"3E11FA47-71CA-11E1-9E33-C80AA9429562:21-57",
+			"3e11fa47-71ca-11e1-9e33-c80aa9429562:21-57",
+		},
+		{
+			" 3E11FA47-71CA-11E1-9E33-C80AA9429562:21-57:60-64",
+			"3e11fa47-71ca-11e1-9e33-c80aa9429562:21-57:60-64",
+		},
+		{
+			"3E11FA47-71CA-11E1-9E33-C80AA9429562:21-57:foo:5 ",
+			"3e11fa47-71ca-11e1-9e33-c80aa9429562:21-57:foo:5",
+		},
+		{
+			"3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10,3E11FA47-71CA-11E1-9E33-C80AA9429563:1-20",
+			"3e11fa47-71ca-11e1-9e33-c80aa9429562:1-10,3e11fa47-71ca-11e1-9e33-c80aa9429563:1-20",
+		},
+	}
+
+	for _, tc := range cases {
+		g, err := ParseMysqlGTIDSet(tc.input)
+		require.NoError(t, err)
+
+		require.Equal(t, tc.output, g.String())
+	}
+}

--- a/mysql/mysql_interval.go
+++ b/mysql/mysql_interval.go
@@ -1,0 +1,150 @@
+package mysql
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/pingcap/errors"
+)
+
+// Like MySQL GTID Interval struct, [start, stop), left closed and right open
+// See MySQL rpl_gtid.h
+type Interval struct {
+	// The first GID of this interval.
+	Start int64
+	// The first GID after this interval.
+	Stop int64
+}
+
+// Interval is [start, stop), but the GTID string's format is [n] or [n1-n2], closed interval
+func parseInterval(str string) (i Interval, err error) {
+	p := strings.Split(str, "-")
+
+	switch len(p) {
+	case 1:
+		i.Start, err = strconv.ParseInt(p[0], 10, 64)
+		if err != nil {
+			return i, errors.Errorf("invalid interval format, not numeric: %v", err)
+		}
+		i.Stop = i.Start + 1
+	case 2:
+		i.Start, err = strconv.ParseInt(p[0], 10, 64)
+		if err == nil {
+			i.Stop, err = strconv.ParseInt(p[1], 10, 64)
+			i.Stop++
+		}
+	default:
+		err = errors.Errorf("invalid interval format, must n[-n]")
+	}
+
+	if err != nil {
+		return i, err
+	}
+
+	if i.Stop <= i.Start {
+		err = errors.Errorf("invalid interval format, must n[-n] and the end must >= start")
+	}
+
+	return i, err
+}
+
+func (i Interval) String() (s string) {
+	if i.Stop == i.Start+1 {
+		s += fmt.Sprintf("%d", i.Start)
+	} else {
+		s += fmt.Sprintf("%d-%d", i.Start, i.Stop-1)
+	}
+	return s
+}
+
+type IntervalSlice []Interval
+
+func (s IntervalSlice) Len() int {
+	return len(s)
+}
+
+// Sort is sorting intervals.
+func (s IntervalSlice) Sort() {
+	slices.SortFunc(s, func(a, b Interval) int {
+		if a.Start < b.Start {
+			return -1
+		} else if a.Start > b.Start {
+			return 1
+		}
+		if a.Stop < b.Stop {
+			return -1
+		} else if a.Stop > b.Stop {
+			return 1
+		}
+		return 0
+	})
+}
+
+func (s IntervalSlice) Normalize() IntervalSlice {
+	var n IntervalSlice
+	if len(s) == 0 {
+		return n
+	}
+
+	s.Sort()
+
+	n = append(n, s[0])
+
+	for i := 1; i < len(s); i++ {
+		last := n[len(n)-1]
+		if s[i].Start > last.Stop {
+			n = append(n, s[i])
+			continue
+		} else {
+			stop := max(last.Stop, s[i].Stop)
+			n[len(n)-1] = Interval{last.Start, stop}
+		}
+	}
+
+	return n
+}
+
+// InsertInterval is merging an Interval into an IntervalSlice
+func (s *IntervalSlice) InsertInterval(interval Interval) {
+	*s = append(*s, interval)
+	*s = s.Normalize()
+}
+
+// Contain returns true if sub in s
+func (s IntervalSlice) Contain(sub IntervalSlice) bool {
+	j := 0
+	for i := range sub {
+		for ; j < len(s); j++ {
+			if sub[i].Start > s[j].Stop {
+				continue
+			} else {
+				break
+			}
+		}
+		if j == len(s) {
+			return false
+		}
+
+		if sub[i].Start < s[j].Start || sub[i].Stop > s[j].Stop {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (s IntervalSlice) Equal(o IntervalSlice) bool {
+	if len(s) != len(o) {
+		return false
+	}
+
+	for i := range s {
+		if s[i].Start != o[i].Start || s[i].Stop != o[i].Stop {
+			return false
+		}
+	}
+
+	return true
+}

--- a/mysql/mysql_interval_test.go
+++ b/mysql/mysql_interval_test.go
@@ -1,0 +1,304 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTagRegexp(t *testing.T) {
+	cases := []struct {
+		tag string
+		ok  bool
+	}{
+		{"_", true},
+		{"_abcdefghi_abcdefghi", true},
+		{"_abcdefghi_abcdefghi_abcdefghi_a", true},
+		{"_abcdefghi_abcdefghi_abcdefghi_ab", false}, // too long
+		{"foo", true},
+		{"Foo", false},     // not lower case
+		{"foo-bar", false}, // character not allowed
+		{"foo123bar", true},
+		{"123bar", false}, // can't start with a number
+		{" foo", false},   // no spaces
+		{"", false},       // too short
+	}
+
+	for _, tc := range cases {
+		r := tagRegexp.MatchString(tc.tag)
+		require.Equal(t, tc.ok, r, tc.tag)
+	}
+}
+
+func TestParseInterval(t *testing.T) {
+	i, err := parseInterval("1-2")
+	require.NoError(t, err)
+	require.Equal(t, Interval{1, 3}, i)
+
+	i, err = parseInterval("1")
+	require.NoError(t, err)
+	require.Equal(t, Interval{1, 2}, i)
+
+	i, err = parseInterval("1-1")
+	require.NoError(t, err)
+	require.Equal(t, Interval{1, 2}, i)
+}
+
+func FuzzParseInterval(f *testing.F) {
+	cases := []string{
+		"1-2",
+		"1-100",
+		"1-100",
+	}
+	for _, tc := range cases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, str string) {
+		_, _ = parseInterval(str)
+	})
+}
+
+func TestIntervalSlice(t *testing.T) {
+	i := IntervalSlice{Interval{1, 2}, Interval{2, 4}, Interval{2, 3}}
+	i.Sort()
+	require.Equal(t, IntervalSlice{Interval{1, 2}, Interval{2, 3}, Interval{2, 4}}, i)
+	n := i.Normalize()
+	require.Equal(t, IntervalSlice{Interval{1, 4}}, n)
+
+	i = IntervalSlice{Interval{1, 2}, Interval{3, 5}, Interval{1, 3}}
+	i.Sort()
+	require.Equal(t, IntervalSlice{Interval{1, 2}, Interval{1, 3}, Interval{3, 5}}, i)
+	n = i.Normalize()
+	require.Equal(t, IntervalSlice{Interval{1, 5}}, n)
+
+	i = IntervalSlice{Interval{1, 2}, Interval{4, 5}, Interval{1, 3}}
+	i.Sort()
+	require.Equal(t, IntervalSlice{Interval{1, 2}, Interval{1, 3}, Interval{4, 5}}, i)
+	n = i.Normalize()
+	require.Equal(t, IntervalSlice{Interval{1, 3}, Interval{4, 5}}, n)
+
+	i = IntervalSlice{Interval{1, 4}, Interval{2, 3}}
+	i.Sort()
+	require.Equal(t, IntervalSlice{Interval{1, 4}, Interval{2, 3}}, i)
+	n = i.Normalize()
+	require.Equal(t, IntervalSlice{Interval{1, 4}}, n)
+
+	n1 := IntervalSlice{Interval{1, 3}, Interval{4, 5}}
+	n2 := IntervalSlice{Interval{1, 2}}
+
+	require.True(t, n1.Contain(n2))
+	require.False(t, n2.Contain(n1))
+
+	n1 = IntervalSlice{Interval{1, 3}, Interval{4, 5}}
+	n2 = IntervalSlice{Interval{1, 6}}
+
+	require.False(t, n1.Contain(n2))
+	require.True(t, n2.Contain(n1))
+}
+
+func TestIntervalSlice_Contain(t *testing.T) {
+	cases := []struct {
+		sliceA    IntervalSlice
+		sliceB    IntervalSlice
+		contained bool
+	}{
+		{
+			IntervalSlice{},
+			IntervalSlice{},
+			true,
+		},
+		{
+			IntervalSlice{
+				Interval{Start: 1, Stop: 3},
+			},
+			IntervalSlice{
+				Interval{Start: 1, Stop: 3},
+			},
+			true,
+		},
+		{
+			IntervalSlice{
+				Interval{Start: 1, Stop: 4},
+			},
+			IntervalSlice{
+				Interval{Start: 1, Stop: 3},
+			},
+			true,
+		},
+		{
+			IntervalSlice{
+				Interval{Start: 1, Stop: 3},
+			},
+			IntervalSlice{
+				Interval{Start: 1, Stop: 4},
+			},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		c := tc.sliceA.Contain(tc.sliceB)
+		require.Equal(t, tc.contained, c, "%s contains %s: expected %v", tc.sliceA, tc.sliceB, tc.contained)
+	}
+}
+
+func TestIntervalSlice_Equal(t *testing.T) {
+	cases := []struct {
+		sliceA IntervalSlice
+		sliceB IntervalSlice
+		equal  bool
+	}{
+		{
+			IntervalSlice{
+				Interval{Start: 10, Stop: 30},
+			},
+			IntervalSlice{
+				Interval{Start: 10, Stop: 30},
+			},
+			true,
+		},
+		{
+			IntervalSlice{
+				Interval{Start: 10, Stop: 30},
+			},
+			IntervalSlice{
+				Interval{Start: 10, Stop: 30},
+				Interval{Start: 40, Stop: 42},
+			},
+			false,
+		},
+		{
+			IntervalSlice{
+				Interval{Start: 10, Stop: 30},
+			},
+			IntervalSlice{
+				Interval{Start: 11, Stop: 30},
+			},
+			false,
+		},
+		{
+			IntervalSlice{
+				Interval{Start: 10, Stop: 30},
+			},
+			IntervalSlice{
+				Interval{Start: 10, Stop: 31},
+			},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		c := tc.sliceA.Equal(tc.sliceB)
+		require.Equal(t, tc.equal, c, "%s equals %s: expected %v", tc.sliceA, tc.sliceB, tc.equal)
+	}
+}
+
+func TestIntervalSlice_InsertInterval(t *testing.T) {
+	i := IntervalSlice{Interval{100, 200}}
+	i.InsertInterval(Interval{300, 400})
+	require.Equal(t, IntervalSlice{Interval{100, 200}, Interval{300, 400}}, i)
+
+	i.InsertInterval(Interval{50, 70})
+	require.Equal(t, IntervalSlice{Interval{50, 70}, Interval{100, 200}, Interval{300, 400}}, i)
+
+	i.InsertInterval(Interval{101, 201})
+	require.Equal(t, IntervalSlice{Interval{50, 70}, Interval{100, 201}, Interval{300, 400}}, i)
+
+	i.InsertInterval(Interval{99, 202})
+	require.Equal(t, IntervalSlice{Interval{50, 70}, Interval{99, 202}, Interval{300, 400}}, i)
+
+	i.InsertInterval(Interval{102, 302})
+	require.Equal(t, IntervalSlice{Interval{50, 70}, Interval{99, 400}}, i)
+
+	i.InsertInterval(Interval{500, 600})
+	require.Equal(t, IntervalSlice{Interval{50, 70}, Interval{99, 400}, Interval{500, 600}}, i)
+
+	i.InsertInterval(Interval{50, 100})
+	require.Equal(t, IntervalSlice{Interval{50, 400}, Interval{500, 600}}, i)
+
+	i.InsertInterval(Interval{900, 1000})
+	require.Equal(t, IntervalSlice{Interval{50, 400}, Interval{500, 600}, Interval{900, 1000}}, i)
+
+	i.InsertInterval(Interval{1010, 1020})
+	require.Equal(t, IntervalSlice{Interval{50, 400}, Interval{500, 600}, Interval{900, 1000}, Interval{1010, 1020}}, i)
+
+	i.InsertInterval(Interval{49, 1000})
+	require.Equal(t, IntervalSlice{Interval{49, 1000}, Interval{1010, 1020}}, i)
+
+	i.InsertInterval(Interval{1, 1012})
+	require.Equal(t, IntervalSlice{Interval{1, 1020}}, i)
+}
+
+func TestIntervalSlice_Len(t *testing.T) {
+	is := IntervalSlice{
+		Interval{Start: 1, Stop: 6},
+		Interval{Start: 1, Stop: 5},
+	}
+	require.Equal(t, 2, is.Len())
+}
+
+func TestIntervalSlice_Sort(t *testing.T) {
+	cases := []struct {
+		islice       IntervalSlice
+		isliceSorted IntervalSlice
+	}{
+		{
+			IntervalSlice{
+				Interval{Start: 1, Stop: 6},
+				Interval{Start: 1, Stop: 5},
+			},
+			IntervalSlice{
+				Interval{Start: 1, Stop: 5},
+				Interval{Start: 1, Stop: 6},
+			},
+		},
+		{
+			IntervalSlice{
+				Interval{Start: 1, Stop: 5},
+				Interval{Start: 10, Stop: 15},
+				Interval{Start: 5, Stop: 10},
+			},
+			IntervalSlice{
+				Interval{Start: 1, Stop: 5},
+				Interval{Start: 5, Stop: 10},
+				Interval{Start: 10, Stop: 15},
+			},
+		},
+		{
+			// duplicate interval, not expected.
+			IntervalSlice{
+				Interval{Start: 1, Stop: 5},
+				Interval{Start: 10, Stop: 15},
+				Interval{Start: 10, Stop: 15},
+				Interval{Start: 5, Stop: 10},
+			},
+			IntervalSlice{
+				Interval{Start: 1, Stop: 5},
+				Interval{Start: 5, Stop: 10},
+				Interval{Start: 10, Stop: 15},
+				Interval{Start: 10, Stop: 15},
+			},
+		},
+		{
+			// tag and start equal, which is not expected.
+			IntervalSlice{
+				Interval{Start: 1, Stop: 6},
+				Interval{Start: 1, Stop: 5},
+				Interval{Start: 1, Stop: 7},
+				Interval{Start: 1, Stop: 8},
+			},
+			IntervalSlice{
+				Interval{Start: 1, Stop: 5},
+				Interval{Start: 1, Stop: 6},
+				Interval{Start: 1, Stop: 7},
+				Interval{Start: 1, Stop: 8},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		require.NotEqual(t, tc.isliceSorted, tc.islice)
+		tc.islice.Sort()
+		require.Equal(t, tc.isliceSorted, tc.islice)
+	}
+}

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -1,247 +1,12 @@
 package mysql
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	_ "github.com/go-mysql-org/go-mysql/test_util" // Will register common flags
 )
-
-func TestMysqlGTIDInterval(t *testing.T) {
-	i, err := parseInterval("1-2")
-	require.NoError(t, err)
-	require.Equal(t, Interval{1, 3}, i)
-
-	i, err = parseInterval("1")
-	require.NoError(t, err)
-	require.Equal(t, Interval{1, 2}, i)
-
-	i, err = parseInterval("1-1")
-	require.NoError(t, err)
-	require.Equal(t, Interval{1, 2}, i)
-}
-
-func TestMysqlGTIDIntervalSlice(t *testing.T) {
-	i := IntervalSlice{Interval{1, 2}, Interval{2, 4}, Interval{2, 3}}
-	i.Sort()
-	require.Equal(t, IntervalSlice{Interval{1, 2}, Interval{2, 3}, Interval{2, 4}}, i)
-	n := i.Normalize()
-	require.Equal(t, IntervalSlice{Interval{1, 4}}, n)
-
-	i = IntervalSlice{Interval{1, 2}, Interval{3, 5}, Interval{1, 3}}
-	i.Sort()
-	require.Equal(t, IntervalSlice{Interval{1, 2}, Interval{1, 3}, Interval{3, 5}}, i)
-	n = i.Normalize()
-	require.Equal(t, IntervalSlice{Interval{1, 5}}, n)
-
-	i = IntervalSlice{Interval{1, 2}, Interval{4, 5}, Interval{1, 3}}
-	i.Sort()
-	require.Equal(t, IntervalSlice{Interval{1, 2}, Interval{1, 3}, Interval{4, 5}}, i)
-	n = i.Normalize()
-	require.Equal(t, IntervalSlice{Interval{1, 3}, Interval{4, 5}}, n)
-
-	i = IntervalSlice{Interval{1, 4}, Interval{2, 3}}
-	i.Sort()
-	require.Equal(t, IntervalSlice{Interval{1, 4}, Interval{2, 3}}, i)
-	n = i.Normalize()
-	require.Equal(t, IntervalSlice{Interval{1, 4}}, n)
-
-	n1 := IntervalSlice{Interval{1, 3}, Interval{4, 5}}
-	n2 := IntervalSlice{Interval{1, 2}}
-
-	require.True(t, n1.Contain(n2))
-	require.False(t, n2.Contain(n1))
-
-	n1 = IntervalSlice{Interval{1, 3}, Interval{4, 5}}
-	n2 = IntervalSlice{Interval{1, 6}}
-
-	require.False(t, n1.Contain(n2))
-	require.True(t, n2.Contain(n1))
-}
-
-func TestMysqlGTIDInsertInterval(t *testing.T) {
-	i := IntervalSlice{Interval{100, 200}}
-	i.InsertInterval(Interval{300, 400})
-	require.Equal(t, IntervalSlice{Interval{100, 200}, Interval{300, 400}}, i)
-
-	i.InsertInterval(Interval{50, 70})
-	require.Equal(t, IntervalSlice{Interval{50, 70}, Interval{100, 200}, Interval{300, 400}}, i)
-
-	i.InsertInterval(Interval{101, 201})
-	require.Equal(t, IntervalSlice{Interval{50, 70}, Interval{100, 201}, Interval{300, 400}}, i)
-
-	i.InsertInterval(Interval{99, 202})
-	require.Equal(t, IntervalSlice{Interval{50, 70}, Interval{99, 202}, Interval{300, 400}}, i)
-
-	i.InsertInterval(Interval{102, 302})
-	require.Equal(t, IntervalSlice{Interval{50, 70}, Interval{99, 400}}, i)
-
-	i.InsertInterval(Interval{500, 600})
-	require.Equal(t, IntervalSlice{Interval{50, 70}, Interval{99, 400}, Interval{500, 600}}, i)
-
-	i.InsertInterval(Interval{50, 100})
-	require.Equal(t, IntervalSlice{Interval{50, 400}, Interval{500, 600}}, i)
-
-	i.InsertInterval(Interval{900, 1000})
-	require.Equal(t, IntervalSlice{Interval{50, 400}, Interval{500, 600}, Interval{900, 1000}}, i)
-
-	i.InsertInterval(Interval{1010, 1020})
-	require.Equal(t, IntervalSlice{Interval{50, 400}, Interval{500, 600}, Interval{900, 1000}, Interval{1010, 1020}}, i)
-
-	i.InsertInterval(Interval{49, 1000})
-	require.Equal(t, IntervalSlice{Interval{49, 1000}, Interval{1010, 1020}}, i)
-
-	i.InsertInterval(Interval{1, 1012})
-	require.Equal(t, IntervalSlice{Interval{1, 1020}}, i)
-}
-
-func TestMysqlGTIDCodec(t *testing.T) {
-	us, err := ParseUUIDSet("de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2")
-	require.NoError(t, err)
-
-	require.Equal(t, "de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2", us.String())
-
-	buf := us.Encode()
-	err = us.Decode(buf)
-	require.NoError(t, err)
-
-	gs, err := ParseMysqlGTIDSet("de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2,de278ad0-2106-11e4-9f8e-6edd0ca20948:1-2")
-	require.NoError(t, err)
-
-	buf = gs.Encode()
-	o, err := DecodeMysqlGTIDSet(buf)
-	require.NoError(t, err)
-	require.Equal(t, gs, o)
-}
-
-func TestMysqlUpdate(t *testing.T) {
-	g1, err := ParseMysqlGTIDSet("3E11FA47-71CA-11E1-9E33-C80AA9429562:21-57")
-	require.NoError(t, err)
-
-	err = g1.Update("3E11FA47-71CA-11E1-9E33-C80AA9429562:21-58")
-	require.NoError(t, err)
-
-	require.Equal(t, "3E11FA47-71CA-11E1-9E33-C80AA9429562:21-58", strings.ToUpper(g1.String()))
-
-	g1, err = ParseMysqlGTIDSet(`
-		519CE70F-A893-11E9-A95A-B32DC65A7026:1-1154661,
-		5C9CA52B-9F11-11E9-8EAF-3381EC1CC790:1-244,
-		802D69FD-A3B6-11E9-B1EA-50BAB55BA838:1-1221371,
-		F2B50559-A891-11E9-B646-884FF0CA2043:1-479261
-	`)
-	require.NoError(t, err)
-
-	err = g1.Update(`
-		802D69FD-A3B6-11E9-B1EA-50BAB55BA838:1221110-1221371,
-		F2B50559-A891-11E9-B646-884FF0CA2043:478509-479266
-	`)
-	require.NoError(t, err)
-
-	g2, err := ParseMysqlGTIDSet(`
-		519CE70F-A893-11E9-A95A-B32DC65A7026:1-1154661,
-		5C9CA52B-9F11-11E9-8EAF-3381EC1CC790:1-244,
-		802D69FD-A3B6-11E9-B1EA-50BAB55BA838:1-1221371,
-		F2B50559-A891-11E9-B646-884FF0CA2043:1-479266
-	`)
-	require.NoError(t, err)
-	require.True(t, g1.Equal(g2))
-}
-
-func TestMysqlAddGTID(t *testing.T) {
-	g, err := ParseMysqlGTIDSet("3E11FA47-71CA-11E1-9E33-C80AA9429562:21-57")
-	require.NoError(t, err)
-
-	g1 := g.(*MysqlGTIDSet)
-
-	u, err := uuid.Parse("3E11FA47-71CA-11E1-9E33-C80AA9429562")
-	require.NoError(t, err)
-
-	g1.AddGTID(u, 58)
-	require.Equal(t, "3E11FA47-71CA-11E1-9E33-C80AA9429562:21-58", strings.ToUpper(g1.String()))
-
-	g1.AddGTID(u, 60)
-	require.Equal(t, "3E11FA47-71CA-11E1-9E33-C80AA9429562:21-58:60", strings.ToUpper(g1.String()))
-
-	g1.AddGTID(u, 59)
-	require.Equal(t, "3E11FA47-71CA-11E1-9E33-C80AA9429562:21-60", strings.ToUpper(g1.String()))
-
-	u2, err := uuid.Parse("519CE70F-A893-11E9-A95A-B32DC65A7026")
-	require.NoError(t, err)
-	g1.AddGTID(u2, 58)
-	g2, err := ParseMysqlGTIDSet(`
-	3E11FA47-71CA-11E1-9E33-C80AA9429562:21-60,
-	519CE70F-A893-11E9-A95A-B32DC65A7026:58
-`)
-	require.NoError(t, err)
-	require.True(t, g2.Equal(g1))
-}
-
-func TestMysqlGTIDContain(t *testing.T) {
-	g1, err := ParseMysqlGTIDSet("3E11FA47-71CA-11E1-9E33-C80AA9429562:23")
-	require.NoError(t, err)
-
-	g2, err := ParseMysqlGTIDSet("3E11FA47-71CA-11E1-9E33-C80AA9429562:21-57")
-	require.NoError(t, err)
-
-	require.True(t, g2.Contain(g1))
-	require.False(t, g1.Contain(g2))
-}
-
-func TestMysqlGTIDAdd(t *testing.T) {
-	testCases := []struct {
-		left, right, expected string
-	}{
-		// simple cases works:
-		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:23", "3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23:28-57"},
-		// summ is associative operation
-		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23:28-57"},
-		// merge intervals:
-		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:23-27", "3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23-57"},
-	}
-
-	for _, tc := range testCases {
-		m1 := mysqlGTIDfromString(t, tc.left)
-		m2 := mysqlGTIDfromString(t, tc.right)
-		err := m1.Add(m2)
-		require.NoError(t, err)
-		one := fmt.Sprintf("%s + %s = %s", tc.left, tc.right, strings.ToUpper(m1.String()))
-		other := fmt.Sprintf("%s + %s = %s", tc.left, tc.right, tc.expected)
-		require.Equal(t, other, one)
-	}
-}
-
-func TestMysqlGTIDMinus(t *testing.T) {
-	testCases := []struct {
-		left, right, expected string
-	}{
-		// Minuses that doesn't affect original value:
-		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:23", "3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23"},
-		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23", "3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57"},
-		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:23", "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-22:24-57", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23"},
-		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:23", "ABCDEF12-1234-5678-9012-345678901234:1-1000", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23"},
-		// Minuses that change original value:
-		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:20-57:60-90", "3E11FA47-71CA-11E1-9E33-C80AA9429562:23", "3E11FA47-71CA-11E1-9E33-C80AA9429562:20-22:24-57:60-90"},
-		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:20-57:60-90", "3E11FA47-71CA-11E1-9E33-C80AA9429562:22-70", "3E11FA47-71CA-11E1-9E33-C80AA9429562:20-21:71-90"},
-		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57", "3E11FA47-71CA-11E1-9E33-C80AA9429562:28-57", ""},
-		{"3E11FA47-71CA-11E1-9E33-C80AA9429562:20-21", "3E11FA47-71CA-11E1-9E33-C80AA9429562:21", "3E11FA47-71CA-11E1-9E33-C80AA9429562:20"},
-		{"582A11ED-786C-11EC-ACCC-E0356662B76E:1-209692", "582A11ED-786C-11EC-ACCC-E0356662B76E:1-146519", "582A11ED-786C-11EC-ACCC-E0356662B76E:146520-209692"},
-		{"582A11ED-786C-11EC-ACCC-E0356662B76E:1-209692", "582A11ED-786C-11EC-ACCC-E0356662B76E:2-146519", "582A11ED-786C-11EC-ACCC-E0356662B76E:1:146520-209692"},
-	}
-
-	for _, tc := range testCases {
-		m1 := mysqlGTIDfromString(t, tc.left)
-		m2 := mysqlGTIDfromString(t, tc.right)
-		err := m1.Minus(m2)
-		require.NoError(t, err)
-		one := fmt.Sprintf("%s - %s = %s", tc.left, tc.right, strings.ToUpper(m1.String()))
-		other := fmt.Sprintf("%s - %s = %s", tc.left, tc.right, tc.expected)
-		require.Equal(t, other, one)
-	}
-}
 
 func TestMysqlParseBinaryInt8(t *testing.T) {
 	i8 := ParseBinaryInt8([]byte{128})
@@ -316,26 +81,10 @@ func TestMysqlNullDecode(t *testing.T) {
 	require.Equal(t, 1, n)
 }
 
-func TestMysqlUUIDClone(t *testing.T) {
-	us, err := ParseUUIDSet("de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2")
-	require.NoError(t, err)
-	require.Equal(t, "de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2", us.String())
-
-	clone := us.Clone()
-	require.Equal(t, "de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2", clone.String())
-}
-
 func TestMysqlEmptyDecode(t *testing.T) {
 	_, isNull, n := LengthEncodedInt(nil)
 	require.True(t, isNull)
 	require.Equal(t, 0, n)
-}
-
-func mysqlGTIDfromString(t *testing.T, gtidStr string) MysqlGTIDSet {
-	gtid, err := ParseMysqlGTIDSet(gtidStr)
-	require.NoError(t, err)
-
-	return *gtid.(*MysqlGTIDSet)
 }
 
 func TestValidateFlavor(t *testing.T) {
@@ -359,13 +108,4 @@ func TestValidateFlavor(t *testing.T) {
 			require.Error(t, err)
 		}
 	}
-}
-
-func TestMysqlGTIDSetIsEmpty(t *testing.T) {
-	emptyGTIDSet := new(MysqlGTIDSet)
-	emptyGTIDSet.Sets = make(map[string]*UUIDSet)
-	require.True(t, emptyGTIDSet.IsEmpty())
-
-	nonEmptyGTIDSet := mysqlGTIDfromString(t, "de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2")
-	require.False(t, nonEmptyGTIDSet.IsEmpty())
 }

--- a/mysql/mysql_uuidset.go
+++ b/mysql/mysql_uuidset.go
@@ -1,0 +1,338 @@
+package mysql
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+	"regexp"
+	"strings"
+
+	"github.com/go-mysql-org/go-mysql/utils"
+	"github.com/google/uuid"
+	"github.com/pingcap/errors"
+)
+
+// Note that MySQL normalized the value set by `SET GTID_NEXT='AUTOMATIC:<tag>`
+// by:
+// - Removing any length of leading and trailing whitespace (tabs, spaces).
+// - Lowercasing the tag
+var tagRegexp = regexp.MustCompile(`^[a-z_][a-z0-9_]{0,31}$`)
+
+// TSID is a Tagged SID
+type TSID struct {
+	SID uuid.UUID
+	Tag string
+}
+
+func (t *TSID) String() string {
+	if t.Tag == "" {
+		return t.SID.String()
+	}
+	return fmt.Sprintf("%s:%s", t.SID.String(), t.Tag)
+}
+
+// MarshalBinary is returning the TSID in binary format
+//
+// if there is no tag:
+// <uuid[16]>
+//
+// if there is a tag:
+// <uuid[16]><length[1]><tag[length]>
+func (t *TSID) MarshalBinary() ([]byte, error) {
+	b, _ := t.SID.MarshalBinary()
+	if t.Tag != "" {
+		b = append(b, byte(len(t.Tag)<<1))
+	}
+	return append(b, []byte(t.Tag)...), nil
+}
+
+// Refer:
+// - https://dev.mysql.com/doc/refman/8.4/en/replication-gtids-concepts.html
+// - https://bugs.mysql.com/bug.php?id=116789
+type UUIDSet struct {
+	TSID      TSID
+	Intervals IntervalSlice
+}
+
+// ParseUUIDSet is returning the first UUIDSet from str
+func ParseUUIDSet(str string) (*UUIDSet, error) {
+	str = strings.TrimSpace(str)
+	sep := strings.Split(str, ":")
+	if len(sep) < 2 {
+		return nil, errors.Errorf("invalid GTID format, must UUID[:tag]:interval[[:tag]:interval]")
+	}
+
+	var err error
+	s := new(UUIDSet)
+	if s.TSID.SID, err = uuid.Parse(sep[0]); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	start := 1
+	if tagRegexp.MatchString(sep[1]) {
+		s.TSID.Tag = sep[1]
+		start++
+	}
+
+	// Handle interval
+	for i := start; i < len(sep); i++ {
+		if tagRegexp.MatchString(sep[i]) {
+			// We found another tag, so that's the next set
+			break
+		} else {
+			if in, err := parseInterval(sep[i]); err != nil {
+				return nil, errors.Trace(err)
+			} else {
+				s.Intervals = append(s.Intervals, in)
+			}
+		}
+	}
+
+	if len(s.Intervals) < 1 {
+		return nil, errors.New("invalid GTID format, missing interval")
+	}
+
+	s.Intervals = s.Intervals.Normalize()
+
+	return s, nil
+}
+
+// ParseUUIDSets is returning all UUIDSets from str
+// str must contain sets with the same UUID, but different tags
+func ParseUUIDSets(str string) ([]UUIDSet, error) {
+	str = strings.TrimSpace(str)
+	sep := strings.Split(str, ":")
+	if len(sep) < 2 {
+		return nil, errors.Errorf("invalid GTID format, must UUID[:tag]:interval[[:tag]:interval]")
+	}
+
+	u, err := uuid.Parse(sep[0])
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var sets []UUIDSet
+
+	s := UUIDSet{
+		TSID: TSID{SID: u},
+	}
+	// Handle interval
+	for i := 1; i < len(sep); i++ {
+		if tagRegexp.MatchString(sep[i]) {
+			if s.Intervals != nil {
+				sets = append(sets, s)
+				s = UUIDSet{
+					TSID: TSID{SID: u},
+				}
+			} else if s.Intervals == nil {
+				return nil, errors.New("invalid GTID format, consecutive tags")
+			}
+			s.TSID.Tag = sep[i]
+		} else {
+			if in, err := parseInterval(sep[i]); err != nil {
+				return nil, errors.Trace(err)
+			} else {
+				s.Intervals = append(s.Intervals, in)
+			}
+		}
+
+		if s.Intervals != nil {
+			s.Intervals = s.Intervals.Normalize()
+		}
+
+		if i+1 == len(sep) {
+			sets = append(sets, s)
+		}
+	}
+
+	return sets, nil
+}
+
+func NewUUIDSet(tsid TSID, in ...Interval) *UUIDSet {
+	s := new(UUIDSet)
+	s.TSID = tsid
+
+	s.Intervals = in
+	s.Intervals = s.Intervals.Normalize()
+
+	return s
+}
+
+func (s *UUIDSet) Contain(sub *UUIDSet) bool {
+	if s.TSID != sub.TSID {
+		return false
+	}
+
+	return s.Intervals.Contain(sub.Intervals)
+}
+
+func (s *UUIDSet) Bytes() []byte {
+	var buf bytes.Buffer
+
+	buf.WriteString(s.TSID.String())
+
+	for _, i := range s.Intervals {
+		buf.WriteString(":")
+		buf.WriteString(i.String())
+	}
+
+	return buf.Bytes()
+}
+
+func (s *UUIDSet) AddInterval(in IntervalSlice) {
+	s.Intervals = append(s.Intervals, in...)
+	s.Intervals = s.Intervals.Normalize()
+}
+
+func (s *UUIDSet) MinusInterval(in IntervalSlice) {
+	var n IntervalSlice
+	in = in.Normalize()
+
+	i, j := 0, 0
+	var minuend Interval
+	var subtrahend Interval
+	for i < len(s.Intervals) {
+		if minuend.Stop != s.Intervals[i].Stop { // `i` changed?
+			minuend = s.Intervals[i]
+		}
+		if j < len(in) {
+			subtrahend = in[j]
+		} else {
+			subtrahend = Interval{Start: math.MaxInt64, Stop: math.MaxInt64}
+		}
+
+		if minuend.Stop <= subtrahend.Start {
+			// no overlapping
+			n = append(n, minuend)
+			i++
+		} else if minuend.Start >= subtrahend.Stop {
+			// no overlapping
+			j++
+		} else {
+			if minuend.Start < subtrahend.Start && minuend.Stop <= subtrahend.Stop {
+				n = append(n, Interval{minuend.Start, subtrahend.Start})
+				i++
+			} else if minuend.Start >= subtrahend.Start && minuend.Stop > subtrahend.Stop {
+				minuend = Interval{subtrahend.Stop, minuend.Stop}
+				j++
+			} else if minuend.Start >= subtrahend.Start && minuend.Stop <= subtrahend.Stop {
+				// minuend is completely removed
+				i++
+			} else if minuend.Start < subtrahend.Start && minuend.Stop > subtrahend.Stop {
+				n = append(n, Interval{minuend.Start, subtrahend.Start})
+				minuend = Interval{subtrahend.Stop, minuend.Stop}
+				j++
+			} else {
+				panic("should never be here")
+			}
+		}
+	}
+
+	s.Intervals = n.Normalize()
+}
+
+func (s *UUIDSet) String() string {
+	return utils.ByteSliceToString(s.Bytes())
+}
+
+func (s *UUIDSet) encode(format GtidFormat, w io.Writer) {
+	b, _ := s.TSID.SID.MarshalBinary()
+	if format == GtidFormatTagged {
+		b = append(b, byte(len(s.TSID.Tag)<<1))
+		b = append(b, []byte(s.TSID.Tag)...)
+	}
+	_, _ = w.Write(b)
+
+	n := int64(len(s.Intervals))
+	_ = binary.Write(w, binary.LittleEndian, n)
+
+	for _, i := range s.Intervals {
+		_ = binary.Write(w, binary.LittleEndian, i.Start)
+		_ = binary.Write(w, binary.LittleEndian, i.Stop)
+	}
+}
+
+// Encode is encoding the GTID Set in the format of COM_BINLOG_DUMP_GTID
+func (s *UUIDSet) Encode(format GtidFormat) []byte {
+	var buf bytes.Buffer
+
+	s.encode(format, &buf)
+
+	return buf.Bytes()
+}
+
+func (s *UUIDSet) decode(data []byte, format GtidFormat) (int, error) {
+	if len(data) < 24 {
+		return 0, errors.Errorf("invalid uuid set buffer, expected 24 or more but got %d", len(data))
+	}
+	pos := 0
+	var err error
+
+	if s.TSID.SID, err = uuid.FromBytes(data[0:16]); err != nil {
+		return 0, err
+	}
+	pos += 16
+
+	if format == GtidFormatTagged {
+		if pos >= len(data) {
+			return 0, errors.New("invalid uuid set buffer, tag length expected")
+		}
+		taglen := int(data[pos] >> 1)
+		pos++
+		if pos+taglen > len(data) {
+			return 0, errors.New("invalid uuid set buffer, tag extends beyond data")
+		}
+		s.TSID.Tag = string(data[pos : pos+taglen])
+		pos += taglen
+	}
+
+	if pos+8 > len(data) {
+		return 0, errors.New("invalid uuid set buffer, truncated interval length")
+	}
+	n := int64(binary.LittleEndian.Uint64(data[pos : pos+8]))
+	pos += 8
+	if len(data) < int(16*n)+pos {
+		return 0, errors.Errorf("invalid uuid set buffer, expected %d, but got %d", pos+int(16*n), len(data))
+	}
+	if n < 0 {
+		return 0, errors.New("invalid uuid set buffer, interval count can't be negative")
+	}
+	if n > math.MaxInt64/16 { // 16 = minimum interval size of start+stop (8+8)
+		return 0, errors.Errorf("invalid uuid set buffer, too many intervals: %d", n)
+	}
+	if len(s.Intervals) == 0 {
+		s.Intervals = make([]Interval, 0, n)
+	} else {
+		s.Intervals = append(make([]Interval, 0, len(s.Intervals)+int(n)), s.Intervals...)
+	}
+
+	var in Interval
+	for range n {
+		in.Start = int64(binary.LittleEndian.Uint64(data[pos : pos+8]))
+		pos += 8
+		in.Stop = int64(binary.LittleEndian.Uint64(data[pos : pos+8]))
+		pos += 8
+		s.Intervals = append(s.Intervals, in)
+	}
+
+	return pos, nil
+}
+
+// Decode is decoding the GTID Set in the format of COM_BINLOG_DUMP_GTID
+func (s *UUIDSet) Decode(data []byte, format GtidFormat) error {
+	n, err := s.decode(data, format)
+	if n != len(data) {
+		return errors.Errorf("invalid uuid set buffer, decoded %d bytes, but data length is %d bytes", n, len(data))
+	}
+	return err
+}
+
+func (s *UUIDSet) Clone() *UUIDSet {
+	clone := new(UUIDSet)
+	clone.TSID = s.TSID
+	clone.Intervals = make([]Interval, len(s.Intervals))
+	copy(clone.Intervals, s.Intervals)
+	return clone
+}

--- a/mysql/mysql_uuidset_test.go
+++ b/mysql/mysql_uuidset_test.go
@@ -1,0 +1,494 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseUUIDSet(t *testing.T) {
+	cases := []struct {
+		gtid      string // input
+		uuidSet   string // result
+		tsid      string // tsid of result
+		intervals IntervalSlice
+	}{
+		{
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2:1",
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2:1",
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2",
+			IntervalSlice{
+				Interval{1, 2},
+			},
+		},
+		{
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2:1-3",
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2:1-3",
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2",
+			IntervalSlice{
+				Interval{1, 4},
+			},
+		},
+		{
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2:1-3:5-8",
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2:1-3:5-8",
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2",
+			IntervalSlice{
+				Interval{1, 4},
+				Interval{5, 9},
+			},
+		},
+		{
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2:1-3:5:7-8:10",
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2:1-3:5:7-8:10",
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2",
+			IntervalSlice{
+				Interval{1, 4},
+				Interval{5, 6},
+				Interval{7, 9},
+				Interval{10, 11},
+			},
+		},
+		{
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2:foobar:1-10",
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2:foobar:1-10",
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2:foobar",
+			IntervalSlice{
+				Interval{1, 11},
+			},
+		},
+		{
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2:1-3:barfoo:1-5:foobar:1",
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2:1-3", // only the first set
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2",
+			IntervalSlice{
+				Interval{1, 4},
+			},
+		},
+		{
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2:foo:1-4:6-8",
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2:foo:1-4:6-8",
+			"40eb4bee-1972-11f1-acc9-324f96ede8f2:foo",
+			IntervalSlice{
+				Interval{Start: 1, Stop: 5},
+				Interval{Start: 6, Stop: 9},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		uuidset, err := ParseUUIDSet(tc.gtid)
+		require.NoError(t, err, tc.gtid)
+		require.Equal(t, tc.uuidSet, uuidset.String())
+		require.Equal(t, tc.tsid, uuidset.TSID.String())
+		require.Equal(t, tc.intervals.Normalize(), uuidset.Intervals, tc.gtid)
+	}
+}
+
+func FuzzParseUUIDSet(f *testing.F) {
+	cases := []string{
+		"40eb4bee-1972-11f1-acc9-324f96ede8f2:1",
+		"40eb4bee-1972-11f1-acc9-324f96ede8f2:1-3",
+		"40eb4bee-1972-11f1-acc9-324f96ede8f2:1-3:5-8",
+		"40eb4bee-1972-11f1-acc9-324f96ede8f2:1-3:5:7-8:10",
+		"40eb4bee-1972-11f1-acc9-324f96ede8f2:foobar:1-10",
+		"40eb4bee-1972-11f1-acc9-324f96ede8f2:1-3:barfoo:1-5:foobar:1",
+		"40eb4bee-1972-11f1-acc9-324f96ede8f2:1-3:abcdefgh:1:abcdefghijklmnopqrstuvwxyz:1:abcdefghijklmnopqrstuvwxyz_____:1:abcdefghijklmnopqrstuvwxyz_____x:1:foobar:1-2:foobaz:1:x:1",
+		"40eb4bee-1972-11f1-acc9-324f96ede8f2:foo:1-4",
+		"40eb4bee-1972-11f1-acc9-324f96ede8f2:foo:1-4:6-8",
+		"40eb4bee-1972-11f1-acc9-324f96ede8f2:bar:6-8:10:foo:1-4:6-8",
+	}
+
+	for _, tc := range cases {
+		f.Add(tc)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		_, _ = ParseUUIDSet(input)
+	})
+}
+
+func TestParseUUIDSet_Invalid(t *testing.T) {
+	cases := []struct {
+		gtid string
+	}{
+		{"40eb4bee-1972-11f1-acc9-324f96ede8f2:1-3:abcdefghijklmnopqrstuvwxyz_____xy:1"}, // tag too long
+		{"40eb4bee-1972-11f1-acc9-324f96ede8f2:Foo:1-3"},                                 // tag not normalized
+		{"40eb4bee-1972-11f1-acc9-324f96ede8f2:foo-bar:1-3"},                             // tag contains invalid character
+		{"40eb4bee-1972-11f1-acc9-324f96ede8f2:foobar"},                                  // tag without start/stop
+		{"40eb4bee-1972-11f1-acc9-324f96ede8f2:10-5"},                                    // start > stop
+		{"40eb4bee-1972-11f1-acc9-324f96ede8f2:foo:10-5"},                                // tag and start > stop
+		{"40eb4bee-1972-11f1-acc9-324f96ede8f2:1-2-3"},                                   // too many parts after split on -
+		{"40eb4bee-1972-11f1-acc9-324f96ede8f2:foo:1-2-3"},                               // tag and too many parts after split on -
+		{"40eb4bee-1972-11f1-acc9-324f96ede8f2:"},                                        // missing interval
+		{"40eb4bee-1972-11f1-acc9-324f96ede8f2"},                                         // split on : doesn't give two parts
+		{"40eb4bee-1972-11f1-acc9-324f96ede8f:1-2"},                                      // Not a valid UUID
+		{"40eb4bee-1972-11f1-acc9-324f96ede8f2:foo:bar:1-2"},                             // Tag not followed by interval
+	}
+
+	for _, tc := range cases {
+		_, err := ParseUUIDSet(tc.gtid)
+		require.Error(t, err, tc.gtid)
+	}
+}
+
+func TestNewUUIDSet(t *testing.T) {
+	tsid := TSID{SID: uuid.New()}
+	s := NewUUIDSet(tsid)
+	require.Equal(t, &UUIDSet{TSID: tsid}, s)
+
+	s2 := NewUUIDSet(tsid, Interval{Start: 1, Stop: 5})
+	require.Equal(t,
+		&UUIDSet{
+			TSID: tsid,
+			Intervals: IntervalSlice{
+				Interval{Start: 1, Stop: 5},
+			},
+		},
+		s2,
+	)
+
+	s3 := NewUUIDSet(tsid,
+		Interval{Start: 1, Stop: 5},
+		Interval{Start: 1, Stop: 10},
+	)
+	require.Equal(t,
+		&UUIDSet{
+			TSID: tsid,
+			Intervals: IntervalSlice{
+				Interval{Start: 1, Stop: 10},
+			},
+		},
+		s3,
+	)
+}
+
+func TestUUIDSet(t *testing.T) {
+	us, err := ParseUUIDSet("de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2")
+	require.NoError(t, err)
+	require.Equal(t, "de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2", us.String())
+
+	buf := us.Encode(GtidFormatClassic)
+	err = us.Decode(buf, GtidFormatClassic)
+	require.NoError(t, err)
+}
+
+func TestUUIDSet_Clone(t *testing.T) {
+	us, err := ParseUUIDSet("de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2")
+	require.NoError(t, err)
+	require.Equal(t, "de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2", us.String())
+
+	clone := us.Clone()
+	require.Equal(t, "de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2", clone.String())
+}
+
+func TestUUIDSet_Contain(t *testing.T) {
+	us1, err := ParseUUIDSet("de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2")
+	require.NoError(t, err)
+
+	us2, err := ParseUUIDSet("de278ad0-2106-11e4-9f8e-6edd0ca20940:1-2")
+	require.NoError(t, err)
+
+	us3, err := ParseUUIDSet("de278ad0-2106-11e4-9f8e-6edd0ca20947:foo:1-2")
+	require.NoError(t, err)
+
+	require.True(t, us1.Contain(us1))
+	require.False(t, us1.Contain(us2))
+	require.False(t, us1.Contain(us3))
+}
+
+func TestUUIDSet_Decode(t *testing.T) {
+	tsid := TSID{
+		SID: uuid.UUID{13, 253, 150, 255, 112, 142, 65, 232, 128, 185, 191, 63, 181, 206, 227, 252},
+	}
+	cases := []struct {
+		format    GtidFormat
+		input     []byte
+		set       *UUIDSet
+		expectErr bool
+	}{
+		{
+			GtidFormatClassic,
+			[]byte{
+				13, 253, 150, 255, 112, 142, 65, 232, 128, 185, 191, 63, 181, 206, 227, 252, // uuid
+				1, 0, 0, 0, 0, 0, 0, 0, // interval
+				1, 0, 0, 0, 0, 0, 0, 0, // start
+				0xa, 0, 0, 0, 0, 0, 0, 0, // stop
+			},
+			NewUUIDSet(tsid, Interval{Start: 1, Stop: 10}),
+			false,
+		},
+		{
+			GtidFormatClassic,
+			[]byte{
+				13, 253, 150, 255, 112, 142, 65, 232, 128, 185, 191, 63, 181, 206, 227, 252, // uuid
+				1, 0, 0, 0, 0, 0, 0, 0, // interval
+				1, 0, 0, 0, 0, 0, 0, 0, // start
+				0xa, 0, 0, 0, 0, 0, 0, 0, // stop
+				0xff, // invalid
+			},
+			NewUUIDSet(tsid, Interval{Start: 1, Stop: 10}),
+			true,
+		},
+		{
+			// Possibly invalid
+			GtidFormatClassic,
+			[]byte{
+				13, 253, 150, 255, 112, 142, 65, 232, 128, 185, 191, 63, 181, 206, 227, 252, // uuid
+				0, 0, 0, 0, 0, 0, 0, 0, // interval
+			},
+			&UUIDSet{
+				TSID:      tsid,
+				Intervals: IntervalSlice{},
+			},
+			false,
+		},
+		{
+			// Possibly invalid
+			GtidFormatClassic,
+			[]byte{
+				13, 253, 150, 255, 112, 142, 65, 232, 128, 185, 191, 63, 181, 206, 227, 252, // uuid
+				1, 0, 0, 0, 0, 0, 0, 0, // interval
+				// truncated
+			},
+			&UUIDSet{
+				TSID:      tsid,
+				Intervals: IntervalSlice{},
+			},
+			true,
+		},
+		{
+			GtidFormatClassic,
+			[]byte{
+				13, 253, 150, 255, 112, 142, 65, 232, 128, 185, 191, 63, 181, 206, 227, 252, // uuid
+				2, 0, 0, 0, 0, 0, 0, 0, // intervals
+				1, 0, 0, 0, 0, 0, 0, 0, // start
+				0x0a, 0, 0, 0, 0, 0, 0, 0, // stop
+				0x7b, 0, 0, 0, 0, 0, 0, 0, // start
+				0x80, 0xc3, 0xc9, 0x1, 0, 0, 0, 0, // stop
+			},
+			NewUUIDSet(tsid, Interval{Start: 1, Stop: 10}, Interval{Start: 123, Stop: 30000000}),
+			false,
+		},
+		{
+			// 071a4ecc-1bf9-11f1-a838-e6dd1807d029:mytagabcdef:1-2
+			GtidFormatTagged,
+			[]byte{
+				0x7, 0x1a, 0x4e, 0xcc, 0x1b, 0xf9, 0x11, 0xf1, 0xa8, 0x38, 0xe6, 0xdd, 0x18, 0x7, 0xd0, 0x29, // uuid
+				0x16,                                                             // tag length (needs >>1)
+				0x6d, 0x79, 0x74, 0x61, 0x67, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, // tag
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // intervals
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // start
+				0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // stop
+			},
+			NewUUIDSet(
+				TSID{
+					SID: uuid.UUID{0x7, 0x1a, 0x4e, 0xcc, 0x1b, 0xf9, 0x11, 0xf1, 0xa8, 0x38, 0xe6, 0xdd, 0x18, 0x7, 0xd0, 0x29},
+					Tag: "mytagabcdef",
+				},
+				Interval{Start: 1, Stop: 3},
+			),
+			false,
+		},
+		{
+			// 071a4ecc-1bf9-11f1-a838-e6dd1807d029:1-2:mytagabcdef:1
+			GtidFormatTagged,
+			[]byte{
+				0x7, 0x1a, 0x4e, 0xcc, 0x1b, 0xf9, 0x11, 0xf1, 0xa8, 0x38, 0xe6, 0xdd, 0x18, 0x7, 0xd0, 0x29, // uuid
+				0x0,                                    // tag length (no tag)
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // intervals
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // start
+				0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // stop
+				0x7, 0x1a, 0x4e, 0xcc, 0x1b, 0xf9, 0x11, 0xf1, 0xa8, 0x38, 0xe6, 0xdd, 0x18, 0x7, 0xd0, 0x29, // uuid
+				0x16,                                                             // tag length (needs >>1)
+				0x6d, 0x79, 0x74, 0x61, 0x67, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, // tag
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // intervals
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // start
+				0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // stop
+			},
+			NewUUIDSet(
+				TSID{SID: uuid.UUID{0x7, 0x1a, 0x4e, 0xcc, 0x1b, 0xf9, 0x11, 0xf1, 0xa8, 0x38, 0xe6, 0xdd, 0x18, 0x7, 0xd0, 0x29}},
+				Interval{Start: 1, Stop: 3},
+			),
+			true,
+		},
+	}
+
+	for i, tc := range cases {
+		rs := UUIDSet{}
+		err := rs.Decode(tc.input, tc.format)
+		if tc.expectErr {
+			require.Error(t, err, "case %d", i)
+		} else {
+			if err != nil {
+				t.Logf("\nExpected UUIDSet:\n%#v\nGot UUIDSet:\n%#v", tc.set, &rs)
+			}
+			require.NoError(t, err, "case %d", i)
+			require.Equal(t, tc.set, &rs, "case %d", i)
+		}
+	}
+}
+
+func FuzzUUIDSet_Decode_classic(f *testing.F) {
+	cases := [][]byte{
+		{
+			13, 253, 150, 255, 112, 142, 65, 232, 128, 185, 191, 63, 181, 206, 227, 252, // uuid
+			1, 0, 0, 0, 0, 0, 0, 0, // interval
+			1, 0, 0, 0, 0, 0, 0, 0, // start
+			0xa, 0, 0, 0, 0, 0, 0, 0, // stop
+		},
+		{
+			13, 253, 150, 255, 112, 142, 65, 232, 128, 185, 191, 63, 181, 206, 227, 252, // uuid
+			0, 0, 0, 0, 0, 0, 0, 0, // interval
+		},
+		{
+			13, 253, 150, 255, 112, 142, 65, 232, 128, 185, 191, 63, 181, 206, 227, 252, // uuid
+			2, 0, 0, 0, 0, 0, 0, 0, // intervals
+			1, 0, 0, 0, 0, 0, 0, 0, // start
+			0x0a, 0, 0, 0, 0, 0, 0, 0, // stop
+			0x7b, 0, 0, 0, 0, 0, 0, 0, // start
+			0x80, 0xc3, 0xc9, 0x1, 0, 0, 0, 0, // stop
+		},
+	}
+
+	for _, tc := range cases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, input []byte) {
+		rs := UUIDSet{}
+		_ = rs.Decode(input, GtidFormatClassic)
+	})
+}
+
+func FuzzUUIDSet_Decode_tagged(f *testing.F) {
+	cases := [][]byte{
+		{
+			0x7, 0x1a, 0x4e, 0xcc, 0x1b, 0xf9, 0x11, 0xf1, 0xa8, 0x38, 0xe6, 0xdd, 0x18, 0x7, 0xd0, 0x29, // uuid
+			0x16,                                                             // tag length (needs >>1)
+			0x6d, 0x79, 0x74, 0x61, 0x67, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, // tag
+			0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // intervals
+			0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // start
+			0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // stop
+		},
+		{
+			0x7, 0x1a, 0x4e, 0xcc, 0x1b, 0xf9, 0x11, 0xf1, 0xa8, 0x38, 0xe6, 0xdd, 0x18, 0x7, 0xd0, 0x29, // uuid
+			0x0,                                    // tag length (no tag)
+			0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // intervals
+			0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // start
+			0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // stop
+			0x7, 0x1a, 0x4e, 0xcc, 0x1b, 0xf9, 0x11, 0xf1, 0xa8, 0x38, 0xe6, 0xdd, 0x18, 0x7, 0xd0, 0x29, // uuid
+			0x16,                                                             // tag length (needs >>1)
+			0x6d, 0x79, 0x74, 0x61, 0x67, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, // tag
+			0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // intervals
+			0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // start
+			0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // stop
+		},
+	}
+
+	for _, tc := range cases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, input []byte) {
+		rs := UUIDSet{}
+		_ = rs.Decode(input, GtidFormatTagged)
+	})
+}
+
+func TestUUIDSet_Encode(t *testing.T) {
+	tsid := TSID{
+		SID: uuid.UUID{13, 253, 150, 255, 112, 142, 65, 232, 128, 185, 191, 63, 181, 206, 227, 252},
+	}
+	cases := []struct {
+		set    *UUIDSet
+		format GtidFormat
+		result []byte
+	}{
+		{
+			NewUUIDSet(tsid, Interval{Start: 1, Stop: 10}),
+			GtidFormatClassic,
+			[]byte{
+				13, 253, 150, 255, 112, 142, 65, 232, 128, 185, 191, 63, 181, 206, 227, 252, // uuid
+				1, 0, 0, 0, 0, 0, 0, 0, // interval
+				1, 0, 0, 0, 0, 0, 0, 0, // start
+				0xa, 0, 0, 0, 0, 0, 0, 0, // stop
+			},
+		},
+		{
+			NewUUIDSet(tsid, Interval{Start: 1, Stop: 10}, Interval{Start: 123, Stop: 30000000}),
+			GtidFormatClassic,
+			[]byte{
+				13, 253, 150, 255, 112, 142, 65, 232, 128, 185, 191, 63, 181, 206, 227, 252, // uuid
+				2, 0, 0, 0, 0, 0, 0, 0, // intervals
+				1, 0, 0, 0, 0, 0, 0, 0, // start
+				0x0a, 0, 0, 0, 0, 0, 0, 0, // stop
+				0x7b, 0, 0, 0, 0, 0, 0, 0, // start
+				0x80, 0xc3, 0xc9, 0x1, 0, 0, 0, 0, // stop
+			},
+		},
+		{
+			// 071a4ecc-1bf9-11f1-a838-e6dd1807d029::mytagabcdef:1-2
+			NewUUIDSet(
+				TSID{
+					SID: uuid.UUID{0x7, 0x1a, 0x4e, 0xcc, 0x1b, 0xf9, 0x11, 0xf1, 0xa8, 0x38, 0xe6, 0xdd, 0x18, 0x7, 0xd0, 0x29},
+					Tag: "mytagabcdef",
+				},
+				Interval{Start: 1, Stop: 3},
+			),
+			GtidFormatTagged,
+			[]byte{
+				0x7, 0x1a, 0x4e, 0xcc, 0x1b, 0xf9, 0x11, 0xf1, 0xa8, 0x38, 0xe6, 0xdd, 0x18, 0x7, 0xd0, 0x29, // uuid
+				0x16,                                                             // tag length (needs >>1)
+				0x6d, 0x79, 0x74, 0x61, 0x67, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, // tag
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // intervals
+				0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // start
+				0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // stop
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		d := tc.set.Encode(tc.format)
+		require.Equal(t, tc.result, d, "case %d (format %s)", i, tc.format.String())
+	}
+}
+
+func TestUUIDSet_MinusInterval(t *testing.T) {
+	tsid := TSID{
+		SID: uuid.New(),
+	}
+	cases := []struct {
+		set    *UUIDSet
+		in     IntervalSlice
+		result *UUIDSet
+	}{
+		{
+			NewUUIDSet(tsid, Interval{Start: 1, Stop: 10}),
+			IntervalSlice{
+				Interval{Start: 8, Stop: 10},
+			},
+			NewUUIDSet(tsid, Interval{Start: 1, Stop: 8}),
+		},
+		{
+			NewUUIDSet(tsid, Interval{Start: 1, Stop: 10}),
+			IntervalSlice{
+				Interval{Start: 20, Stop: 21},
+			},
+			NewUUIDSet(tsid, Interval{Start: 1, Stop: 10}),
+		},
+		{
+			NewUUIDSet(tsid, Interval{Start: 1, Stop: 10}),
+			IntervalSlice{
+				Interval{Start: 5, Stop: 8},
+			},
+			NewUUIDSet(tsid,
+				Interval{Start: 1, Stop: 5},
+				Interval{Start: 8, Stop: 10},
+			),
+		},
+	}
+	for _, tc := range cases {
+		tc.set.MinusInterval(tc.in)
+		require.Equal(t, tc.result, tc.set)
+	}
+}

--- a/replication/event.go
+++ b/replication/event.go
@@ -268,41 +268,10 @@ type PreviousGTIDsEvent struct {
 	GTIDSets string
 }
 
-type GtidFormat int
-
-const (
-	GtidFormatClassic = iota
-	GtidFormatTagged
-)
-
-// Decode the number of sids (source identifiers) and if it is using
-// tagged GTIDs or classic (non-tagged) GTIDs.
-//
-// Note that each gtid tag increases the sidno here, so a single UUID
-// might turn up multiple times if there are multipl tags.
-//
-// see also:
-// decode_nsids_format in mysql/mysql-server
-// https://github.com/mysql/mysql-server/blob/61a3a1d8ef15512396b4c2af46e922a19bf2b174/sql/rpl_gtid_set.cc#L1363-L1378
-func decodeSid(data []byte) (format GtidFormat, sidnr uint64) {
-	if data[7] == 1 {
-		format = GtidFormatTagged
-	}
-
-	if format == GtidFormatTagged {
-		masked := make([]byte, 8)
-		copy(masked, data[1:7])
-		sidnr = binary.LittleEndian.Uint64(masked)
-		return format, sidnr
-	}
-	sidnr = binary.LittleEndian.Uint64(data[:8])
-	return format, sidnr
-}
-
 func (e *PreviousGTIDsEvent) Decode(data []byte) error {
 	pos := 0
 
-	format, uuidCount := decodeSid(data)
+	format, uuidCount := mysql.DecodeSid(data)
 	pos += 8
 
 	previousGTIDSets := make([]string, uuidCount)
@@ -313,7 +282,7 @@ func (e *PreviousGTIDsEvent) Decode(data []byte) error {
 		uuid := e.decodeUuid(data[pos : pos+16])
 		pos += 16
 		var tag string
-		if format == GtidFormatTagged {
+		if format == mysql.GtidFormatTagged {
 			tagLength := int(data[pos]) / 2
 			pos += 1
 			if tagLength > 0 { // 0 == no tag, >0 == tag

--- a/replication/event_test.go
+++ b/replication/event_test.go
@@ -141,25 +141,6 @@ func TestIntVarEvent(t *testing.T) {
 	require.Equal(t, uint64(23), ev.Value)
 }
 
-func TestDecodeSid(t *testing.T) {
-	testcases := []struct {
-		input      []byte
-		gtidFormat GtidFormat
-		uuidCount  uint64
-	}{
-		{[]byte{1, 2, 0, 0, 0, 0, 0, 1}, GtidFormatTagged, 2},
-		{[]byte{1, 1, 0, 0, 0, 0, 0, 1}, GtidFormatTagged, 1},
-		{[]byte{1, 0, 0, 0, 0, 0, 0, 1}, GtidFormatTagged, 0},
-		{[]byte{1, 0, 0, 0, 0, 0, 0, 0}, GtidFormatClassic, 1},
-	}
-
-	for _, tc := range testcases {
-		format, uuidCount := decodeSid(tc.input)
-		assert.Equal(t, tc.gtidFormat, format)
-		assert.Equal(t, tc.uuidCount, uuidCount)
-	}
-}
-
 func TestPreviousGTIDEvent(t *testing.T) {
 	testcases := []struct {
 		input    []byte


### PR DESCRIPTION
Closes #845 

Similar to #1116 

The difference is this:

Take `de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2:mytag:1-10`:
- In #1116 this is considered a single SID (uuid) with two intervals: `1-2` and `mytag:1-10`.
- In this PR this is considered two TSIDs (uuid+tag), one with a empty tag and `1-2` and the other with `mytag` and `1-10`

Note that the text representation suggests that for a single UUID all intervals and tags belong together. However in the binary representation there is always a `<uuid><tag>` combination, which suggests that they key should be the uuid+tag.

This PR:
- Adds a `TSID` type to store the UUID+Tag.
- Changes the key for the `map` that `MysqlGTIDSet` uses from a string to a `TSID`


API changes

```
+func (f GtidFormat) String() string {
-func (s IntervalSlice) Compare(o IntervalSlice) int {
-func (s IntervalSlice) Less(i, j int) bool {
-func (s IntervalSlice) Swap(i, j int) {
+func (s *MysqlGTIDSet) AddGTIDWithTag(tsid TSID, gno int64) {
+func (s *MysqlGTIDSet) AddSets(sets []UUIDSet) {
-func (s *UUIDSet) Decode(data []byte) error {
+func (s *UUIDSet) Decode(data []byte, format GtidFormat) error {
-func (s *UUIDSet) Encode() []byte {
+func (s *UUIDSet) Encode(format GtidFormat) []byte {
+func (t *TSID) MarshalBinary() ([]byte, error) {
+func (t *TSID) String() string {
-func NewUUIDSet(sid uuid.UUID, in ...Interval) *UUIDSet {
+func NewUUIDSet(tsid TSID, in ...Interval) *UUIDSet {
+func DecodeSid(data []byte) (format GtidFormat, sidnr uint64) {
+func ParseUUIDSets(str string) ([]UUIDSet, error) {
```