### PR TITLE
client/server: preserve OK payload for procedure multi-results

### DIFF
--- a/client/ok_payload_test.go
+++ b/client/ok_payload_test.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleOKPacketPreservesSuffix(t *testing.T) {
+	c := &Conn{}
+	c.capability = mysql.CLIENT_PROTOCOL_41 | mysql.CLIENT_SESSION_TRACK
+
+	data := []byte{mysql.OK_HEADER}
+	data = append(data, mysql.PutLengthEncodedInt(0)...)
+	data = append(data, mysql.PutLengthEncodedInt(0)...)
+	data = binary.LittleEndian.AppendUint16(data, 0) // status
+	data = binary.LittleEndian.AppendUint16(data, 0) // warnings
+	suffix := []byte{0x01, 0xfe, 0xaa, 0xbb}
+	data = append(data, suffix...)
+
+	r, err := c.handleOKPacket(data)
+	require.NoError(t, err)
+	require.Equal(t, suffix, r.OKPayloadSuffix)
+}

--- a/client/resp.go
+++ b/client/resp.go
@@ -46,6 +46,12 @@ func (c *Conn) handleOKPacket(data []byte) (*mysql.Result, error) {
 		pos += 2
 	}
 
+	// Preserve trailing OK payload (info + session tracking bytes) for
+	// protocol-transparent proxy forwarding.
+	if pos < len(data) {
+		r.OKPayloadSuffix = append([]byte(nil), data[pos:]...)
+	}
+
 	if (c.capability&mysql.CLIENT_SESSION_TRACK > 0) &&
 		(c.status&mysql.SERVER_SESSION_STATE_CHANGED > 0) {
 		var err error

--- a/client/stmt.go
+++ b/client/stmt.go
@@ -49,6 +49,44 @@ func (s *Stmt) ExecuteSelectStreaming(result *mysql.Result, perRowCb SelectPerRo
 	return s.conn.readResultStreaming(true, result, perRowCb, perResCb)
 }
 
+// StmtProcedureMultiResultForward is called for each logical result returned by
+// COM_STMT_EXECUTE. When err is non-nil, res is nil.
+type StmtProcedureMultiResultForward func(res *mysql.Result, err error) error
+
+// ExecuteProcedureMultiResults runs COM_STMT_EXECUTE and drains all procedure
+// results until SERVER_MORE_RESULTS_EXISTS is no longer set.
+func (s *Stmt) ExecuteProcedureMultiResults(args []any, forward StmtProcedureMultiResultForward) (*mysql.Result, error) {
+	if err := s.write(args...); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var forwardErr error
+	for {
+		res, err := s.conn.readResult(true)
+		if forwardErr == nil {
+			if err != nil {
+				forwardErr = forward(nil, err)
+			} else if res != nil {
+				forwardErr = forward(res, nil)
+			}
+		}
+		if err != nil {
+			break
+		}
+		if res == nil || res.Status&mysql.SERVER_MORE_RESULTS_EXISTS == 0 {
+			break
+		}
+	}
+
+	if forwardErr != nil {
+		return nil, forwardErr
+	}
+	rs := mysql.NewResultset(1)
+	rs.Streaming = mysql.StreamingMultiple
+	rs.StreamingDone = true
+	return mysql.NewResult(rs), nil
+}
+
 func (s *Stmt) Close() error {
 	if err := s.conn.writeCommandUint32(mysql.COM_STMT_CLOSE, s.ID); err != nil {
 		return errors.Trace(err)

--- a/client/stmt.go
+++ b/client/stmt.go
@@ -56,6 +56,10 @@ type StmtProcedureMultiResultForward func(res *mysql.Result, err error) error
 // ExecuteProcedureMultiResults runs COM_STMT_EXECUTE and drains all procedure
 // results until SERVER_MORE_RESULTS_EXISTS is no longer set.
 func (s *Stmt) ExecuteProcedureMultiResults(args []any, forward StmtProcedureMultiResultForward) (*mysql.Result, error) {
+	if forward == nil {
+		return nil, errors.New("forward callback cannot be nil")
+	}
+
 	if err := s.write(args...); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/mysql/result.go
+++ b/mysql/result.go
@@ -9,6 +9,11 @@ type Result struct {
 	InsertId     uint64
 	AffectedRows uint64
 
+	// OKPayloadSuffix stores OK packet bytes after the fixed PROTOCOL_41 header
+	// (status + warnings). This allows transparent OK packet passthrough when
+	// proxying responses that include info/session-tracking payload.
+	OKPayloadSuffix []byte
+
 	StatusMessage   string
 	SessionTracking *SessionTrackingInfo
 

--- a/server/resp.go
+++ b/server/resp.go
@@ -27,6 +27,9 @@ func (c *Conn) writeOK(r *mysql.Result) error {
 		data = append(data, byte(r.Status), byte(r.Status>>8))
 		data = append(data, byte(r.Warnings), byte(r.Warnings>>8))
 	}
+	if len(r.OKPayloadSuffix) > 0 {
+		data = append(data, r.OKPayloadSuffix...)
+	}
 
 	return c.WritePacket(data)
 }

--- a/server/resp_test.go
+++ b/server/resp_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -35,6 +36,23 @@ func TestConnWriteOK(t *testing.T) {
 	require.NoError(t, err)
 	expected = []byte{7, 0, 0, 1, mysql.OK_HEADER, 1, 2, 0, 8, 0, 0}
 	require.Equal(t, expected, clientConn.WriteBuffered)
+}
+
+func TestConnWriteOKWithPayloadSuffix(t *testing.T) {
+	clientConn := &mockconn.MockConn{}
+	conn := &Conn{Conn: packet.NewConn(clientConn)}
+	conn.SetCapability(mysql.CLIENT_PROTOCOL_41)
+
+	result := mysql.NewResultReserveResultset(0)
+	result.AffectedRows = 1
+	result.InsertId = 2
+	result.OKPayloadSuffix = []byte{0x01, 0xfe, 0xaa, 0xbb}
+
+	err := conn.writeOK(result)
+	require.NoError(t, err)
+
+	payload := clientConn.WriteBuffered[4:]
+	require.True(t, bytes.HasSuffix(payload, result.OKPayloadSuffix))
 }
 
 func TestConnWriteEOF(t *testing.T) {

--- a/server/server_conf.go
+++ b/server/server_conf.go
@@ -54,7 +54,8 @@ func NewDefaultServer() *Server {
 		protocolVersion: 10,
 		capability: mysql.CLIENT_LONG_PASSWORD | mysql.CLIENT_LONG_FLAG | mysql.CLIENT_CONNECT_WITH_DB | mysql.CLIENT_PROTOCOL_41 |
 			mysql.CLIENT_TRANSACTIONS | mysql.CLIENT_SECURE_CONNECTION | mysql.CLIENT_PLUGIN_AUTH | mysql.CLIENT_SSL |
-			mysql.CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA | mysql.CLIENT_CONNECT_ATTRS,
+			mysql.CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA | mysql.CLIENT_CONNECT_ATTRS |
+			mysql.CLIENT_MULTI_RESULTS | mysql.CLIENT_PS_MULTI_RESULTS | mysql.CLIENT_SESSION_TRACK,
 		collationId:       mysql.DEFAULT_COLLATION_ID,
 		defaultAuthMethod: mysql.AUTH_NATIVE_PASSWORD,
 		rsaPrivateKey:     rsaPrivateKey,
@@ -100,7 +101,8 @@ func NewServerWithAuth(serverVersion string, collationId uint8, defaultAuthMetho
 
 	capFlag := mysql.CLIENT_LONG_PASSWORD | mysql.CLIENT_LONG_FLAG | mysql.CLIENT_CONNECT_WITH_DB | mysql.CLIENT_PROTOCOL_41 |
 		mysql.CLIENT_TRANSACTIONS | mysql.CLIENT_SECURE_CONNECTION | mysql.CLIENT_PLUGIN_AUTH | mysql.CLIENT_CONNECT_ATTRS |
-		mysql.CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA
+		mysql.CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA |
+		mysql.CLIENT_MULTI_RESULTS | mysql.CLIENT_PS_MULTI_RESULTS | mysql.CLIENT_SESSION_TRACK
 	if tlsConfig != nil {
 		capFlag |= mysql.CLIENT_SSL
 	}


### PR DESCRIPTION
Context: using go-mysql to create a mysql proxy server (with a 8.0 target mysql server), I encountered 2 issues

- I couldn't drain properly some multi-results connections
- doing a store procedure call with an out parameter through Connector/J was not working.

So this PR is about: keep trailing OK packet payload bytes available for proxy passthrough and expose a statement helper to drain stored procedure multi-results safely, improving Connector/J CALL + OUT compatibility.

