### PR TITLE
fix: MariadbGTIDSet.AddSet() replace server entry on same domain to avoid duplicate domain id error

### DIFF
--- a/mysql/mariadb_gtid.go
+++ b/mysql/mariadb_gtid.go
@@ -102,7 +102,9 @@ func (gtid *MariadbGTID) forward(newer *MariadbGTID) error {
 	return nil
 }
 
-// MariadbGTIDSet is a set of mariadb gtid
+// MariadbGTIDSet represents a MariaDB GTID position (one GTID per domain_id).
+// Despite the name, this is a position, not a set — unlike MySQL's executed GTID set.
+// See https://github.com/go-mysql-org/go-mysql/pull/1122
 type MariadbGTIDSet struct {
 	Sets map[uint32]map[uint32]*MariadbGTID
 }
@@ -121,7 +123,9 @@ func ParseMariadbGTIDSet(str string) (GTIDSet, error) {
 	return s, nil
 }
 
-// AddSet adds mariadb gtid into mariadb gtid set
+// AddSet adds or updates a GTID position for a domain. If the domain already has
+// a GTID with a different server_id (e.g. after primary failover), the old entry
+// is replaced to maintain one position per domain_id.
 func (s *MariadbGTIDSet) AddSet(gtid *MariadbGTID) error {
 	if gtid == nil {
 		return nil

--- a/mysql/mariadb_gtid.go
+++ b/mysql/mariadb_gtid.go
@@ -132,6 +132,9 @@ func (s *MariadbGTIDSet) AddSet(gtid *MariadbGTID) error {
 			gtid.ServerID: gtid,
 		}
 	} else if o, ok := serverSets[gtid.ServerID]; !ok {
+		// Same domain, different server (e.g. master failover). MariaDB only allows one GTID per domain.
+		slog.Warn("replacing server entries for domain", slog.Uint64("domainID", uint64(gtid.DomainID)), slog.Any("new", gtid))
+		clear(serverSets)
 		serverSets[gtid.ServerID] = gtid
 	} else {
 		err := o.forward(gtid)

--- a/mysql/mariadb_gtid.go
+++ b/mysql/mariadb_gtid.go
@@ -132,7 +132,6 @@ func (s *MariadbGTIDSet) AddSet(gtid *MariadbGTID) error {
 			gtid.ServerID: gtid,
 		}
 	} else if o, ok := serverSets[gtid.ServerID]; !ok {
-		// Same domain, different server (e.g. master failover). MariaDB only allows one GTID per domain.
 		slog.Warn("replacing server entries for domain", slog.Uint64("domainID", uint64(gtid.DomainID)), slog.Any("new", gtid))
 		clear(serverSets)
 		serverSets[gtid.ServerID] = gtid

--- a/mysql/mariadb_gtid_test.go
+++ b/mysql/mariadb_gtid_test.go
@@ -179,7 +179,7 @@ func TestMariaDBGTIDSetEqual(t *testing.T) {
 		{"1-1-1,2-2-2", "1-1-1", false},
 		{"1-1-1,2-2-2", "1-1-1,2-2-2", true},
 		{"1-1-1,2-2-2", "1-1-1,2-2-3", false},
-		{"0-1-1,0-2-2", "0-2-2", false},
+		{"0-1-1,0-2-2", "0-2-2", true}, // MariaDB allows only one GTID per domain; 0-2-2 replaces 0-1-1
 	}
 
 	for _, cs := range cases {

--- a/mysql/mariadb_gtid_test.go
+++ b/mysql/mariadb_gtid_test.go
@@ -179,7 +179,7 @@ func TestMariaDBGTIDSetEqual(t *testing.T) {
 		{"1-1-1,2-2-2", "1-1-1", false},
 		{"1-1-1,2-2-2", "1-1-1,2-2-2", true},
 		{"1-1-1,2-2-2", "1-1-1,2-2-3", false},
-		{"0-1-1,0-2-2", "0-2-2", true}, // MariaDB allows only one GTID per domain; 0-2-2 replaces 0-1-1
+		{"0-1-1,0-2-2", "0-2-2", true},
 	}
 
 	for _, cs := range cases {


### PR DESCRIPTION
## Problem

`MariadbGTIDSet.AddSet()` stores multiple server IDs per domain in its
`map[uint32]map[uint32]*MariadbGTID` structure. When a MariaDB master failover changes
the server ID within the same domain, `AddSet()` adds a new server entry alongside
the old one instead of replacing it.

This causes `String()` to output GTIDSet strings like `0-1013-100,0-963-200` with
duplicate domain ID 0. MariaDB rejects this in `START SLAVE UNTIL MASTER_GTID_POS`
with error #1943: `GTID 0-963-200 and 0-1013-100 conflict (duplicate domain id 0)`.

## Fix

When `AddSet()` encounters a GTID with the same domain but different server ID,
clear existing server entries before adding the new one. MariaDB only allows one
GTID per domain in `gtid_slave_pos` / `MASTER_GTID_POS`.

## Test

Updated `TestMariaDBGTIDSetEqual` test case to reflect correct behavior.
