### PR TITLE
refactor: flatten MariadbGTIDSet to map[uint32]*MariadbGTID (one entry per domain)

### DIFF
--- a/mysql/mariadb_gtid.go
+++ b/mysql/mariadb_gtid.go
@@ -1,7 +1,6 @@
 package mysql
 
 import (
-	"bytes"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -104,15 +103,15 @@ func (gtid *MariadbGTID) forward(newer *MariadbGTID) error {
 
 // MariadbGTIDSet represents a MariaDB GTID position (one GTID per domain_id).
 // Despite the name, this is a position, not a set — unlike MySQL's executed GTID set.
-// See https://github.com/go-mysql-org/go-mysql/pull/1122
+// See https://github.com/go-mysql-org/go-mysql/issues/1123
 type MariadbGTIDSet struct {
-	Sets map[uint32]map[uint32]*MariadbGTID
+	Sets map[uint32]*MariadbGTID
 }
 
 // ParseMariadbGTIDSet parses str into mariadb gtid sets
 func ParseMariadbGTIDSet(str string) (GTIDSet, error) {
 	s := new(MariadbGTIDSet)
-	s.Sets = make(map[uint32]map[uint32]*MariadbGTID)
+	s.Sets = make(map[uint32]*MariadbGTID)
 	if str == "" {
 		return s, nil
 	}
@@ -125,25 +124,18 @@ func ParseMariadbGTIDSet(str string) (GTIDSet, error) {
 
 // AddSet adds or updates a GTID position for a domain. If the domain already has
 // a GTID with a different server_id (e.g. after primary failover), the old entry
-// is replaced to maintain one position per domain_id.
+// is replaced via forward() to maintain one position per domain_id.
 func (s *MariadbGTIDSet) AddSet(gtid *MariadbGTID) error {
 	if gtid == nil {
 		return nil
 	}
 
-	if serverSets, ok := s.Sets[gtid.DomainID]; !ok {
-		s.Sets[gtid.DomainID] = map[uint32]*MariadbGTID{
-			gtid.ServerID: gtid,
-		}
-	} else if o, ok := serverSets[gtid.ServerID]; !ok {
-		slog.Warn("replacing server entries for domain", slog.Uint64("domainID", uint64(gtid.DomainID)), slog.Any("new", gtid))
-		clear(serverSets)
-		serverSets[gtid.ServerID] = gtid
-	} else {
-		err := o.forward(gtid)
-		if err != nil {
+	if existing, ok := s.Sets[gtid.DomainID]; ok {
+		if err := existing.forward(gtid); err != nil {
 			return errors.Trace(err)
 		}
+	} else {
+		s.Sets[gtid.DomainID] = gtid.Clone()
 	}
 
 	return nil
@@ -168,10 +160,8 @@ func (s *MariadbGTIDSet) Update(GTIDStr string) error {
 
 func (s *MariadbGTIDSet) String() string {
 	sets := make([]string, 0, len(s.Sets))
-	for _, set := range s.Sets {
-		for _, gtid := range set {
-			sets = append(sets, gtid.String())
-		}
+	for _, gtid := range s.Sets {
+		sets = append(sets, gtid.String())
 	}
 	sort.Strings(sets)
 
@@ -180,29 +170,16 @@ func (s *MariadbGTIDSet) String() string {
 
 // Encode encodes mariadb gtid set
 func (s *MariadbGTIDSet) Encode() []byte {
-	var buf bytes.Buffer
-	sep := ""
-	for _, set := range s.Sets {
-		for _, gtid := range set {
-			buf.WriteString(sep)
-			buf.WriteString(gtid.String())
-			sep = ","
-		}
-	}
-
-	return buf.Bytes()
+	return []byte(s.String())
 }
 
 // Clone clones a mariadb gtid set
 func (s *MariadbGTIDSet) Clone() GTIDSet {
 	clone := &MariadbGTIDSet{
-		Sets: make(map[uint32]map[uint32]*MariadbGTID),
+		Sets: make(map[uint32]*MariadbGTID),
 	}
-	for domainID, set := range s.Sets {
-		clone.Sets[domainID] = make(map[uint32]*MariadbGTID)
-		for serverID, gtid := range set {
-			clone.Sets[domainID][serverID] = gtid.Clone()
-		}
+	for domainID, gtid := range s.Sets {
+		clone.Sets[domainID] = gtid.Clone()
 	}
 
 	return clone
@@ -219,20 +196,13 @@ func (s *MariadbGTIDSet) Equal(o GTIDSet) bool {
 		return false
 	}
 
-	for domainID, set := range other.Sets {
-		serverSet, ok := s.Sets[domainID]
+	for domainID, gtid := range other.Sets {
+		ourGTID, ok := s.Sets[domainID]
 		if !ok {
 			return false
 		}
-		if len(serverSet) != len(set) {
+		if *gtid != *ourGTID {
 			return false
-		}
-		for serverID, gtid := range set {
-			if o, ok := serverSet[serverID]; !ok {
-				return false
-			} else if *gtid != *o {
-				return false
-			}
 		}
 	}
 
@@ -246,17 +216,13 @@ func (s *MariadbGTIDSet) Contain(o GTIDSet) bool {
 		return false
 	}
 
-	for doaminID, set := range other.Sets {
-		serverSet, ok := s.Sets[doaminID]
+	for domainID, gtid := range other.Sets {
+		ourGTID, ok := s.Sets[domainID]
 		if !ok {
 			return false
 		}
-		for serverID, gtid := range set {
-			if o, ok := serverSet[serverID]; !ok {
-				return false
-			} else if !o.Contain(gtid) {
-				return false
-			}
+		if !ourGTID.Contain(gtid) {
+			return false
 		}
 	}
 

--- a/mysql/mariadb_gtid.go
+++ b/mysql/mariadb_gtid.go
@@ -61,7 +61,6 @@ func (gtid *MariadbGTID) String() string {
 	return fmt.Sprintf("%d-%d-%d", gtid.DomainID, gtid.ServerID, gtid.SequenceNumber)
 }
 
-// Contain return whether one mariadb gtid covers another mariadb gtid
 func (gtid *MariadbGTID) Contain(other *MariadbGTID) bool {
 	return gtid.DomainID == other.DomainID && gtid.SequenceNumber >= other.SequenceNumber
 }
@@ -75,7 +74,7 @@ func (gtid *MariadbGTID) Clone() *MariadbGTID {
 
 func (gtid *MariadbGTID) forward(newer *MariadbGTID) error {
 	if newer.DomainID != gtid.DomainID {
-		return errors.Errorf("%s is not same with doamin of %s", newer, gtid)
+		return errors.Errorf("%s is not same with domain of %s", newer, gtid)
 	}
 
 	/*

--- a/mysql/mariadb_gtid_test.go
+++ b/mysql/mariadb_gtid_test.go
@@ -16,6 +16,13 @@ func TestParseMariaDBGTID(t *testing.T) {
 		{"0-1-1-1", true},
 		{"1", true},
 		{"0-1-seq", true},
+		{"x-1-1", true},                    // non-numeric domain ID
+		{"0-x-1", true},                    // non-numeric server ID
+		{"1e5-1-2", true},                  // scientific notation
+		{"4294967295-1-2", false},          // max uint32 domain
+		{"4294967296-1-2", true},           // uint32 overflow domain
+		{"0-4294967296-1", true},           // uint32 overflow server
+		{"0-1-18446744073709551616", true}, // uint64 overflow sequence
 	}
 
 	for _, cs := range cases {
@@ -99,6 +106,7 @@ func TestParseMariaDBGTIDSet(t *testing.T) {
 		{"", nil, "", false},
 		{"0-1-1,1-2-3", map[uint32]string{0: "0-1-1", 1: "1-2-3"}, "0-1-1,1-2-3", false},
 		{"0-1--1", nil, "", true},
+		{"x-1-1", nil, "", true}, // non-numeric domain ID in set parsing
 		// Same domain, different server — last one wins (forward replaces)
 		{"0-1-1,0-2-2", map[uint32]string{0: "0-2-2"}, "0-2-2", false},
 	}
@@ -171,6 +179,8 @@ func TestMariaDBGTIDSetEqual(t *testing.T) {
 		{"1-1-1,2-2-2", "1-1-1,2-2-2", true},
 		{"1-1-1,2-2-2", "1-1-1,2-2-3", false},
 		{"0-1-1,0-2-2", "0-2-2", true}, // same domain, forward replaces
+		// Different domains entirely — tests the "domain not found" branch
+		{"1-1-1", "2-1-1", false},
 	}
 
 	for _, cs := range cases {
@@ -182,6 +192,11 @@ func TestMariaDBGTIDSetEqual(t *testing.T) {
 
 		require.Equal(t, cs.equals, originGTID.Equal(otherGTID))
 	}
+
+	// Equal with non-MariadbGTIDSet type returns false
+	mariaSet, _ := ParseMariadbGTIDSet("1-1-1")
+	mysqlSet, _ := ParseMysqlGTIDSet("")
+	require.False(t, mariaSet.Equal(mysqlSet))
 }
 
 func TestMariaDBGTIDSetContain(t *testing.T) {
@@ -195,6 +210,8 @@ func TestMariaDBGTIDSetContain(t *testing.T) {
 		{"1-1-1,2-2-2", "1-1-1,2-2-2", true},
 		{"1-1-1,2-2-2", "1-1-1,2-2-1", true},
 		{"1-1-1,2-2-2", "1-1-1,2-2-3", false},
+		// Domain not found in origin — tests the "domain not found" branch
+		{"1-1-1", "2-1-1", false},
 	}
 
 	for _, cs := range cases {
@@ -206,6 +223,11 @@ func TestMariaDBGTIDSetContain(t *testing.T) {
 
 		require.Equal(t, cs.contain, originGTIDSet.Contain(otherGTIDSet))
 	}
+
+	// Contain with non-MariadbGTIDSet type returns false
+	mariaSet, _ := ParseMariadbGTIDSet("1-1-1")
+	mysqlSet, _ := ParseMysqlGTIDSet("")
+	require.False(t, mariaSet.Contain(mysqlSet))
 }
 
 func TestMariaDBGTIDSetClone(t *testing.T) {
@@ -288,6 +310,105 @@ func TestMariaDBGTIDSetSameDomainDifferentServer(t *testing.T) {
 	// Mutating clone should not affect original
 	require.NoError(t, cloned.Update("0-111-300"))
 	require.Equal(t, "0-963-200,1-500-50", gtidSet4.String(), "original should be unmodified after clone mutation")
+}
+
+// TestMariaDBGTIDSetInterleavedServers tests the scenario from PR #852:
+// interleaved binlog events from different servers in the same domain
+// (gtid_strict_mode=OFF with multi-source replication).
+func TestMariaDBGTIDSetInterleavedServers(t *testing.T) {
+	gtidSet, err := ParseMariadbGTIDSet("")
+	require.NoError(t, err)
+	set := gtidSet.(*MariadbGTIDSet)
+
+	// Simulate interleaved binlog events (from PR #852's example):
+	// 0-112-6, 0-112-7, 0-111-5, 0-112-8, 0-111-6
+	events := []MariadbGTID{
+		{DomainID: 0, ServerID: 112, SequenceNumber: 6},
+		{DomainID: 0, ServerID: 112, SequenceNumber: 7},
+		{DomainID: 0, ServerID: 111, SequenceNumber: 5}, // different server, lower seq
+		{DomainID: 0, ServerID: 112, SequenceNumber: 8},
+		{DomainID: 0, ServerID: 111, SequenceNumber: 6}, // different server, lower seq
+	}
+
+	for _, ev := range events {
+		err := set.AddSet(&ev)
+		require.NoError(t, err)
+		// Must always have exactly one entry per domain
+		require.Len(t, set.Sets, 1, "must have one entry per domain at all times")
+	}
+
+	// Final position should be the last event seen
+	require.Equal(t, "0-111-6", set.String())
+	require.Equal(t, uint32(111), set.Sets[0].ServerID)
+	require.Equal(t, uint64(6), set.Sets[0].SequenceNumber)
+}
+
+// TestMariaDBGTIDSetDoubleFailover tests two consecutive primary failovers.
+func TestMariaDBGTIDSetDoubleFailover(t *testing.T) {
+	set, err := ParseMariadbGTIDSet("0-100-50,1-200-30")
+	require.NoError(t, err)
+
+	// First failover: server 100 → 101 in domain 0
+	require.NoError(t, set.Update("0-101-51"))
+	require.Equal(t, "0-101-51,1-200-30", set.String())
+
+	// Second failover: server 101 → 102 in domain 0
+	require.NoError(t, set.Update("0-102-52"))
+	require.Equal(t, "0-102-52,1-200-30", set.String())
+
+	// Domain 1 unchanged
+	ms := set.(*MariadbGTIDSet)
+	require.Equal(t, uint32(200), ms.Sets[1].ServerID)
+	require.Equal(t, uint64(30), ms.Sets[1].SequenceNumber)
+}
+
+// TestMariaDBGTIDSetContainCrossServer tests Contain() behavior across server IDs.
+func TestMariaDBGTIDSetContainCrossServer(t *testing.T) {
+	// After failover: position is 0-963-200
+	current, _ := ParseMariadbGTIDSet("0-963-200")
+	// Check if it "contains" a position from the old server
+	old, _ := ParseMariadbGTIDSet("0-1013-100")
+	// Matches MariaDB's native behavior: compares sequence only, ignores serverID
+	require.True(t, current.Contain(old), "200 >= 100, same domain")
+
+	// Reverse should be false
+	require.False(t, old.Contain(current), "100 < 200")
+
+	// Same sequence, different server — still contained (matches MariaDB)
+	a, _ := ParseMariadbGTIDSet("0-1-100")
+	b, _ := ParseMariadbGTIDSet("0-2-100")
+	require.True(t, a.Contain(b))
+	require.True(t, b.Contain(a))
+}
+
+// TestMariaDBGTIDSetEncode verifies Encode returns the same as String.
+func TestMariaDBGTIDSetEncode(t *testing.T) {
+	set, _ := ParseMariadbGTIDSet("0-1-100,1-2-200")
+	require.Equal(t, set.String(), string(set.Encode()))
+
+	empty, _ := ParseMariadbGTIDSet("")
+	require.Equal(t, "", string(empty.Encode()))
+}
+
+// TestMariaDBGTIDSetForwardError tests that forward() error propagates through AddSet.
+func TestMariaDBGTIDSetForwardError(t *testing.T) {
+	set, err := ParseMariadbGTIDSet("0-1-1")
+	require.NoError(t, err)
+	ms := set.(*MariadbGTIDSet)
+
+	// Manually inject a GTID with mismatched domain to trigger forward() error.
+	// In normal usage the map key guarantees domain match, so this path is
+	// unreachable — but we test it for completeness.
+	ms.Sets[0] = &MariadbGTID{DomainID: 99, ServerID: 1, SequenceNumber: 1}
+	err = ms.AddSet(&MariadbGTID{DomainID: 0, ServerID: 1, SequenceNumber: 2})
+	require.Error(t, err, "forward() should error on domain mismatch")
+
+	// Update() with invalid GTID string
+	set2, _ := ParseMariadbGTIDSet("0-1-1")
+	err = set2.Update("x-1-1")
+	require.Error(t, err, "Update with non-numeric domain should error")
+	err = set2.Update("0-1--1")
+	require.Error(t, err, "Update with invalid sequence should error")
 }
 
 func TestMariadbGTIDSetIsEmpty(t *testing.T) {

--- a/mysql/mariadb_gtid_test.go
+++ b/mysql/mariadb_gtid_test.go
@@ -1,7 +1,6 @@
 package mysql
 
 import (
-	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -92,14 +91,16 @@ func TestMariaDBForward(t *testing.T) {
 func TestParseMariaDBGTIDSet(t *testing.T) {
 	cases := []struct {
 		gtidStr     string
-		subGTIDs    map[uint32]map[uint32]string // domain ID => gtid string
-		expectedStr []string                     // test String()
+		subGTIDs    map[uint32]string // domain ID => gtid string
+		expectedStr string
 		hasError    bool
 	}{
-		{"0-1-1", map[uint32]map[uint32]string{0: {1: "0-1-1"}}, []string{"0-1-1"}, false},
-		{"", nil, []string{""}, false},
-		{"0-1-1,1-2-3", map[uint32]map[uint32]string{0: {1: "0-1-1"}, 1: {2: "1-2-3"}}, []string{"0-1-1,1-2-3", "1-2-3,0-1-1"}, false},
-		{"0-1--1", nil, nil, true},
+		{"0-1-1", map[uint32]string{0: "0-1-1"}, "0-1-1", false},
+		{"", nil, "", false},
+		{"0-1-1,1-2-3", map[uint32]string{0: "0-1-1", 1: "1-2-3"}, "0-1-1,1-2-3", false},
+		{"0-1--1", nil, "", true},
+		// Same domain, different server — last one wins (forward replaces)
+		{"0-1-1,0-2-2", map[uint32]string{0: "0-2-2"}, "0-2-2", false},
 	}
 
 	for _, cs := range cases {
@@ -113,21 +114,13 @@ func TestParseMariaDBGTIDSet(t *testing.T) {
 
 			// check sub gtid
 			require.Len(t, mariadbGTIDSet.Sets, len(cs.subGTIDs))
-			for domainID, set := range mariadbGTIDSet.Sets {
-				require.Contains(t, mariadbGTIDSet.Sets, domainID)
-				for serverID, gtid := range set {
-					require.Contains(t, cs.subGTIDs, domainID)
-					require.Equal(t, cs.subGTIDs[domainID][serverID], gtid.String())
-				}
+			for domainID, gtid := range mariadbGTIDSet.Sets {
+				require.Contains(t, cs.subGTIDs, domainID)
+				require.Equal(t, cs.subGTIDs[domainID], gtid.String())
 			}
 
 			// check String() function
-			inExpectedResult := false
-			actualStr := mariadbGTIDSet.String()
-			if slices.Contains(cs.expectedStr, actualStr) {
-				inExpectedResult = true
-			}
-			require.True(t, inExpectedResult)
+			require.Equal(t, cs.expectedStr, mariadbGTIDSet.String())
 		}
 	}
 }
@@ -136,13 +129,14 @@ func TestMariaDBGTIDSetUpdate(t *testing.T) {
 	cases := []struct {
 		isNilGTID bool
 		gtidStr   string
-		subGTIDs  map[uint32]map[uint32]string
+		subGTIDs  map[uint32]string // domain ID => gtid string
 	}{
-		{true, "", map[uint32]map[uint32]string{1: {1: "1-1-1"}, 2: {2: "2-2-2"}}},
-		{false, "1-2-2", map[uint32]map[uint32]string{1: {1: "1-1-1", 2: "1-2-2"}, 2: {2: "2-2-2"}}},
-		{false, "1-2-1", map[uint32]map[uint32]string{1: {1: "1-1-1", 2: "1-2-1"}, 2: {2: "2-2-2"}}},
-		{false, "3-2-1", map[uint32]map[uint32]string{1: {1: "1-1-1"}, 2: {2: "2-2-2"}, 3: {2: "3-2-1"}}},
-		{false, "3-2-1,4-2-1", map[uint32]map[uint32]string{1: {1: "1-1-1"}, 2: {2: "2-2-2"}, 3: {2: "3-2-1"}, 4: {2: "4-2-1"}}},
+		{true, "", map[uint32]string{1: "1-1-1", 2: "2-2-2"}},
+		// Same domain (1), different server (2) — forward replaces server ID
+		{false, "1-2-2", map[uint32]string{1: "1-2-2", 2: "2-2-2"}},
+		{false, "1-2-1", map[uint32]string{1: "1-2-1", 2: "2-2-2"}},
+		{false, "3-2-1", map[uint32]string{1: "1-1-1", 2: "2-2-2", 3: "3-2-1"}},
+		{false, "3-2-1,4-2-1", map[uint32]string{1: "1-1-1", 2: "2-2-2", 3: "3-2-1", 4: "4-2-1"}},
 	}
 
 	for _, cs := range cases {
@@ -159,12 +153,9 @@ func TestMariaDBGTIDSetUpdate(t *testing.T) {
 		}
 		// check sub gtid
 		require.Len(t, mariadbGTIDSet.Sets, len(cs.subGTIDs))
-		for domainID, set := range mariadbGTIDSet.Sets {
-			require.Contains(t, mariadbGTIDSet.Sets, domainID)
-			for serverID, gtid := range set {
-				require.Contains(t, cs.subGTIDs, domainID)
-				require.Equal(t, cs.subGTIDs[domainID][serverID], gtid.String())
-			}
+		for domainID, gtid := range mariadbGTIDSet.Sets {
+			require.Contains(t, cs.subGTIDs, domainID)
+			require.Equal(t, cs.subGTIDs[domainID], gtid.String())
 		}
 	}
 }
@@ -179,7 +170,7 @@ func TestMariaDBGTIDSetEqual(t *testing.T) {
 		{"1-1-1,2-2-2", "1-1-1", false},
 		{"1-1-1,2-2-2", "1-1-1,2-2-2", true},
 		{"1-1-1,2-2-2", "1-1-1,2-2-3", false},
-		{"0-1-1,0-2-2", "0-2-2", true},
+		{"0-1-1,0-2-2", "0-2-2", true}, // same domain, forward replaces
 	}
 
 	for _, cs := range cases {
@@ -242,9 +233,66 @@ func TestMariaDBGTIDSetSortedString(t *testing.T) {
 	}
 }
 
+// TestMariaDBGTIDSetSameDomainDifferentServer tests the key behavior: when a GTID
+// with the same domain but different server ID is added (e.g. primary failover),
+// the old entry is replaced via forward(), maintaining one position per domain.
+func TestMariaDBGTIDSetSameDomainDifferentServer(t *testing.T) {
+	// Start with domain 0, server 1013
+	gtidSet, err := ParseMariadbGTIDSet("0-1013-100")
+	require.NoError(t, err)
+	require.Equal(t, "0-1013-100", gtidSet.String())
+
+	// Simulate primary failover: new server 963, higher sequence
+	err = gtidSet.Update("0-963-200")
+	require.NoError(t, err)
+	require.Equal(t, "0-963-200", gtidSet.String(), "should replace server 1013 with 963 in domain 0")
+
+	// Verify only one entry per domain
+	mariadbSet := gtidSet.(*MariadbGTIDSet)
+	require.Len(t, mariadbSet.Sets, 1)
+	require.Equal(t, uint32(963), mariadbSet.Sets[0].ServerID)
+	require.Equal(t, uint64(200), mariadbSet.Sets[0].SequenceNumber)
+
+	// Multiple domains: only affected domain is updated
+	gtidSet2, err := ParseMariadbGTIDSet("0-1013-100,1-500-50,2-600-75")
+	require.NoError(t, err)
+
+	err = gtidSet2.Update("0-963-200")
+	require.NoError(t, err)
+	require.Equal(t, "0-963-200,1-500-50,2-600-75", gtidSet2.String(), "only domain 0 should change")
+
+	mariadbSet2 := gtidSet2.(*MariadbGTIDSet)
+	require.Len(t, mariadbSet2.Sets, 3)
+	require.Equal(t, uint32(963), mariadbSet2.Sets[0].ServerID)
+	require.Equal(t, uint32(500), mariadbSet2.Sets[1].ServerID, "domain 1 unchanged")
+	require.Equal(t, uint32(600), mariadbSet2.Sets[2].ServerID, "domain 2 unchanged")
+
+	// AddSet directly (as binlogsyncer does)
+	gtidSet3, err := ParseMariadbGTIDSet("0-1013-100")
+	require.NoError(t, err)
+	newGTID := &MariadbGTID{DomainID: 0, ServerID: 963, SequenceNumber: 200}
+	err = gtidSet3.(*MariadbGTIDSet).AddSet(newGTID)
+	require.NoError(t, err)
+	require.Equal(t, "0-963-200", gtidSet3.String())
+
+	// Equal after forward: both should be equal
+	a, _ := ParseMariadbGTIDSet("0-1013-100")
+	b, _ := ParseMariadbGTIDSet("0-963-100")
+	require.NoError(t, a.Update("0-963-100"))
+	require.True(t, a.Equal(b), "after forward, positions should be equal")
+
+	// Clone preserves flat structure
+	gtidSet4, _ := ParseMariadbGTIDSet("0-963-200,1-500-50")
+	cloned := gtidSet4.Clone()
+	require.True(t, gtidSet4.Equal(cloned))
+	// Mutating clone should not affect original
+	require.NoError(t, cloned.Update("0-111-300"))
+	require.Equal(t, "0-963-200,1-500-50", gtidSet4.String(), "original should be unmodified after clone mutation")
+}
+
 func TestMariadbGTIDSetIsEmpty(t *testing.T) {
 	emptyGTIDSet := new(MariadbGTIDSet)
-	emptyGTIDSet.Sets = make(map[uint32]map[uint32]*MariadbGTID)
+	emptyGTIDSet.Sets = make(map[uint32]*MariadbGTID)
 	require.True(t, emptyGTIDSet.IsEmpty())
 
 	nonEmptyGTIDSet, err := ParseMariadbGTIDSet("0-1-2")


### PR DESCRIPTION
Fixes #1123

## Problem

`MariadbGTIDSet` used `map[uint32]map[uint32]*MariadbGTID` (domain_id → server_id → GTID),
which allowed multiple server entries per domain. This is incorrect for MariaDB, which tracks
exactly **one GTID position per domain_id** in `gtid_slave_pos` and `MASTER_GTID_POS`.

This structure was introduced in PR #852 (`034c7ab`). Before that, PR #272 (`cb167c0`) used a
flat `map[uint32]*MariadbGTID` which correctly enforced one entry per domain.

## Changes

### `mariadb_gtid.go`

- **`MariadbGTIDSet.Sets`**: flattened from `map[uint32]map[uint32]*MariadbGTID` to `map[uint32]*MariadbGTID`
- **`AddSet()`**: simplified — if domain exists, call `forward()` to update server ID + sequence; otherwise add new entry. The `forward()` method already handles server ID changes (as happens during primary failovers)
- **`String()`**, **`Encode()`**, **`Clone()`**, **`Equal()`**, **`Contain()`**: all simplified from nested iteration to single-level map iteration
- Removed unused `"bytes"` import

### `mariadb_gtid_test.go`

- Updated all test expectations from `map[uint32]map[uint32]string` to `map[uint32]string`
- Added `TestMariaDBGTIDSetSameDomainDifferentServer` with comprehensive coverage:
  - Basic server replacement (primary failover scenario)
  - Multi-domain isolation (only affected domain changes)
  - Direct `AddSet()` call (as `binlogsyncer` does)
  - Equality after forward
  - Clone independence
- Removed unused `"slices"` import

### No changes to `binlogsyncer.go`

`AddSet(&event.GTID)` passes `*MariadbGTID` — same signature, works with the flat map.

## Context

As discussed in #1122 and noted by @dveeden and @lance6716, MariaDB's GTID is a **position**
(one per domain), not a **set** (like MySQL's executed GTID set). The flat map structure
enforces this at the type level, making it impossible to accidentally accumulate multiple
server entries under the same domain.