### PR TITLE
server: support pre-computed hashed passwords in Credential (closes part of #1037)

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/pingcap/tidb/pkg/parser/auth"
+
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/errors"
 )
@@ -76,6 +78,46 @@ func scrambleValidation(cached, nonce, scramble []byte) bool {
 	return subtle.ConstantTimeCompare(m, cached) == 1
 }
 
+// safeNativeCompare wraps mysql.CompareNativePassword in a recover so a
+// malformed stored hash (installed by constructing Credential directly,
+// bypassing validateHashedPassword) cannot crash the connection goroutine.
+// Returns (match, err); on panic, err is non-nil and match is false.
+func safeNativeCompare(clientAuthData, hash, salt []byte) (match bool, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			match = false
+			err = errors.Errorf("CompareNativePassword panicked: %v", r)
+		}
+	}()
+	return mysql.CompareNativePassword(clientAuthData, hash, salt), nil
+}
+
+// safeSha256Check wraps mysql.Check256HashingPassword in a recover for the
+// same reason as safeNativeCompare. The verifier slices into parts[2][:16]
+// which can panic on malformed stored hashes.
+func safeSha256Check(hash []byte, password string) (match bool, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			match = false
+			err = errors.Errorf("Check256HashingPassword panicked: %v", r)
+		}
+	}()
+	return mysql.Check256HashingPassword(hash, password)
+}
+
+// safeCachingSha2Check wraps auth.CheckHashingPassword in a recover. The
+// upstream verifier slices into parts[3][:SALT_LENGTH] which can panic on
+// malformed stored hashes.
+func safeCachingSha2Check(hash []byte, password, plugin string) (match bool, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			match = false
+			err = errors.Errorf("CheckHashingPassword panicked: %v", r)
+		}
+	}()
+	return auth.CheckHashingPassword(hash, password, plugin)
+}
+
 func (c *Conn) compareNativePasswordAuthData(clientAuthData []byte, credential Credential) error {
 	if isEmptyPassword(clientAuthData) {
 		if credential.hasEmptyPassword() {
@@ -88,7 +130,12 @@ func (c *Conn) compareNativePasswordAuthData(clientAuthData []byte, credential C
 	// credentials when only the server-side hash is available (no plaintext),
 	// and they're cheaper per connect because we skip the SHA1(SHA1(...)) step.
 	for _, hash := range credential.HashedPasswords {
-		if mysql.CompareNativePassword(clientAuthData, hash, c.salt) {
+		match, err := safeNativeCompare(clientAuthData, hash, c.salt)
+		if err != nil {
+			log.Printf("server: native_password hash compare error for user %q: %v", c.user, err)
+			continue
+		}
+		if match {
 			return nil
 		}
 	}
@@ -145,16 +192,17 @@ func (c *Conn) compareSha256PasswordAuthData(clientAuthData []byte, credential C
 	// (e.g. mirroring `mysql.user.authentication_string`), and we skip
 	// the per-connect hashPassword work.
 	for _, hash := range credential.HashedPasswords {
-		check, err := mysql.Check256HashingPassword(hash, string(clientAuthData))
+		check, err := safeSha256Check(hash, string(clientAuthData))
 		if err != nil {
 			// Stored hashes registered via AddUserWithHashedPassword have
 			// already been shape-checked by validateHashedPassword, so
 			// reaching this branch means either a malformed hash was
-			// installed by constructing Credential directly, or the
-			// upstream verifier changed format expectations. Log so the
-			// silent skip is auditable; auth still falls through to the
-			// plaintext loop and ultimately ErrAccessDenied if nothing
-			// matches.
+			// installed by constructing Credential directly (which can
+			// trigger an upstream slice-out-of-bounds panic that
+			// safeSha256Check converts to an error), or the upstream
+			// verifier changed format expectations. Log so the silent
+			// skip is auditable; auth still falls through to the plaintext
+			// loop and ultimately ErrAccessDenied if nothing matches.
 			log.Printf("server: sha256_password hash compare error for user %q: %v", c.user, err)
 			continue
 		}

--- a/server/auth.go
+++ b/server/auth.go
@@ -129,8 +129,8 @@ func (c *Conn) compareNativePasswordAuthData(clientAuthData []byte, credential C
 	// Pre-computed hashes are checked first: they let callers configure
 	// credentials when only the server-side hash is available (no plaintext),
 	// and they're cheaper per connect because we skip the SHA1(SHA1(...)) step.
-	for _, hash := range credential.HashedPasswords {
-		match, err := safeNativeCompare(clientAuthData, hash, c.salt)
+	for _, hp := range credential.HashedPasswords {
+		match, err := safeNativeCompare(clientAuthData, hp.data, c.salt)
 		if err != nil {
 			log.Printf("server: native_password hash compare error for user %q: %v", c.user, err)
 			continue
@@ -191,8 +191,8 @@ func (c *Conn) compareSha256PasswordAuthData(clientAuthData []byte, credential C
 	// credentials when only the server-side stored hash is available
 	// (e.g. mirroring `mysql.user.authentication_string`), and we skip
 	// the per-connect hashPassword work.
-	for _, hash := range credential.HashedPasswords {
-		check, err := safeSha256Check(hash, string(clientAuthData))
+	for _, hp := range credential.HashedPasswords {
+		check, err := safeSha256Check(hp.data, string(clientAuthData))
 		if err != nil {
 			// Stored hashes registered via AddUserWithHashedPassword have
 			// already been shape-checked by validateHashedPassword, so

--- a/server/auth.go
+++ b/server/auth.go
@@ -41,14 +41,14 @@ func (c *Conn) compareAuthData(authPluginName string, clientAuthData []byte) err
 }
 
 func (c *Conn) acquireCredential() error {
-	if len(c.credential.Passwords) > 0 {
+	if c.credential.hasAnyCredential() {
 		return nil
 	}
 	credential, found, err := c.authHandler.GetCredential(c.user)
 	if err != nil {
 		return err
 	}
-	if !found || len(credential.Passwords) == 0 {
+	if !found || !credential.hasAnyCredential() {
 		return mysql.NewDefaultError(mysql.ER_NO_SUCH_USER, c.user, c.RemoteAddr().String())
 	}
 	c.credential = credential
@@ -81,6 +81,15 @@ func (c *Conn) compareNativePasswordAuthData(clientAuthData []byte, credential C
 			return nil
 		}
 		return ErrAccessDeniedNoPassword
+	}
+
+	// Pre-computed hashes are checked first: they let callers configure
+	// credentials when only the server-side hash is available (no plaintext),
+	// and they're cheaper per connect because we skip the SHA1(SHA1(...)) step.
+	for _, hash := range credential.HashedPasswords {
+		if mysql.CompareNativePassword(clientAuthData, hash, c.salt) {
+			return nil
+		}
 	}
 
 	for _, password := range credential.Passwords {

--- a/server/auth.go
+++ b/server/auth.go
@@ -8,6 +8,7 @@ import (
 	"crypto/subtle"
 	"crypto/tls"
 	"fmt"
+	"log"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/errors"
@@ -146,6 +147,15 @@ func (c *Conn) compareSha256PasswordAuthData(clientAuthData []byte, credential C
 	for _, hash := range credential.HashedPasswords {
 		check, err := mysql.Check256HashingPassword(hash, string(clientAuthData))
 		if err != nil {
+			// Stored hashes registered via AddUserWithHashedPassword have
+			// already been shape-checked by validateHashedPassword, so
+			// reaching this branch means either a malformed hash was
+			// installed by constructing Credential directly, or the
+			// upstream verifier changed format expectations. Log so the
+			// silent skip is auditable; auth still falls through to the
+			// plaintext loop and ultimately ErrAccessDenied if nothing
+			// matches.
+			log.Printf("server: sha256_password hash compare error for user %q: %v", c.user, err)
 			continue
 		}
 		if check {

--- a/server/auth.go
+++ b/server/auth.go
@@ -8,9 +8,6 @@ import (
 	"crypto/subtle"
 	"crypto/tls"
 	"fmt"
-	"log"
-
-	"github.com/pingcap/tidb/pkg/parser/auth"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/errors"
@@ -78,46 +75,6 @@ func scrambleValidation(cached, nonce, scramble []byte) bool {
 	return subtle.ConstantTimeCompare(m, cached) == 1
 }
 
-// safeNativeCompare wraps mysql.CompareNativePassword in a recover so a
-// malformed stored hash (installed by constructing Credential directly,
-// bypassing validateHashedPassword) cannot crash the connection goroutine.
-// Returns (match, err); on panic, err is non-nil and match is false.
-func safeNativeCompare(clientAuthData, hash, salt []byte) (match bool, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			match = false
-			err = errors.Errorf("CompareNativePassword panicked: %v", r)
-		}
-	}()
-	return mysql.CompareNativePassword(clientAuthData, hash, salt), nil
-}
-
-// safeSha256Check wraps mysql.Check256HashingPassword in a recover for the
-// same reason as safeNativeCompare. The verifier slices into parts[2][:16]
-// which can panic on malformed stored hashes.
-func safeSha256Check(hash []byte, password string) (match bool, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			match = false
-			err = errors.Errorf("Check256HashingPassword panicked: %v", r)
-		}
-	}()
-	return mysql.Check256HashingPassword(hash, password)
-}
-
-// safeCachingSha2Check wraps auth.CheckHashingPassword in a recover. The
-// upstream verifier slices into parts[3][:SALT_LENGTH] which can panic on
-// malformed stored hashes.
-func safeCachingSha2Check(hash []byte, password, plugin string) (match bool, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			match = false
-			err = errors.Errorf("CheckHashingPassword panicked: %v", r)
-		}
-	}()
-	return auth.CheckHashingPassword(hash, password, plugin)
-}
-
 func (c *Conn) compareNativePasswordAuthData(clientAuthData []byte, credential Credential) error {
 	if isEmptyPassword(clientAuthData) {
 		if credential.hasEmptyPassword() {
@@ -130,12 +87,7 @@ func (c *Conn) compareNativePasswordAuthData(clientAuthData []byte, credential C
 	// credentials when only the server-side hash is available (no plaintext),
 	// and they're cheaper per connect because we skip the SHA1(SHA1(...)) step.
 	for _, hp := range credential.HashedPasswords {
-		match, err := safeNativeCompare(clientAuthData, hp.data, c.salt)
-		if err != nil {
-			log.Printf("server: native_password hash compare error for user %q: %v", c.user, err)
-			continue
-		}
-		if match {
+		if mysql.CompareNativePassword(clientAuthData, hp.data, c.salt) {
 			return nil
 		}
 	}
@@ -192,18 +144,15 @@ func (c *Conn) compareSha256PasswordAuthData(clientAuthData []byte, credential C
 	// (e.g. mirroring `mysql.user.authentication_string`), and we skip
 	// the per-connect hashPassword work.
 	for _, hp := range credential.HashedPasswords {
-		check, err := safeSha256Check(hp.data, string(clientAuthData))
+		check, err := mysql.Check256HashingPassword(hp.data, string(clientAuthData))
 		if err != nil {
-			// Stored hashes registered via AddUserWithHashedPassword have
-			// already been shape-checked by validateHashedPassword, so
-			// reaching this branch means either a malformed hash was
-			// installed by constructing Credential directly (which can
-			// trigger an upstream slice-out-of-bounds panic that
-			// safeSha256Check converts to an error), or the upstream
-			// verifier changed format expectations. Log so the silent
+			// Stored hashes are shape-checked at construction time
+			// (validateHashedPassword via NewHashedPassword), so reaching
+			// this branch implies the upstream verifier changed format
+			// expectations. Log via the configurable logger so the silent
 			// skip is auditable; auth still falls through to the plaintext
 			// loop and ultimately ErrAccessDenied if nothing matches.
-			log.Printf("server: sha256_password hash compare error for user %q: %v", c.user, err)
+			c.serverConf.logger().Error("sha256_password hash compare error", "user", c.user, "error", err)
 			continue
 		}
 		if check {

--- a/server/auth.go
+++ b/server/auth.go
@@ -139,6 +139,20 @@ func (c *Conn) compareSha256PasswordAuthData(clientAuthData []byte, credential C
 			clientAuthData = clientAuthData[:l-1]
 		}
 	}
+	// Pre-computed hashes are checked first: callers can configure
+	// credentials when only the server-side stored hash is available
+	// (e.g. mirroring `mysql.user.authentication_string`), and we skip
+	// the per-connect hashPassword work.
+	for _, hash := range credential.HashedPasswords {
+		check, err := mysql.Check256HashingPassword(hash, string(clientAuthData))
+		if err != nil {
+			continue
+		}
+		if check {
+			return nil
+		}
+	}
+
 	for _, password := range credential.Passwords {
 		hash, err := credential.hashPassword(password)
 		if err != nil {

--- a/server/auth_switch_response.go
+++ b/server/auth_switch_response.go
@@ -86,8 +86,8 @@ func (c *Conn) checkSha2CacheCredentials(clientAuthData []byte, credential Crede
 	// credentials when only the server-side stored "$A$..." form is
 	// available (e.g. mirroring another server's mysql.user table), and
 	// we skip the per-connect hashPassword work.
-	for _, hash := range credential.HashedPasswords {
-		match, err := safeCachingSha2Check(hash, string(clientAuthData), mysql.AUTH_CACHING_SHA2_PASSWORD)
+	for _, hp := range credential.HashedPasswords {
+		match, err := safeCachingSha2Check(hp.data, string(clientAuthData), mysql.AUTH_CACHING_SHA2_PASSWORD)
 		if err != nil {
 			// Stored hashes registered via AddUserWithHashedPassword have
 			// already been shape-checked by validateHashedPassword, so

--- a/server/auth_switch_response.go
+++ b/server/auth_switch_response.go
@@ -81,6 +81,17 @@ func (c *Conn) checkSha2CacheCredentials(clientAuthData []byte, credential Crede
 		return ErrAccessDeniedNoPassword
 	}
 
+	// Pre-computed hashes are checked first: callers can configure
+	// credentials when only the server-side stored "$A$..." form is
+	// available (e.g. mirroring another server's mysql.user table), and
+	// we skip the per-connect hashPassword work.
+	for _, hash := range credential.HashedPasswords {
+		match, err := auth.CheckHashingPassword(hash, string(clientAuthData), mysql.AUTH_CACHING_SHA2_PASSWORD)
+		if match && err == nil {
+			return nil
+		}
+	}
+
 	for _, password := range credential.Passwords {
 		hash, err := credential.hashPassword(password)
 		if err != nil {

--- a/server/auth_switch_response.go
+++ b/server/auth_switch_response.go
@@ -87,16 +87,17 @@ func (c *Conn) checkSha2CacheCredentials(clientAuthData []byte, credential Crede
 	// available (e.g. mirroring another server's mysql.user table), and
 	// we skip the per-connect hashPassword work.
 	for _, hash := range credential.HashedPasswords {
-		match, err := auth.CheckHashingPassword(hash, string(clientAuthData), mysql.AUTH_CACHING_SHA2_PASSWORD)
+		match, err := safeCachingSha2Check(hash, string(clientAuthData), mysql.AUTH_CACHING_SHA2_PASSWORD)
 		if err != nil {
 			// Stored hashes registered via AddUserWithHashedPassword have
 			// already been shape-checked by validateHashedPassword, so
 			// reaching this branch means either a malformed hash was
-			// installed by constructing Credential directly, or the
-			// upstream verifier changed format expectations. Log so the
-			// silent skip is auditable; auth still falls through to the
-			// plaintext loop and ultimately ErrAccessDenied if nothing
-			// matches.
+			// installed by constructing Credential directly (which can
+			// trigger an upstream slice-out-of-bounds panic that
+			// safeCachingSha2Check converts to an error), or the upstream
+			// verifier changed format expectations. Log so the silent skip
+			// is auditable; auth still falls through to the plaintext loop
+			// and ultimately ErrAccessDenied if nothing matches.
 			log.Printf("server: caching_sha2_password hash compare error for user %q: %v", c.user, err)
 			continue
 		}

--- a/server/auth_switch_response.go
+++ b/server/auth_switch_response.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"crypto/tls"
 	"fmt"
+	"log"
 
 	"github.com/pingcap/tidb/pkg/parser/auth"
 
@@ -87,7 +88,19 @@ func (c *Conn) checkSha2CacheCredentials(clientAuthData []byte, credential Crede
 	// we skip the per-connect hashPassword work.
 	for _, hash := range credential.HashedPasswords {
 		match, err := auth.CheckHashingPassword(hash, string(clientAuthData), mysql.AUTH_CACHING_SHA2_PASSWORD)
-		if match && err == nil {
+		if err != nil {
+			// Stored hashes registered via AddUserWithHashedPassword have
+			// already been shape-checked by validateHashedPassword, so
+			// reaching this branch means either a malformed hash was
+			// installed by constructing Credential directly, or the
+			// upstream verifier changed format expectations. Log so the
+			// silent skip is auditable; auth still falls through to the
+			// plaintext loop and ultimately ErrAccessDenied if nothing
+			// matches.
+			log.Printf("server: caching_sha2_password hash compare error for user %q: %v", c.user, err)
+			continue
+		}
+		if match {
 			return nil
 		}
 	}

--- a/server/auth_switch_response.go
+++ b/server/auth_switch_response.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha256"
 	"crypto/tls"
 	"fmt"
-	"log"
 
 	"github.com/pingcap/tidb/pkg/parser/auth"
 
@@ -87,18 +86,15 @@ func (c *Conn) checkSha2CacheCredentials(clientAuthData []byte, credential Crede
 	// available (e.g. mirroring another server's mysql.user table), and
 	// we skip the per-connect hashPassword work.
 	for _, hp := range credential.HashedPasswords {
-		match, err := safeCachingSha2Check(hp.data, string(clientAuthData), mysql.AUTH_CACHING_SHA2_PASSWORD)
+		match, err := auth.CheckHashingPassword(hp.data, string(clientAuthData), mysql.AUTH_CACHING_SHA2_PASSWORD)
 		if err != nil {
-			// Stored hashes registered via AddUserWithHashedPassword have
-			// already been shape-checked by validateHashedPassword, so
-			// reaching this branch means either a malformed hash was
-			// installed by constructing Credential directly (which can
-			// trigger an upstream slice-out-of-bounds panic that
-			// safeCachingSha2Check converts to an error), or the upstream
-			// verifier changed format expectations. Log so the silent skip
-			// is auditable; auth still falls through to the plaintext loop
-			// and ultimately ErrAccessDenied if nothing matches.
-			log.Printf("server: caching_sha2_password hash compare error for user %q: %v", c.user, err)
+			// Stored hashes are shape-checked at construction time
+			// (validateHashedPassword via NewHashedPassword), so reaching
+			// this branch implies the upstream verifier changed format
+			// expectations. Log via the configurable logger so the silent
+			// skip is auditable; auth still falls through to the plaintext
+			// loop and ultimately ErrAccessDenied if nothing matches.
+			c.serverConf.logger().Error("caching_sha2_password hash compare error", "user", c.user, "error", err)
 			continue
 		}
 		if match {

--- a/server/authentication_handler.go
+++ b/server/authentication_handler.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"slices"
 	"sync"
 
@@ -52,10 +53,16 @@ func NewInMemoryAuthenticationHandler(defaultAuthMethod ...string) *InMemoryAuth
 // rehoming users from another server's `mysql.user` table) configure credentials when only the stored
 // hash is available. The byte format depends on AuthPluginName:
 //
-//   - mysql_native_password: the 20-byte SHA1(SHA1(plaintext)) value, i.e. what NativePasswordHash
-//     returns, or what DecodePasswordHex returns from MySQL's standard "*XXXX..." (41-char) hex form.
-//
-// Other auth plugins do not currently consume HashedPasswords; for them, populate Passwords instead.
+//   - mysql_native_password: the 20-byte SHA1(SHA1(plaintext)) value, i.e. what
+//     mysql.NativePasswordHash returns, or what mysql.DecodePasswordHex returns from MySQL's standard
+//     "*XXXX..." (41-char) hex form.
+//   - caching_sha2_password: the bytes of the standard "$A$<iter>$<salt>$<hash>" stored form, i.e.
+//     what auth.NewHashPassword(plaintext, AUTH_CACHING_SHA2_PASSWORD) returns. Note that this auth
+//     plugin's full-auth flow requires either TLS or a configured RSA key on the server (same
+//     constraint as plaintext Passwords). After the first successful full auth the server caches
+//     SHA256(SHA256(plaintext)) per user@host so subsequent connections can take the fast-auth path.
+//   - sha256_password: the bytes of the standard "$<iter>$<salt>$<hashHex>" stored form, i.e. what
+//     mysql.NewSha256PasswordHash returns. Same TLS/RSA requirement as caching_sha2_password.
 //
 // Both fields can be set on the same Credential: HashedPasswords is checked first (cheaper, no
 // hashing per connect), then Passwords.
@@ -144,16 +151,28 @@ func (h *InMemoryAuthenticationHandler) AddUser(username, password string, optio
 // AddUserWithHashedPassword registers a user whose password is already in
 // the server-side hashed form, so the plaintext never has to be supplied.
 //
-// The expected byte format depends on authPluginName; see Credential.HashedPasswords.
-// For mysql_native_password (currently the only plugin that consumes
-// HashedPasswords) hash must be the 20-byte SHA1(SHA1(plaintext)) value.
-// To take MySQL's standard 41-character "*XXXX..." form, use
-// mysql.DecodePasswordHex first:
+// The expected byte format depends on authPluginName; see Credential.HashedPasswords
+// for the full list. As shorthand:
+//
+//   - mysql_native_password: the 20-byte SHA1(SHA1(plaintext)) value. Use
+//     mysql.DecodePasswordHex to strip the "*" and decode MySQL's 41-char hex form.
+//   - caching_sha2_password: the bytes of "$A$<iter>$<salt>$<hash>".
+//   - sha256_password: the bytes of "$<iter>$<salt>$<hashHex>".
+//
+// The hash is rejected up front if it doesn't match the expected shape for
+// the chosen auth plugin, so a misconfigured caller fails immediately rather
+// than registering a user that can never authenticate. authPluginName
+// defaults to the handler's default auth method.
+//
+// caching_sha2_password and sha256_password additionally require the server
+// to be configured with TLS or an RSA key, since the full-auth flow sends
+// the plaintext on the wire — same constraint that already applies to
+// plaintext Passwords with these plugins.
+//
+// Example:
 //
 //	bytes, _ := mysql.DecodePasswordHex("*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9")
 //	handler.AddUserWithHashedPassword("alice", bytes)
-//
-// authPluginName defaults to the handler's default auth method.
 func (h *InMemoryAuthenticationHandler) AddUserWithHashedPassword(username string, hash []byte, optionalAuthPluginName ...string) error {
 	authPluginName := h.defaultAuthMethod
 	if len(optionalAuthPluginName) > 0 {
@@ -163,17 +182,8 @@ func (h *InMemoryAuthenticationHandler) AddUserWithHashedPassword(username strin
 	if !isAuthMethodSupported(authPluginName) {
 		return errors.Errorf("unknown authentication plugin name '%s'", authPluginName)
 	}
-	if authPluginName != mysql.AUTH_NATIVE_PASSWORD {
-		// Future work: extend HashedPasswords semantics to caching_sha2_password
-		// and sha256_password. Reject up front so callers don't silently get
-		// "auth always fails" for unsupported plugins.
-		return errors.Errorf("AddUserWithHashedPassword does not yet support auth plugin '%s'; only '%s' is supported", authPluginName, mysql.AUTH_NATIVE_PASSWORD)
-	}
-	// mysql_native_password's stored form is exactly SHA1(SHA1(plaintext)) =
-	// 20 bytes. Reject any other length so a misconfigured caller fails up
-	// front rather than ending up with users that always get ER_ACCESS_DENIED.
-	if len(hash) != mysqlNativePasswordHashLen {
-		return errors.Errorf("invalid hashed password length for %s: expected %d bytes, got %d", authPluginName, mysqlNativePasswordHashLen, len(hash))
+	if err := validateHashedPassword(authPluginName, hash); err != nil {
+		return err
 	}
 
 	// Defensive copy so a caller that reuses or mutates its backing slice
@@ -189,6 +199,76 @@ func (h *InMemoryAuthenticationHandler) AddUserWithHashedPassword(username strin
 // mysqlNativePasswordHashLen is the length of a native_password hash
 // (sha1(sha1(plaintext))) in bytes.
 const mysqlNativePasswordHashLen = 20
+
+// validateHashedPassword does a lightweight shape check on a stored-hash
+// byte string for the given auth plugin. It does NOT verify cryptographic
+// correctness — that happens during the actual handshake — it just rejects
+// obvious format mismatches (empty, wrong length, missing structure) so
+// callers find out at AddUser time, not on the first failed login.
+func validateHashedPassword(authPluginName string, hash []byte) error {
+	if len(hash) == 0 {
+		return errors.Errorf("invalid hashed password for %s: empty", authPluginName)
+	}
+	switch authPluginName {
+	case mysql.AUTH_NATIVE_PASSWORD:
+		// Stored form is exactly SHA1(SHA1(plaintext)) = 20 bytes.
+		if len(hash) != mysqlNativePasswordHashLen {
+			return errors.Errorf("invalid hashed password length for %s: expected %d bytes, got %d", authPluginName, mysqlNativePasswordHashLen, len(hash))
+		}
+		return nil
+	case mysql.AUTH_CACHING_SHA2_PASSWORD:
+		// Standard form is "$A$<iter-hex>$<salt><hash>" with the salt
+		// (auth.SALT_LENGTH = 20 bytes) and hash (43 bytes) concatenated
+		// in the final segment — see auth.NewHashPassword and
+		// auth.CheckHashingPassword. We require a 4-part split with
+		// hashType "A" and a final segment strictly longer than the salt
+		// so the hash bytes are present (CheckHashingPassword would panic
+		// otherwise on `parts[3][:SALT_LENGTH]`).
+		const cachingSha2SaltLen = 20 // = auth.SALT_LENGTH (unexported constant value)
+		parts := bytes.Split(hash, []byte("$"))
+		if len(parts) != 4 || len(parts[0]) != 0 {
+			return errors.Errorf("invalid hashed password for %s: expected $A$<iter>$<salt><hash> form", authPluginName)
+		}
+		if string(parts[1]) != "A" {
+			return errors.Errorf("invalid hashed password for %s: expected hash type 'A', got %q", authPluginName, parts[1])
+		}
+		if len(parts[2]) == 0 {
+			return errors.Errorf("invalid hashed password for %s: missing iteration count", authPluginName)
+		}
+		if len(parts[3]) <= cachingSha2SaltLen {
+			return errors.Errorf("invalid hashed password for %s: final segment must contain salt and hash (got %d bytes, need >%d)", authPluginName, len(parts[3]), cachingSha2SaltLen)
+		}
+		return nil
+	case mysql.AUTH_SHA256_PASSWORD:
+		// Standard form is "$<iter-decimal>$<salt:mysql.SALT_LENGTH=16>$<hashHex:64>"
+		// — see mysql.NewSha256PasswordHash and mysql.Check256HashingPassword.
+		parts := bytes.Split(hash, []byte("$"))
+		if len(parts) != 4 || len(parts[0]) != 0 {
+			return errors.Errorf("invalid hashed password for %s: expected $<iter>$<salt>$<hashHex> form", authPluginName)
+		}
+		if len(parts[1]) == 0 {
+			return errors.Errorf("invalid hashed password for %s: missing iteration count", authPluginName)
+		}
+		for _, b := range parts[1] {
+			if b < '0' || b > '9' {
+				return errors.Errorf("invalid hashed password for %s: iteration count must be decimal", authPluginName)
+			}
+		}
+		if len(parts[2]) < mysql.SALT_LENGTH {
+			return errors.Errorf("invalid hashed password for %s: salt must be at least %d bytes (got %d)", authPluginName, mysql.SALT_LENGTH, len(parts[2]))
+		}
+		if len(parts[3]) == 0 {
+			return errors.Errorf("invalid hashed password for %s: missing hash segment", authPluginName)
+		}
+		return nil
+	case mysql.AUTH_CLEAR_PASSWORD:
+		// Clear-password is plaintext on the wire; there is no meaningful
+		// "hashed" form. Callers should use AddUser instead.
+		return errors.Errorf("AddUserWithHashedPassword does not apply to %s; use AddUser with the plaintext", authPluginName)
+	default:
+		return errors.Errorf("unknown authentication plugin name '%s'", authPluginName)
+	}
+}
 
 func (h *InMemoryAuthenticationHandler) OnAuthSuccess(conn *Conn) error {
 	return nil

--- a/server/authentication_handler.go
+++ b/server/authentication_handler.go
@@ -169,16 +169,26 @@ func (h *InMemoryAuthenticationHandler) AddUserWithHashedPassword(username strin
 		// "auth always fails" for unsupported plugins.
 		return errors.Errorf("AddUserWithHashedPassword does not yet support auth plugin '%s'; only '%s' is supported", authPluginName, mysql.AUTH_NATIVE_PASSWORD)
 	}
-	if len(hash) == 0 {
-		return errors.New("hashed password must not be empty")
+	// mysql_native_password's stored form is exactly SHA1(SHA1(plaintext)) =
+	// 20 bytes. Reject any other length so a misconfigured caller fails up
+	// front rather than ending up with users that always get ER_ACCESS_DENIED.
+	if len(hash) != mysqlNativePasswordHashLen {
+		return errors.Errorf("invalid hashed password length for %s: expected %d bytes, got %d", authPluginName, mysqlNativePasswordHashLen, len(hash))
 	}
 
+	// Defensive copy so a caller that reuses or mutates its backing slice
+	// can't change the stored credential out from under us.
+	stored := slices.Clone(hash)
 	h.userPool.Store(username, Credential{
-		HashedPasswords: [][]byte{hash},
+		HashedPasswords: [][]byte{stored},
 		AuthPluginName:  authPluginName,
 	})
 	return nil
 }
+
+// mysqlNativePasswordHashLen is the length of a native_password hash
+// (sha1(sha1(plaintext))) in bytes.
+const mysqlNativePasswordHashLen = 20
 
 func (h *InMemoryAuthenticationHandler) OnAuthSuccess(conn *Conn) error {
 	return nil

--- a/server/authentication_handler.go
+++ b/server/authentication_handler.go
@@ -42,12 +42,27 @@ func NewInMemoryAuthenticationHandler(defaultAuthMethod ...string) *InMemoryAuth
 }
 
 // Credential holds authentication settings for a user.
+//
 // Passwords contains all valid raw passwords for the user. They are hashed on demand during comparison.
 // If empty password authentication is allowed, Passwords must contain an empty string (e.g., []string{""})
 // rather than being a zero-length slice. A zero-length slice means no valid passwords are configured.
+//
+// HashedPasswords contains pre-computed password hashes that the server compares directly against the
+// client's challenge response, without ever needing the plaintext. This lets callers (e.g. a MySQL proxy
+// rehoming users from another server's `mysql.user` table) configure credentials when only the stored
+// hash is available. The byte format depends on AuthPluginName:
+//
+//   - mysql_native_password: the 20-byte SHA1(SHA1(plaintext)) value, i.e. what NativePasswordHash
+//     returns, or what DecodePasswordHex returns from MySQL's standard "*XXXX..." (41-char) hex form.
+//
+// Other auth plugins do not currently consume HashedPasswords; for them, populate Passwords instead.
+//
+// Both fields can be set on the same Credential: HashedPasswords is checked first (cheaper, no
+// hashing per connect), then Passwords.
 type Credential struct {
-	Passwords      []string
-	AuthPluginName string
+	Passwords       []string
+	HashedPasswords [][]byte
+	AuthPluginName  string
 }
 
 // hashPassword computes the password hash for a given password using the credential's auth plugin.
@@ -77,6 +92,13 @@ func (c Credential) hashPassword(password string) (string, error) {
 // hasEmptyPassword returns true if any password in the credential is empty.
 func (c Credential) hasEmptyPassword() bool {
 	return slices.Contains(c.Passwords, "")
+}
+
+// hasAnyCredential reports whether the credential has at least one usable
+// entry — either a plaintext password (including the empty string, which
+// signals "empty password is OK") or a pre-computed hash.
+func (c Credential) hasAnyCredential() bool {
+	return len(c.Passwords) > 0 || len(c.HashedPasswords) > 0
 }
 
 // InMemoryAuthenticationHandler implements AuthenticationHandler with in-memory credential storage.
@@ -115,6 +137,45 @@ func (h *InMemoryAuthenticationHandler) AddUser(username, password string, optio
 	h.userPool.Store(username, Credential{
 		Passwords:      []string{password},
 		AuthPluginName: authPluginName,
+	})
+	return nil
+}
+
+// AddUserWithHashedPassword registers a user whose password is already in
+// the server-side hashed form, so the plaintext never has to be supplied.
+//
+// The expected byte format depends on authPluginName; see Credential.HashedPasswords.
+// For mysql_native_password (currently the only plugin that consumes
+// HashedPasswords) hash must be the 20-byte SHA1(SHA1(plaintext)) value.
+// To take MySQL's standard 41-character "*XXXX..." form, use
+// mysql.DecodePasswordHex first:
+//
+//	bytes, _ := mysql.DecodePasswordHex("*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9")
+//	handler.AddUserWithHashedPassword("alice", bytes)
+//
+// authPluginName defaults to the handler's default auth method.
+func (h *InMemoryAuthenticationHandler) AddUserWithHashedPassword(username string, hash []byte, optionalAuthPluginName ...string) error {
+	authPluginName := h.defaultAuthMethod
+	if len(optionalAuthPluginName) > 0 {
+		authPluginName = optionalAuthPluginName[0]
+	}
+
+	if !isAuthMethodSupported(authPluginName) {
+		return errors.Errorf("unknown authentication plugin name '%s'", authPluginName)
+	}
+	if authPluginName != mysql.AUTH_NATIVE_PASSWORD {
+		// Future work: extend HashedPasswords semantics to caching_sha2_password
+		// and sha256_password. Reject up front so callers don't silently get
+		// "auth always fails" for unsupported plugins.
+		return errors.Errorf("AddUserWithHashedPassword does not yet support auth plugin '%s'; only '%s' is supported", authPluginName, mysql.AUTH_NATIVE_PASSWORD)
+	}
+	if len(hash) == 0 {
+		return errors.New("hashed password must not be empty")
+	}
+
+	h.userPool.Store(username, Credential{
+		HashedPasswords: [][]byte{hash},
+		AuthPluginName:  authPluginName,
 	})
 	return nil
 }

--- a/server/authentication_handler.go
+++ b/server/authentication_handler.go
@@ -51,36 +51,15 @@ func NewInMemoryAuthenticationHandler(defaultAuthMethod ...string) *InMemoryAuth
 // HashedPasswords contains pre-computed password hashes that the server compares directly against the
 // client's challenge response, without ever needing the plaintext. This lets callers (e.g. a MySQL proxy
 // rehoming users from another server's `mysql.user` table) configure credentials when only the stored
-// hash is available. The byte format depends on AuthPluginName:
-//
-//   - mysql_native_password: the 20-byte SHA1(SHA1(plaintext)) value, i.e. what
-//     mysql.NativePasswordHash returns, or what mysql.DecodePasswordHex returns from MySQL's standard
-//     "*XXXX..." (41-char) hex form.
-//   - caching_sha2_password: the bytes of the standard "$A$<iter>$<salt><hash>" stored form (salt
-//     and hash are concatenated, with no '$' between them — see auth.NewHashPassword in
-//     pingcap/tidb). Note that this auth plugin's full-auth flow requires either TLS or a
-//     configured RSA key on the server, because the server must obtain the plaintext to verify it
-//     against the stored hash and to populate the cache. After the first successful full auth the
-//     server caches SHA256(SHA256(plaintext)) per user@host so subsequent connections can take the
-//     fast-auth path.
-//   - sha256_password: the bytes of the standard "$<iter>$<salt>$<hashHex>" stored form, i.e. what
-//     mysql.NewSha256PasswordHash returns. Same TLS-or-RSA requirement as caching_sha2_password,
-//     for the same reason.
+// hash is available. Each entry is a HashedPassword value (see NewHashedPassword) which validates the
+// per-plugin byte format at construction time, so direct assignment cannot install a malformed hash.
+// The expected byte format per plugin is documented on HashedPassword.
 //
 // Both fields can be set on the same Credential: HashedPasswords is checked first (cheaper, no
 // hashing per connect), then Passwords.
-//
-// Hashes installed via AddUserWithHashedPassword / NewHashedPassword are
-// shape-checked up front. Constructing a Credential directly and inserting
-// arbitrary bytes into HashedPasswords bypasses that check: a malformed
-// caching_sha2_password value (e.g. a final "$A$<iter>$<salt><hash>"
-// segment shorter than the 20-byte salt) can panic inside the upstream
-// tidb verifier auth.CheckHashingPassword. Callers loading hashes from an
-// untrusted source should go through the documented helpers, or run their
-// own validation before assigning to this field.
 type Credential struct {
 	Passwords       []string
-	HashedPasswords [][]byte
+	HashedPasswords []HashedPassword
 	AuthPluginName  string
 }
 
@@ -90,10 +69,26 @@ type Credential struct {
 // construction time. Construct it with NewHashedPassword; the zero value is
 // not usable.
 //
-// The point of the type is to let callers validate a (plugin, hash) pair once
-// — for example when loading credentials at startup — and then reuse the
-// resulting value, instead of revalidating on every AddUser call. See
-// Credential.HashedPasswords for the per-plugin byte format.
+// Because the wrapped bytes are unexported and Bytes returns a copy, a
+// HashedPassword value is effectively immutable to outside callers — that's
+// why Credential.HashedPasswords can be exported as []HashedPassword without
+// the panic-shape risks that would come with []byte.
+//
+// The expected byte format per plugin:
+//
+//   - mysql_native_password: the 20-byte SHA1(SHA1(plaintext)) value, i.e. what
+//     mysql.NativePasswordHash returns, or what mysql.DecodePasswordHex returns
+//     from MySQL's standard "*XXXX..." (41-char) hex form.
+//   - caching_sha2_password: the bytes of the standard "$A$<iter>$<salt><hash>"
+//     stored form (salt and hash concatenated, no '$' between them — see
+//     auth.NewHashPassword in pingcap/tidb). Full-auth requires TLS or an RSA
+//     key on the server because the server must obtain the plaintext to verify
+//     it against the stored hash and to populate the cache. After the first
+//     successful full auth the server caches SHA256(SHA256(plaintext)) per
+//     user@host so subsequent connections can take the fast-auth path.
+//   - sha256_password: the bytes of the standard "$<iter>$<salt>$<hashHex>"
+//     stored form, i.e. what mysql.NewSha256PasswordHash returns. Same
+//     TLS-or-RSA requirement as caching_sha2_password.
 type HashedPassword struct {
 	plugin string
 	data   []byte
@@ -155,19 +150,13 @@ func (c Credential) hasAnyCredential() bool {
 	return len(c.Passwords) > 0 || len(c.HashedPasswords) > 0
 }
 
-// cloneCredential returns a deep copy of c so that callers cannot mutate
-// the stored slices. Both Passwords and the per-entry HashedPasswords byte
-// slices are copied; AuthPluginName is a string and is already immutable.
 func cloneCredential(c Credential) Credential {
 	out := Credential{AuthPluginName: c.AuthPluginName}
 	if c.Passwords != nil {
 		out.Passwords = slices.Clone(c.Passwords)
 	}
 	if c.HashedPasswords != nil {
-		out.HashedPasswords = make([][]byte, len(c.HashedPasswords))
-		for i, h := range c.HashedPasswords {
-			out.HashedPasswords[i] = slices.Clone(h)
-		}
+		out.HashedPasswords = slices.Clone(c.HashedPasswords)
 	}
 	return out
 }
@@ -192,13 +181,12 @@ func (h *InMemoryAuthenticationHandler) GetCredential(username string) (credenti
 	if !valid {
 		return Credential{}, true, errors.Errorf("invalid credential")
 	}
-	// Defensive deep copy: Credential carries []string and [][]byte fields
-	// whose backing arrays would otherwise be shared with the stored value.
-	// A caller mutating the returned slices (intentionally or by accident)
-	// must not corrupt the credential held in the user pool.
 	return cloneCredential(c), true, nil
 }
 
+// AddUser registers (or replaces) a user with a single plaintext password.
+// Calling AddUser for an existing username overwrites the previous
+// credential entirely, including any HashedPasswords entries.
 func (h *InMemoryAuthenticationHandler) AddUser(username, password string, optionalAuthPluginName ...string) error {
 	authPluginName := h.defaultAuthMethod
 	if len(optionalAuthPluginName) > 0 {
@@ -216,10 +204,13 @@ func (h *InMemoryAuthenticationHandler) AddUser(username, password string, optio
 	return nil
 }
 
-// AddUserWithHashedPassword registers a user whose password is already in
-// the server-side hashed form, so the plaintext never has to be supplied.
+// AddUserWithHashedPassword registers (or replaces) a user whose password
+// is already in the server-side hashed form, so the plaintext never has to
+// be supplied. Calling it for an existing username overwrites the previous
+// credential entirely, including any HashedPasswords entries; use
+// AppendUserHashed if you want to add another hash to an existing user.
 //
-// The expected byte format depends on authPluginName; see Credential.HashedPasswords
+// The expected byte format depends on authPluginName; see HashedPassword
 // for the full list. As shorthand:
 //
 //   - mysql_native_password: the 20-byte SHA1(SHA1(plaintext)) value. Use
@@ -255,7 +246,12 @@ func (h *InMemoryAuthenticationHandler) AddUserWithHashedPassword(username strin
 	return h.AddUserHashed(username, hp)
 }
 
-// AddUserHashed registers username with a pre-validated HashedPassword.
+// AddUserHashed registers username with a pre-validated HashedPassword,
+// replacing any existing credential for that username (same overwrite
+// semantics as AddUser). To install additional hashes for an existing
+// user — e.g. during password rotation, where both the old and new hash
+// should authenticate for a window — use AppendUserHashed instead.
+//
 // Equivalent to AddUserWithHashedPassword but takes the already-validated
 // value from NewHashedPassword, which is convenient when the same hash is
 // being installed against multiple usernames or when callers want to keep
@@ -263,23 +259,47 @@ func (h *InMemoryAuthenticationHandler) AddUserWithHashedPassword(username strin
 //
 // The HashedPassword zero value is rejected — its plugin name is empty and
 // its data is nil, which would otherwise register a user that is reachable
-// (`hasAnyCredential` returns true on `[][]byte{nil}`) but can never
-// authenticate. To stay defensive against any in-place mutation between
-// NewHashedPassword and this call, AddUserHashed re-runs
+// (hasAnyCredential returns true on a length-1 HashedPasswords slice) but
+// can never authenticate. To stay defensive against any in-place mutation
+// between NewHashedPassword and this call, AddUserHashed re-runs
 // validateHashedPassword on the wrapped (plugin, data) pair.
 func (h *InMemoryAuthenticationHandler) AddUserHashed(username string, hp HashedPassword) error {
 	if err := validateHashedPassword(hp.plugin, hp.data); err != nil {
 		return err
 	}
-	// Defensive copy so a caller that constructed HashedPassword via
-	// NewHashedPassword (which already cloned the input) is still
-	// protected from later AddUserHashed calls accidentally aliasing
-	// the same backing array, and so HashedPassword.Bytes returning a
-	// fresh copy stays consistent with the credential storage model.
 	h.userPool.Store(username, Credential{
-		HashedPasswords: [][]byte{slices.Clone(hp.data)},
+		HashedPasswords: []HashedPassword{hp},
 		AuthPluginName:  hp.plugin,
 	})
+	return nil
+}
+
+// AppendUserHashed adds another hash to an existing user's credential,
+// rather than replacing it. The intended use case is password rotation:
+// install the new hash alongside the old, let in-flight clients drain on
+// the old credential, then prune the old hash.
+//
+// The user must already exist (returns an error otherwise — use
+// AddUserHashed for first-time registration), and hp's auth plugin must
+// match the existing credential's AuthPluginName so a single verifier
+// flow handles every entry.
+func (h *InMemoryAuthenticationHandler) AppendUserHashed(username string, hp HashedPassword) error {
+	if err := validateHashedPassword(hp.plugin, hp.data); err != nil {
+		return err
+	}
+	v, ok := h.userPool.Load(username)
+	if !ok {
+		return errors.Errorf("user %q not found; use AddUserHashed to register", username)
+	}
+	c, valid := v.(Credential)
+	if !valid {
+		return errors.Errorf("invalid credential stored for user %q", username)
+	}
+	if c.AuthPluginName != hp.plugin {
+		return errors.Errorf("cannot append %s hash to user %q (existing credential uses %s)", hp.plugin, username, c.AuthPluginName)
+	}
+	c.HashedPasswords = append(slices.Clone(c.HashedPasswords), hp)
+	h.userPool.Store(username, c)
 	return nil
 }
 

--- a/server/authentication_handler.go
+++ b/server/authentication_handler.go
@@ -72,6 +72,41 @@ type Credential struct {
 	AuthPluginName  string
 }
 
+// HashedPassword pairs a stored-form password hash with its auth plugin and
+// guarantees that the pair has been validated for shape (see
+// validateHashedPassword) and that the bytes were defensively copied at
+// construction time. Construct it with NewHashedPassword; the zero value is
+// not usable.
+//
+// The point of the type is to let callers validate a (plugin, hash) pair once
+// — for example when loading credentials at startup — and then reuse the
+// resulting value, instead of revalidating on every AddUser call. See
+// Credential.HashedPasswords for the per-plugin byte format.
+type HashedPassword struct {
+	plugin string
+	data   []byte
+}
+
+// NewHashedPassword validates hash for the given auth plugin and returns a
+// HashedPassword wrapping a defensive copy of the bytes. authPluginName must
+// be one of the supported hash-bearing plugins (mysql_native_password,
+// caching_sha2_password, sha256_password); mysql_clear_password has no
+// hashed form and is rejected. See Credential.HashedPasswords for the
+// expected byte layout per plugin.
+func NewHashedPassword(authPluginName string, hash []byte) (HashedPassword, error) {
+	if err := validateHashedPassword(authPluginName, hash); err != nil {
+		return HashedPassword{}, err
+	}
+	return HashedPassword{plugin: authPluginName, data: slices.Clone(hash)}, nil
+}
+
+// Plugin returns the auth plugin name this hash was constructed for.
+func (h HashedPassword) Plugin() string { return h.plugin }
+
+// Bytes returns a copy of the stored hash bytes. The copy means callers can
+// safely mutate the returned slice without affecting the HashedPassword.
+func (h HashedPassword) Bytes() []byte { return slices.Clone(h.data) }
+
 // hashPassword computes the password hash for a given password using the credential's auth plugin.
 func (c Credential) hashPassword(password string) (string, error) {
 	if password == "" {
@@ -178,23 +213,29 @@ func (h *InMemoryAuthenticationHandler) AddUserWithHashedPassword(username strin
 	if len(optionalAuthPluginName) > 0 {
 		authPluginName = optionalAuthPluginName[0]
 	}
-
-	// validateHashedPassword's default case already rejects unknown
-	// plugins, and its AUTH_CLEAR_PASSWORD branch gives a clearer
-	// "use AddUser with the plaintext" message — no need for a
-	// separate isAuthMethodSupported gate here.
-	if err := validateHashedPassword(authPluginName, hash); err != nil {
+	hp, err := NewHashedPassword(authPluginName, hash)
+	if err != nil {
 		return err
 	}
-
-	// Defensive copy so a caller that reuses or mutates its backing slice
-	// can't change the stored credential out from under us.
-	stored := slices.Clone(hash)
-	h.userPool.Store(username, Credential{
-		HashedPasswords: [][]byte{stored},
-		AuthPluginName:  authPluginName,
-	})
+	h.AddUserHashed(username, hp)
 	return nil
+}
+
+// AddUserHashed registers username with a pre-validated HashedPassword.
+// Equivalent to AddUserWithHashedPassword but takes the already-validated
+// value from NewHashedPassword, which is convenient when the same hash is
+// being installed against multiple usernames or when callers want to keep
+// validation separate from registration.
+func (h *InMemoryAuthenticationHandler) AddUserHashed(username string, hp HashedPassword) {
+	// Defensive copy so a caller that constructed HashedPassword via
+	// NewHashedPassword (which already cloned the input) is still
+	// protected from later AddUserHashed calls accidentally aliasing
+	// the same backing array, and so HashedPassword.Bytes returning a
+	// fresh copy stays consistent with the credential storage model.
+	h.userPool.Store(username, Credential{
+		HashedPasswords: [][]byte{slices.Clone(hp.data)},
+		AuthPluginName:  hp.plugin,
+	})
 }
 
 // mysqlNativePasswordHashLen is the length of a native_password hash

--- a/server/authentication_handler.go
+++ b/server/authentication_handler.go
@@ -56,13 +56,16 @@ func NewInMemoryAuthenticationHandler(defaultAuthMethod ...string) *InMemoryAuth
 //   - mysql_native_password: the 20-byte SHA1(SHA1(plaintext)) value, i.e. what
 //     mysql.NativePasswordHash returns, or what mysql.DecodePasswordHex returns from MySQL's standard
 //     "*XXXX..." (41-char) hex form.
-//   - caching_sha2_password: the bytes of the standard "$A$<iter>$<salt>$<hash>" stored form, i.e.
-//     what auth.NewHashPassword(plaintext, AUTH_CACHING_SHA2_PASSWORD) returns. Note that this auth
-//     plugin's full-auth flow requires either TLS or a configured RSA key on the server (same
-//     constraint as plaintext Passwords). After the first successful full auth the server caches
-//     SHA256(SHA256(plaintext)) per user@host so subsequent connections can take the fast-auth path.
+//   - caching_sha2_password: the bytes of the standard "$A$<iter>$<salt><hash>" stored form (salt
+//     and hash are concatenated, with no '$' between them — see auth.NewHashPassword in
+//     pingcap/tidb). Note that this auth plugin's full-auth flow requires either TLS or a
+//     configured RSA key on the server, because the server must obtain the plaintext to verify it
+//     against the stored hash and to populate the cache. After the first successful full auth the
+//     server caches SHA256(SHA256(plaintext)) per user@host so subsequent connections can take the
+//     fast-auth path.
 //   - sha256_password: the bytes of the standard "$<iter>$<salt>$<hashHex>" stored form, i.e. what
-//     mysql.NewSha256PasswordHash returns. Same TLS/RSA requirement as caching_sha2_password.
+//     mysql.NewSha256PasswordHash returns. Same TLS-or-RSA requirement as caching_sha2_password,
+//     for the same reason.
 //
 // Both fields can be set on the same Credential: HashedPasswords is checked first (cheaper, no
 // hashing per connect), then Passwords.
@@ -152,6 +155,23 @@ func (c Credential) hasAnyCredential() bool {
 	return len(c.Passwords) > 0 || len(c.HashedPasswords) > 0
 }
 
+// cloneCredential returns a deep copy of c so that callers cannot mutate
+// the stored slices. Both Passwords and the per-entry HashedPasswords byte
+// slices are copied; AuthPluginName is a string and is already immutable.
+func cloneCredential(c Credential) Credential {
+	out := Credential{AuthPluginName: c.AuthPluginName}
+	if c.Passwords != nil {
+		out.Passwords = slices.Clone(c.Passwords)
+	}
+	if c.HashedPasswords != nil {
+		out.HashedPasswords = make([][]byte, len(c.HashedPasswords))
+		for i, h := range c.HashedPasswords {
+			out.HashedPasswords[i] = slices.Clone(h)
+		}
+	}
+	return out
+}
+
 // InMemoryAuthenticationHandler implements AuthenticationHandler with in-memory credential storage.
 type InMemoryAuthenticationHandler struct {
 	userPool          sync.Map // username -> Credential
@@ -172,7 +192,11 @@ func (h *InMemoryAuthenticationHandler) GetCredential(username string) (credenti
 	if !valid {
 		return Credential{}, true, errors.Errorf("invalid credential")
 	}
-	return c, true, nil
+	// Defensive deep copy: Credential carries []string and [][]byte fields
+	// whose backing arrays would otherwise be shared with the stored value.
+	// A caller mutating the returned slices (intentionally or by accident)
+	// must not corrupt the credential held in the user pool.
+	return cloneCredential(c), true, nil
 }
 
 func (h *InMemoryAuthenticationHandler) AddUser(username, password string, optionalAuthPluginName ...string) error {
@@ -200,7 +224,7 @@ func (h *InMemoryAuthenticationHandler) AddUser(username, password string, optio
 //
 //   - mysql_native_password: the 20-byte SHA1(SHA1(plaintext)) value. Use
 //     mysql.DecodePasswordHex to strip the "*" and decode MySQL's 41-char hex form.
-//   - caching_sha2_password: the bytes of "$A$<iter>$<salt>$<hash>".
+//   - caching_sha2_password: the bytes of "$A$<iter>$<salt><hash>".
 //   - sha256_password: the bytes of "$<iter>$<salt>$<hashHex>".
 //
 // The hash is rejected up front if it doesn't match the expected shape for
@@ -209,12 +233,14 @@ func (h *InMemoryAuthenticationHandler) AddUser(username, password string, optio
 // defaults to the handler's default auth method.
 //
 // caching_sha2_password and sha256_password additionally require the server
-// to be configured with TLS or an RSA key, since the full-auth flow sends
-// the plaintext on the wire — same constraint that already applies to
-// plaintext Passwords with these plugins.
+// to be configured with TLS or an RSA key, because the full-auth flow needs
+// the plaintext on the server side — both to verify against the stored hash
+// and (for caching_sha2) to populate the cache. Same constraint that
+// already applies to plaintext Passwords with these plugins.
 //
 // Example:
 //
+//	handler := NewInMemoryAuthenticationHandler(mysql.AUTH_NATIVE_PASSWORD)
 //	bytes, _ := mysql.DecodePasswordHex("*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9")
 //	handler.AddUserWithHashedPassword("alice", bytes)
 func (h *InMemoryAuthenticationHandler) AddUserWithHashedPassword(username string, hash []byte, optionalAuthPluginName ...string) error {
@@ -226,8 +252,7 @@ func (h *InMemoryAuthenticationHandler) AddUserWithHashedPassword(username strin
 	if err != nil {
 		return err
 	}
-	h.AddUserHashed(username, hp)
-	return nil
+	return h.AddUserHashed(username, hp)
 }
 
 // AddUserHashed registers username with a pre-validated HashedPassword.
@@ -235,7 +260,17 @@ func (h *InMemoryAuthenticationHandler) AddUserWithHashedPassword(username strin
 // value from NewHashedPassword, which is convenient when the same hash is
 // being installed against multiple usernames or when callers want to keep
 // validation separate from registration.
-func (h *InMemoryAuthenticationHandler) AddUserHashed(username string, hp HashedPassword) {
+//
+// The HashedPassword zero value is rejected — its plugin name is empty and
+// its data is nil, which would otherwise register a user that is reachable
+// (`hasAnyCredential` returns true on `[][]byte{nil}`) but can never
+// authenticate. To stay defensive against any in-place mutation between
+// NewHashedPassword and this call, AddUserHashed re-runs
+// validateHashedPassword on the wrapped (plugin, data) pair.
+func (h *InMemoryAuthenticationHandler) AddUserHashed(username string, hp HashedPassword) error {
+	if err := validateHashedPassword(hp.plugin, hp.data); err != nil {
+		return err
+	}
 	// Defensive copy so a caller that constructed HashedPassword via
 	// NewHashedPassword (which already cloned the input) is still
 	// protected from later AddUserHashed calls accidentally aliasing
@@ -245,11 +280,32 @@ func (h *InMemoryAuthenticationHandler) AddUserHashed(username string, hp Hashed
 		HashedPasswords: [][]byte{slices.Clone(hp.data)},
 		AuthPluginName:  hp.plugin,
 	})
+	return nil
 }
 
-// mysqlNativePasswordHashLen is the length of a native_password hash
-// (sha1(sha1(plaintext))) in bytes.
-const mysqlNativePasswordHashLen = 20
+const (
+	// mysqlNativePasswordHashLen is the length of a native_password hash
+	// (sha1(sha1(plaintext))) in bytes.
+	mysqlNativePasswordHashLen = 20
+	// cachingSha2SaltLen is auth.SALT_LENGTH (the constant is unexported
+	// in pingcap/tidb's parser/auth package). The salt is 20 bytes for
+	// caching_sha2_password regardless of plaintext length.
+	cachingSha2SaltLen = 20
+	// cachingSha2HashLen is the length of the hash portion appended after
+	// the salt in the final $A$<iter>$<salt><hash> segment, derived from
+	// the eleven b64From24bit calls in auth.hashCrypt (10 × 4 chars + 1
+	// × 3 chars).
+	cachingSha2HashLen = 43
+	// sha256HashHexLen is the length of the hash segment in
+	// $<iter>$<salt>$<hashHex> for sha256_password — sha256 produces 32
+	// bytes and hex.EncodeToString doubles that.
+	sha256HashHexLen = 64
+)
+
+// isHexDigit reports whether b is one of [0-9a-fA-F].
+func isHexDigit(b byte) bool {
+	return (b >= '0' && b <= '9') || (b >= 'a' && b <= 'f') || (b >= 'A' && b <= 'F')
+}
 
 // validateHashedPassword does a lightweight shape check on a stored-hash
 // byte string for the given auth plugin. It does NOT verify cryptographic
@@ -271,11 +327,12 @@ func validateHashedPassword(authPluginName string, hash []byte) error {
 		// Standard form is "$A$<iter-hex>$<salt><hash>" with the salt
 		// (auth.SALT_LENGTH = 20 bytes) and hash (43 bytes) concatenated
 		// in the final segment — see auth.NewHashPassword and
-		// auth.CheckHashingPassword. We require a 4-part split with
-		// hashType "A" and a final segment strictly longer than the salt
-		// so the hash bytes are present (CheckHashingPassword would panic
-		// otherwise on `parts[3][:SALT_LENGTH]`).
-		const cachingSha2SaltLen = 20 // = auth.SALT_LENGTH (unexported constant value)
+		// auth.CheckHashingPassword in pingcap/tidb. We require a 4-part
+		// split with hashType "A", a non-empty hex iteration count, and
+		// a final segment of exactly salt+hash bytes. The exact-length
+		// check both prevents the upstream panic on parts[3][:SALT_LENGTH]
+		// and ensures we don't store hashes the verifier would always
+		// reject.
 		parts := bytes.Split(hash, []byte("$"))
 		if len(parts) != 4 || len(parts[0]) != 0 {
 			return errors.Errorf("invalid hashed password for %s: expected $A$<iter>$<salt><hash> form", authPluginName)
@@ -286,13 +343,22 @@ func validateHashedPassword(authPluginName string, hash []byte) error {
 		if len(parts[2]) == 0 {
 			return errors.Errorf("invalid hashed password for %s: missing iteration count", authPluginName)
 		}
-		if len(parts[3]) <= cachingSha2SaltLen {
-			return errors.Errorf("invalid hashed password for %s: final segment must contain salt and hash (got %d bytes, need >%d)", authPluginName, len(parts[3]), cachingSha2SaltLen)
+		for _, b := range parts[2] {
+			if !isHexDigit(b) {
+				return errors.Errorf("invalid hashed password for %s: iteration count must be hex", authPluginName)
+			}
+		}
+		if want, got := cachingSha2SaltLen+cachingSha2HashLen, len(parts[3]); got != want {
+			return errors.Errorf("invalid hashed password for %s: final segment must be exactly %d bytes (salt+hash), got %d", authPluginName, want, got)
 		}
 		return nil
 	case mysql.AUTH_SHA256_PASSWORD:
 		// Standard form is "$<iter-decimal>$<salt:mysql.SALT_LENGTH=16>$<hashHex:64>"
 		// — see mysql.NewSha256PasswordHash and mysql.Check256HashingPassword.
+		// We require an exact-length salt and a 64-char hex digest because
+		// that is what the verifier produces when reconstructing for the
+		// equality check; any other shape is a stored-format mismatch and
+		// would never authenticate, so it's better to reject up front.
 		parts := bytes.Split(hash, []byte("$"))
 		if len(parts) != 4 || len(parts[0]) != 0 {
 			return errors.Errorf("invalid hashed password for %s: expected $<iter>$<salt>$<hashHex> form", authPluginName)
@@ -305,11 +371,16 @@ func validateHashedPassword(authPluginName string, hash []byte) error {
 				return errors.Errorf("invalid hashed password for %s: iteration count must be decimal", authPluginName)
 			}
 		}
-		if len(parts[2]) < mysql.SALT_LENGTH {
-			return errors.Errorf("invalid hashed password for %s: salt must be at least %d bytes (got %d)", authPluginName, mysql.SALT_LENGTH, len(parts[2]))
+		if len(parts[2]) != mysql.SALT_LENGTH {
+			return errors.Errorf("invalid hashed password for %s: salt must be exactly %d bytes (got %d)", authPluginName, mysql.SALT_LENGTH, len(parts[2]))
 		}
-		if len(parts[3]) == 0 {
-			return errors.Errorf("invalid hashed password for %s: missing hash segment", authPluginName)
+		if len(parts[3]) != sha256HashHexLen {
+			return errors.Errorf("invalid hashed password for %s: hash segment must be exactly %d hex chars (got %d)", authPluginName, sha256HashHexLen, len(parts[3]))
+		}
+		for _, b := range parts[3] {
+			if !isHexDigit(b) {
+				return errors.Errorf("invalid hashed password for %s: hash segment must be hex", authPluginName)
+			}
 		}
 		return nil
 	case mysql.AUTH_CLEAR_PASSWORD:

--- a/server/authentication_handler.go
+++ b/server/authentication_handler.go
@@ -66,6 +66,15 @@ func NewInMemoryAuthenticationHandler(defaultAuthMethod ...string) *InMemoryAuth
 //
 // Both fields can be set on the same Credential: HashedPasswords is checked first (cheaper, no
 // hashing per connect), then Passwords.
+//
+// Hashes installed via AddUserWithHashedPassword / NewHashedPassword are
+// shape-checked up front. Constructing a Credential directly and inserting
+// arbitrary bytes into HashedPasswords bypasses that check: a malformed
+// caching_sha2_password value (e.g. a final "$A$<iter>$<salt><hash>"
+// segment shorter than the 20-byte salt) can panic inside the upstream
+// tidb verifier auth.CheckHashingPassword. Callers loading hashes from an
+// untrusted source should go through the documented helpers, or run their
+// own validation before assigning to this field.
 type Credential struct {
 	Passwords       []string
 	HashedPasswords [][]byte

--- a/server/authentication_handler.go
+++ b/server/authentication_handler.go
@@ -179,9 +179,10 @@ func (h *InMemoryAuthenticationHandler) AddUserWithHashedPassword(username strin
 		authPluginName = optionalAuthPluginName[0]
 	}
 
-	if !isAuthMethodSupported(authPluginName) {
-		return errors.Errorf("unknown authentication plugin name '%s'", authPluginName)
-	}
+	// validateHashedPassword's default case already rejects unknown
+	// plugins, and its AUTH_CLEAR_PASSWORD branch gives a clearer
+	// "use AddUser with the plaintext" message — no need for a
+	// separate isAuthMethodSupported gate here.
 	if err := validateHashedPassword(authPluginName, hash); err != nil {
 		return err
 	}

--- a/server/authentication_handler_test.go
+++ b/server/authentication_handler_test.go
@@ -176,6 +176,12 @@ func TestAddUserWithHashedPasswordRejectsClearPassword(t *testing.T) {
 // shape validation: each plugin has a distinct stored-hash format, and
 // passing a value that obviously doesn't match should fail at AddUser
 // time rather than producing a user that can never authenticate.
+//
+// Several caching_sha2 cases below are specifically chosen to be the
+// "panic-shaped" inputs that would trip auth.CheckHashingPassword in
+// upstream tidb (e.g. parts[3][:SALT_LENGTH] on a too-short final
+// segment). validateHashedPassword's <= cachingSha2SaltLen check is what
+// keeps that panic from being reachable through the documented API.
 func TestAddUserWithHashedPasswordRejectsBadFormat(t *testing.T) {
 	handler := NewInMemoryAuthenticationHandler(mysql.AUTH_NATIVE_PASSWORD)
 
@@ -196,7 +202,19 @@ func TestAddUserWithHashedPasswordRejectsBadFormat(t *testing.T) {
 		{"caching_sha2: empty", mysql.AUTH_CACHING_SHA2_PASSWORD, []byte{}},
 		{"caching_sha2: missing $A$ prefix", mysql.AUTH_CACHING_SHA2_PASSWORD, []byte("not-a-hash")},
 		{"caching_sha2: wrong hash type 'B'", mysql.AUTH_CACHING_SHA2_PASSWORD, []byte("$B$005$saltsaltsaltsaltsalt$hashhashhashhashhashhashhashhashhashhash43")},
-		{"caching_sha2: not enough $-parts", mysql.AUTH_CACHING_SHA2_PASSWORD, []byte("$A$005$saltsaltsaltsaltsalt")},
+
+		// 4-part split, type 'A', iter present, but parts[3] is exactly
+		// SALT_LENGTH (20) bytes — i.e. salt only, no hash tail. Without
+		// the <= SALT_LENGTH check, auth.CheckHashingPassword would slice
+		// parts[3][:SALT_LENGTH] into the salt and then operate on an
+		// empty hash, panicking in upstream tidb. This case pins the
+		// "panic shape" dveeden flagged in PR review.
+		{"caching_sha2: parts[3] exactly SALT_LENGTH (panic shape)", mysql.AUTH_CACHING_SHA2_PASSWORD, []byte("$A$005$saltsaltsaltsaltsalt")},
+		// 4-part split, type 'A', iter present, but parts[3] is shorter
+		// than SALT_LENGTH (1 byte). Same family as the panic shape
+		// above; included separately to make the "way too short" case
+		// unmistakable.
+		{"caching_sha2: parts[3] shorter than SALT_LENGTH", mysql.AUTH_CACHING_SHA2_PASSWORD, []byte("$A$005$x")},
 
 		// sha256_password: "$<iter>$<salt>$<hashHex>" — iterations must be decimal.
 		{"sha256: empty", mysql.AUTH_SHA256_PASSWORD, []byte{}},

--- a/server/authentication_handler_test.go
+++ b/server/authentication_handler_test.go
@@ -160,11 +160,54 @@ func TestAddUserWithHashedPasswordRejectsUnsupportedPlugin(t *testing.T) {
 	require.Contains(t, err.Error(), "AddUserWithHashedPassword does not yet support")
 }
 
-func TestAddUserWithHashedPasswordRejectsEmptyHash(t *testing.T) {
+// TestAddUserWithHashedPasswordRejectsWrongHashLength makes sure that a
+// caller passing anything other than the exact 20 bytes a native_password
+// hash takes (e.g. an empty slice, a string accidentally cast to []byte
+// without DecodePasswordHex, or a truncated value) fails up front rather
+// than registering a user that can never authenticate.
+func TestAddUserWithHashedPasswordRejectsWrongHashLength(t *testing.T) {
 	handler := NewInMemoryAuthenticationHandler(mysql.AUTH_NATIVE_PASSWORD)
-	err := handler.AddUserWithHashedPassword("bob", nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "must not be empty")
+
+	cases := []struct {
+		name string
+		hash []byte
+	}{
+		{"nil", nil},
+		{"empty", []byte{}},
+		{"too short (19 bytes)", make([]byte, 19)},
+		{"too long (21 bytes)", make([]byte, 21)},
+		{"hex string mistakenly passed as bytes", []byte("*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := handler.AddUserWithHashedPassword("bob", tc.hash)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "expected 20 bytes")
+		})
+	}
+}
+
+// TestAddUserWithHashedPasswordCopiesSlice verifies the helper takes a
+// defensive copy of the hash, so a caller that reuses or mutates its
+// backing slice can't change the stored credential afterwards.
+func TestAddUserWithHashedPasswordCopiesSlice(t *testing.T) {
+	plaintext := "s3cr3t"
+	hash := mysql.NativePasswordHash([]byte(plaintext))
+
+	handler := NewInMemoryAuthenticationHandler(mysql.AUTH_NATIVE_PASSWORD)
+	require.NoError(t, handler.AddUserWithHashedPassword("alice", hash))
+
+	// Mutate the caller's slice. The stored credential must not change.
+	for i := range hash {
+		hash[i] = 0xff
+	}
+
+	cred, found, err := handler.GetCredential("alice")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, cred.HashedPasswords, 1)
+	require.NotEqual(t, hash, cred.HashedPasswords[0])
+	require.Equal(t, mysql.NativePasswordHash([]byte(plaintext)), cred.HashedPasswords[0])
 }
 
 func TestOnAuthFailureCalled(t *testing.T) {

--- a/server/authentication_handler_test.go
+++ b/server/authentication_handler_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"bytes"
 	"database/sql"
+	"log/slog"
 	"net"
 	"sync/atomic"
 	"testing"
@@ -621,42 +623,69 @@ func TestAddUserWithHashedPassword_Sha256Password(t *testing.T) {
 	require.Error(t, dbBad.Ping())
 }
 
-// TestSafeVerifierWrappersRecover pins the Finding #2 invariant: the
-// recover-safe wrappers around the upstream verifier calls must convert
-// any slice-out-of-bounds panic on a malformed stored hash into a
-// boring (false, error) return, so a Credential constructed directly
-// (bypassing validateHashedPassword) cannot kill the connection
-// goroutine.
-func TestSafeVerifierWrappersRecover(t *testing.T) {
-	t.Run("safeSha256Check on parts[2] shorter than SALT_LENGTH", func(t *testing.T) {
-		// 4 $-segments, decimal iterations, but salt is 1 byte so the
-		// upstream verifier's parts[2][:SALT_LENGTH] would slice past the
-		// end and panic.
-		bad := []byte("$5$x$" + // iter=5, salt="x", hash=""
-			"deadbeef")
-		match, err := safeSha256Check(bad, "anything")
-		require.False(t, match)
-		require.Error(t, err)
-	})
-	t.Run("safeCachingSha2Check on parts[3] shorter than SALT_LENGTH", func(t *testing.T) {
-		// $A$, hex iter, then a final segment well below SALT_LENGTH.
-		bad := []byte("$A$005$x")
-		match, err := safeCachingSha2Check(bad, "anything", mysql.AUTH_CACHING_SHA2_PASSWORD)
-		require.False(t, match)
-		require.Error(t, err)
-	})
-	t.Run("safeNativeCompare on undersized hash", func(t *testing.T) {
-		// Native verifier is permissive about input shapes (it doesn't
-		// fixed-length-slice), so this case is mostly here to document
-		// that the wrapper exists and never panics regardless of input.
-		// An empty hash is enough to demonstrate "no panic, no match".
-		match, err := safeNativeCompare([]byte("client-data"), nil, make([]byte, 20))
-		require.False(t, match)
-		// err may be nil if the verifier itself doesn't panic on this
-		// shape; the contract is "no panic", not "always errors".
-		_ = err
-	})
+// TestServerLoggerWiring verifies SetLogger replaces the slog.Logger
+// used by the auth code paths. We trigger the sha256_password
+// hash-compare error log by stuffing a malformed HashedPassword
+// directly into a Credential (bypassing NewHashedPassword's validation,
+// which is the only realistic way that error path gets exercised in
+// practice) and assert the configured logger captures the message.
+func TestServerLoggerWiring(t *testing.T) {
+	// Custom handler that hands back a Credential carrying a
+	// malformed sha256 hash (5 $-segments). NewHashedPassword would
+	// reject this, but the field is exported so a buggy caller could
+	// produce it — and we want the resulting log to land on the
+	// configured logger, not stdout.
+	bad := HashedPassword{plugin: mysql.AUTH_SHA256_PASSWORD, data: []byte("$$$$$$nope")}
+	handler := &fixedCredentialHandler{
+		cred: Credential{
+			HashedPasswords: []HashedPassword{bad},
+			AuthPluginName:  mysql.AUTH_SHA256_PASSWORD,
+		},
+	}
+
+	var buf bytes.Buffer
+	srv := NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_SHA256_PASSWORD, test_keys.RSAKey(), tlsConf)
+	srv.SetLogger(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l.Close()
+
+	go func() {
+		conn, acceptErr := l.Accept()
+		if acceptErr != nil {
+			return
+		}
+		co, _ := srv.NewCustomizedConn(conn, handler, &EmptyHandler{})
+		if co != nil {
+			for co.HandleCommand() == nil {
+			}
+		}
+	}()
+
+	db, err := sql.Open("mysql", "alice:wrongpass@tcp("+l.Addr().String()+")/test?tls=skip-verify")
+	require.NoError(t, err)
+	defer db.Close()
+	db.SetConnMaxLifetime(time.Second)
+	_ = db.Ping() // expected to fail; we only care about the log line
+
+	require.Contains(t, buf.String(), "sha256_password hash compare error",
+		"configured logger should receive auth diagnostic; got: %q", buf.String())
+	require.Contains(t, buf.String(), "user=alice")
 }
+
+// fixedCredentialHandler is a test-only AuthenticationHandler that
+// returns the same Credential for any username. Used to inject
+// hand-crafted Credentials into the auth flow without going through
+// the public AddUser* helpers (which would validate the hash and
+// reject the malformed entry needed by TestServerLoggerWiring).
+type fixedCredentialHandler struct{ cred Credential }
+
+func (h *fixedCredentialHandler) GetCredential(string) (Credential, bool, error) {
+	return h.cred, true, nil
+}
+func (h *fixedCredentialHandler) OnAuthSuccess(*Conn) error  { return nil }
+func (h *fixedCredentialHandler) OnAuthFailure(*Conn, error) {}
 
 func TestOnAuthFailureCalled(t *testing.T) {
 	handler := &hookTrackingAuthenticationHandler{

--- a/server/authentication_handler_test.go
+++ b/server/authentication_handler_test.go
@@ -9,7 +9,9 @@ import (
 
 	_ "github.com/go-mysql-org/go-mysql/driver"
 	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/test_util/test_keys"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/stretchr/testify/require"
 )
 
@@ -148,41 +150,64 @@ func TestAddUserWithHashedPassword(t *testing.T) {
 	require.Error(t, dbBad.Ping())
 }
 
-// TestAddUserWithHashedPasswordRejectsUnsupportedPlugin confirms the helper
-// fails up front for plugins that don't yet consume HashedPasswords, rather
-// than silently accepting an unauthenticatable user.
-func TestAddUserWithHashedPasswordRejectsUnsupportedPlugin(t *testing.T) {
+// TestAddUserWithHashedPasswordRejectsUnknownPlugin confirms the helper
+// fails up front for an unknown auth plugin name (typo, deprecated, etc.)
+// rather than registering an unauthenticatable user.
+func TestAddUserWithHashedPasswordRejectsUnknownPlugin(t *testing.T) {
 	handler := NewInMemoryAuthenticationHandler(mysql.AUTH_NATIVE_PASSWORD)
 	someHash := mysql.NativePasswordHash([]byte("anything"))
 
-	err := handler.AddUserWithHashedPassword("bob", someHash, mysql.AUTH_CACHING_SHA2_PASSWORD)
+	err := handler.AddUserWithHashedPassword("bob", someHash, "made_up_auth_plugin")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "AddUserWithHashedPassword does not yet support")
+	require.Contains(t, err.Error(), "unknown authentication plugin")
 }
 
-// TestAddUserWithHashedPasswordRejectsWrongHashLength makes sure that a
-// caller passing anything other than the exact 20 bytes a native_password
-// hash takes (e.g. an empty slice, a string accidentally cast to []byte
-// without DecodePasswordHex, or a truncated value) fails up front rather
-// than registering a user that can never authenticate.
-func TestAddUserWithHashedPasswordRejectsWrongHashLength(t *testing.T) {
+// TestAddUserWithHashedPasswordRejectsClearPassword confirms that
+// mysql_clear_password — which has no meaningful hashed form — is
+// directed to the plaintext API instead.
+func TestAddUserWithHashedPasswordRejectsClearPassword(t *testing.T) {
+	handler := NewInMemoryAuthenticationHandler(mysql.AUTH_NATIVE_PASSWORD)
+	err := handler.AddUserWithHashedPassword("bob", []byte("anything"), mysql.AUTH_CLEAR_PASSWORD)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "use AddUser with the plaintext")
+}
+
+// TestAddUserWithHashedPasswordRejectsBadFormat covers the per-plugin
+// shape validation: each plugin has a distinct stored-hash format, and
+// passing a value that obviously doesn't match should fail at AddUser
+// time rather than producing a user that can never authenticate.
+func TestAddUserWithHashedPasswordRejectsBadFormat(t *testing.T) {
 	handler := NewInMemoryAuthenticationHandler(mysql.AUTH_NATIVE_PASSWORD)
 
-	cases := []struct {
-		name string
-		hash []byte
-	}{
-		{"nil", nil},
-		{"empty", []byte{}},
-		{"too short (19 bytes)", make([]byte, 19)},
-		{"too long (21 bytes)", make([]byte, 21)},
-		{"hex string mistakenly passed as bytes", []byte("*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9")},
+	type tc struct {
+		name   string
+		plugin string
+		hash   []byte
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := handler.AddUserWithHashedPassword("bob", tc.hash)
+	cases := []tc{
+		// mysql_native_password: must be exactly 20 bytes (SHA1×2).
+		{"native: nil", mysql.AUTH_NATIVE_PASSWORD, nil},
+		{"native: empty", mysql.AUTH_NATIVE_PASSWORD, []byte{}},
+		{"native: 19 bytes", mysql.AUTH_NATIVE_PASSWORD, make([]byte, 19)},
+		{"native: 21 bytes", mysql.AUTH_NATIVE_PASSWORD, make([]byte, 21)},
+		{"native: hex string passed as bytes", mysql.AUTH_NATIVE_PASSWORD, []byte("*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9")},
+
+		// caching_sha2_password: "$A$<iter>$<salt>$<hash>" — wrong type or shape rejected.
+		{"caching_sha2: empty", mysql.AUTH_CACHING_SHA2_PASSWORD, []byte{}},
+		{"caching_sha2: missing $A$ prefix", mysql.AUTH_CACHING_SHA2_PASSWORD, []byte("not-a-hash")},
+		{"caching_sha2: wrong hash type 'B'", mysql.AUTH_CACHING_SHA2_PASSWORD, []byte("$B$005$saltsaltsaltsaltsalt$hashhashhashhashhashhashhashhashhashhash43")},
+		{"caching_sha2: not enough $-parts", mysql.AUTH_CACHING_SHA2_PASSWORD, []byte("$A$005$saltsaltsaltsaltsalt")},
+
+		// sha256_password: "$<iter>$<salt>$<hashHex>" — iterations must be decimal.
+		{"sha256: empty", mysql.AUTH_SHA256_PASSWORD, []byte{}},
+		{"sha256: not a hash", mysql.AUTH_SHA256_PASSWORD, []byte("plain-string")},
+		{"sha256: non-numeric iterations", mysql.AUTH_SHA256_PASSWORD, []byte("$A$saltsaltsaltsaltsalt$hashhashhashhashhashhashhashhash")},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := handler.AddUserWithHashedPassword("bob", c.hash, c.plugin)
 			require.Error(t, err)
-			require.Contains(t, err.Error(), "expected 20 bytes")
+			require.Contains(t, err.Error(), "invalid hashed password")
 		})
 	}
 }
@@ -208,6 +233,105 @@ func TestAddUserWithHashedPasswordCopiesSlice(t *testing.T) {
 	require.Len(t, cred.HashedPasswords, 1)
 	require.NotEqual(t, hash, cred.HashedPasswords[0])
 	require.Equal(t, mysql.NativePasswordHash([]byte(plaintext)), cred.HashedPasswords[0])
+}
+
+// TestAddUserWithHashedPassword_CachingSha2 runs the same end-to-end
+// shape as TestAddUserWithHashedPassword, but for caching_sha2_password.
+// We use auth.NewHashPassword to produce the exact stored form a real
+// MySQL server would have at rest, so this also documents the format
+// callers should pass in. Because caching_sha2's full-auth flow sends
+// the plaintext on the wire, the server must be configured with TLS
+// (or an RSA key); we use the same tlsConf as the other server tests.
+func TestAddUserWithHashedPassword_CachingSha2(t *testing.T) {
+	const plaintext = "s3cr3t"
+	stored := []byte(auth.NewHashPassword(plaintext, mysql.AUTH_CACHING_SHA2_PASSWORD))
+
+	handler := NewInMemoryAuthenticationHandler(mysql.AUTH_CACHING_SHA2_PASSWORD)
+	require.NoError(t, handler.AddUserWithHashedPassword("alice", stored, mysql.AUTH_CACHING_SHA2_PASSWORD))
+
+	srv := NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_CACHING_SHA2_PASSWORD, test_keys.RSAKey(), tlsConf)
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l.Close()
+
+	go func() {
+		for {
+			conn, acceptErr := l.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go func(c net.Conn) {
+				co, _ := srv.NewCustomizedConn(c, handler, &EmptyHandler{})
+				if co != nil {
+					for co.HandleCommand() == nil {
+					}
+				}
+			}(conn)
+		}
+	}()
+
+	// Correct plaintext under TLS → success. Two pings exercise both the
+	// full-auth path (cache miss) and the fast-auth path (cache hit).
+	dbOK, err := sql.Open("mysql", "alice:"+plaintext+"@tcp("+l.Addr().String()+")/test?tls=skip-verify")
+	require.NoError(t, err)
+	defer dbOK.Close()
+	dbOK.SetConnMaxLifetime(time.Second)
+	require.NoError(t, dbOK.Ping())
+	require.NoError(t, dbOK.Ping())
+
+	// Wrong plaintext → access denied.
+	dbBad, err := sql.Open("mysql", "alice:wrongpass@tcp("+l.Addr().String()+")/test?tls=skip-verify")
+	require.NoError(t, err)
+	defer dbBad.Close()
+	dbBad.SetConnMaxLifetime(time.Second)
+	require.Error(t, dbBad.Ping())
+}
+
+// TestAddUserWithHashedPassword_Sha256Password mirrors the test above for
+// sha256_password. Same TLS requirement; no cache layer.
+func TestAddUserWithHashedPassword_Sha256Password(t *testing.T) {
+	const plaintext = "s3cr3t"
+	storedString, err := mysql.NewSha256PasswordHash(plaintext)
+	require.NoError(t, err)
+	stored := []byte(storedString)
+
+	handler := NewInMemoryAuthenticationHandler(mysql.AUTH_SHA256_PASSWORD)
+	require.NoError(t, handler.AddUserWithHashedPassword("alice", stored, mysql.AUTH_SHA256_PASSWORD))
+
+	srv := NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_SHA256_PASSWORD, test_keys.RSAKey(), tlsConf)
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l.Close()
+
+	go func() {
+		for {
+			conn, acceptErr := l.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go func(c net.Conn) {
+				co, _ := srv.NewCustomizedConn(c, handler, &EmptyHandler{})
+				if co != nil {
+					for co.HandleCommand() == nil {
+					}
+				}
+			}(conn)
+		}
+	}()
+
+	dbOK, err := sql.Open("mysql", "alice:"+plaintext+"@tcp("+l.Addr().String()+")/test?tls=skip-verify")
+	require.NoError(t, err)
+	defer dbOK.Close()
+	dbOK.SetConnMaxLifetime(time.Second)
+	require.NoError(t, dbOK.Ping())
+
+	dbBad, err := sql.Open("mysql", "alice:wrongpass@tcp("+l.Addr().String()+")/test?tls=skip-verify")
+	require.NoError(t, err)
+	defer dbBad.Close()
+	dbBad.SetConnMaxLifetime(time.Second)
+	require.Error(t, dbBad.Ping())
 }
 
 func TestOnAuthFailureCalled(t *testing.T) {

--- a/server/authentication_handler_test.go
+++ b/server/authentication_handler_test.go
@@ -92,6 +92,81 @@ func TestOnAuthSuccessCanReject(t *testing.T) {
 	require.Equal(t, int32(1), handler.onSuccessCalled.Load())
 }
 
+// TestAddUserWithHashedPassword verifies the in-memory handler accepts a
+// pre-computed mysql_native_password hash, that a client supplying the
+// corresponding plaintext successfully authenticates, and that supplying a
+// different plaintext fails — without the handler ever seeing the plaintext.
+func TestAddUserWithHashedPassword(t *testing.T) {
+	const plaintext = "s3cr3t"
+	hash := mysql.NativePasswordHash([]byte(plaintext))
+
+	handler := NewInMemoryAuthenticationHandler(mysql.AUTH_NATIVE_PASSWORD)
+	require.NoError(t, handler.AddUserWithHashedPassword("alice", hash))
+
+	// Round-trip: callers usually have the standard "*XXXX..." 41-char form
+	// (e.g. from MySQL's mysql.user table or ProxySQL config). DecodePasswordHex
+	// strips the leading '*' and returns the same 20 bytes.
+	hexForm := mysql.EncodePasswordHex(hash)
+	decoded, err := mysql.DecodePasswordHex(hexForm)
+	require.NoError(t, err)
+	require.Equal(t, hash, decoded)
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l.Close()
+
+	go func() {
+		for {
+			conn, acceptErr := l.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go func(c net.Conn) {
+				co, _ := NewDefaultServer().NewCustomizedConn(c, handler, &EmptyHandler{})
+				if co != nil {
+					for co.HandleCommand() == nil {
+					}
+				}
+			}(conn)
+		}
+	}()
+
+	// Correct plaintext → server hashes the client's challenge response
+	// and matches it against the stored HashedPasswords entry. The handler
+	// never knows the plaintext.
+	dbOK, err := sql.Open("mysql", "alice:"+plaintext+"@tcp("+l.Addr().String()+")/test")
+	require.NoError(t, err)
+	defer dbOK.Close()
+	dbOK.SetConnMaxLifetime(time.Second)
+	require.NoError(t, dbOK.Ping())
+
+	// Wrong plaintext → access denied.
+	dbBad, err := sql.Open("mysql", "alice:wrongpass@tcp("+l.Addr().String()+")/test")
+	require.NoError(t, err)
+	defer dbBad.Close()
+	dbBad.SetConnMaxLifetime(time.Second)
+	require.Error(t, dbBad.Ping())
+}
+
+// TestAddUserWithHashedPasswordRejectsUnsupportedPlugin confirms the helper
+// fails up front for plugins that don't yet consume HashedPasswords, rather
+// than silently accepting an unauthenticatable user.
+func TestAddUserWithHashedPasswordRejectsUnsupportedPlugin(t *testing.T) {
+	handler := NewInMemoryAuthenticationHandler(mysql.AUTH_NATIVE_PASSWORD)
+	someHash := mysql.NativePasswordHash([]byte("anything"))
+
+	err := handler.AddUserWithHashedPassword("bob", someHash, mysql.AUTH_CACHING_SHA2_PASSWORD)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "AddUserWithHashedPassword does not yet support")
+}
+
+func TestAddUserWithHashedPasswordRejectsEmptyHash(t *testing.T) {
+	handler := NewInMemoryAuthenticationHandler(mysql.AUTH_NATIVE_PASSWORD)
+	err := handler.AddUserWithHashedPassword("bob", nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must not be empty")
+}
+
 func TestOnAuthFailureCalled(t *testing.T) {
 	handler := &hookTrackingAuthenticationHandler{
 		InMemoryAuthenticationHandler: NewInMemoryAuthenticationHandler(mysql.AUTH_NATIVE_PASSWORD),

--- a/server/authentication_handler_test.go
+++ b/server/authentication_handler_test.go
@@ -235,6 +235,91 @@ func TestAddUserWithHashedPasswordCopiesSlice(t *testing.T) {
 	require.Equal(t, mysql.NativePasswordHash([]byte(plaintext)), cred.HashedPasswords[0])
 }
 
+// TestNewHashedPassword covers the construction-time validation and the
+// defensive copy of the input hash bytes. These are the two guarantees the
+// type promises beyond a raw (plugin, []byte) pair.
+func TestNewHashedPassword(t *testing.T) {
+	t.Run("native_password roundtrip", func(t *testing.T) {
+		hash := mysql.NativePasswordHash([]byte("s3cr3t"))
+		hp, err := NewHashedPassword(mysql.AUTH_NATIVE_PASSWORD, hash)
+		require.NoError(t, err)
+		require.Equal(t, mysql.AUTH_NATIVE_PASSWORD, hp.Plugin())
+		require.Equal(t, hash, hp.Bytes())
+	})
+
+	t.Run("input slice is copied", func(t *testing.T) {
+		hash := mysql.NativePasswordHash([]byte("s3cr3t"))
+		original := append([]byte(nil), hash...)
+		hp, err := NewHashedPassword(mysql.AUTH_NATIVE_PASSWORD, hash)
+		require.NoError(t, err)
+		// Mutate the caller's slice; the wrapped value must not change.
+		for i := range hash {
+			hash[i] = 0xff
+		}
+		require.Equal(t, original, hp.Bytes())
+	})
+
+	t.Run("Bytes returns a copy", func(t *testing.T) {
+		hash := mysql.NativePasswordHash([]byte("s3cr3t"))
+		hp, err := NewHashedPassword(mysql.AUTH_NATIVE_PASSWORD, hash)
+		require.NoError(t, err)
+		out := hp.Bytes()
+		for i := range out {
+			out[i] = 0xff
+		}
+		require.Equal(t, hash, hp.Bytes())
+	})
+
+	t.Run("rejects unknown plugin", func(t *testing.T) {
+		_, err := NewHashedPassword("not_a_real_plugin", []byte{0x01})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unknown authentication plugin")
+	})
+
+	t.Run("rejects clear password", func(t *testing.T) {
+		_, err := NewHashedPassword(mysql.AUTH_CLEAR_PASSWORD, []byte("plaintext"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "use AddUser with the plaintext")
+	})
+
+	t.Run("rejects bad shape", func(t *testing.T) {
+		_, err := NewHashedPassword(mysql.AUTH_NATIVE_PASSWORD, []byte{0x00, 0x01})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid hashed password length")
+	})
+}
+
+// TestAddUserHashed verifies the constructor-based registration path
+// stores the credential and is decoupled from the caller's input slice
+// even when the same HashedPassword is reused across multiple users.
+func TestAddUserHashed(t *testing.T) {
+	hash := mysql.NativePasswordHash([]byte("s3cr3t"))
+	hp, err := NewHashedPassword(mysql.AUTH_NATIVE_PASSWORD, hash)
+	require.NoError(t, err)
+
+	handler := NewInMemoryAuthenticationHandler(mysql.AUTH_NATIVE_PASSWORD)
+	handler.AddUserHashed("alice", hp)
+	handler.AddUserHashed("bob", hp)
+
+	for _, name := range []string{"alice", "bob"} {
+		cred, found, err := handler.GetCredential(name)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, mysql.AUTH_NATIVE_PASSWORD, cred.AuthPluginName)
+		require.Len(t, cred.HashedPasswords, 1)
+		require.Equal(t, hash, cred.HashedPasswords[0])
+	}
+
+	// Mutating one stored credential's slice must not bleed into the other:
+	// AddUserHashed clones on insert so the two users don't share storage.
+	cred, _, _ := handler.GetCredential("alice")
+	for i := range cred.HashedPasswords[0] {
+		cred.HashedPasswords[0][i] = 0xff
+	}
+	bobCred, _, _ := handler.GetCredential("bob")
+	require.Equal(t, hash, bobCred.HashedPasswords[0])
+}
+
 // TestAddUserWithHashedPassword_CachingSha2 runs the same end-to-end
 // shape as TestAddUserWithHashedPassword, but for caching_sha2_password.
 // We use auth.NewHashPassword to produce the exact stored form a real

--- a/server/authentication_handler_test.go
+++ b/server/authentication_handler_test.go
@@ -190,6 +190,18 @@ func TestAddUserWithHashedPasswordRejectsBadFormat(t *testing.T) {
 		plugin string
 		hash   []byte
 	}
+	// Helpers for synthesizing inputs at exact byte lengths so the test
+	// reads obviously rather than counting characters in literals.
+	mkBytes := func(n int, fill byte) []byte {
+		out := make([]byte, n)
+		for i := range out {
+			out[i] = fill
+		}
+		return out
+	}
+	cs2OK := append(append([]byte("$A$005$"), mkBytes(cachingSha2SaltLen, 's')...), mkBytes(cachingSha2HashLen, 'h')...)
+	_ = cs2OK // sanity: this exact shape must be accepted (covered by TestValidateHashedPassword_AcceptsRealVerifierOutput)
+
 	cases := []tc{
 		// mysql_native_password: must be exactly 20 bytes (SHA1×2).
 		{"native: nil", mysql.AUTH_NATIVE_PASSWORD, nil},
@@ -198,28 +210,47 @@ func TestAddUserWithHashedPasswordRejectsBadFormat(t *testing.T) {
 		{"native: 21 bytes", mysql.AUTH_NATIVE_PASSWORD, make([]byte, 21)},
 		{"native: hex string passed as bytes", mysql.AUTH_NATIVE_PASSWORD, []byte("*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9")},
 
-		// caching_sha2_password: "$A$<iter>$<salt>$<hash>" — wrong type or shape rejected.
+		// caching_sha2_password: "$A$<iter-hex>$<salt><hash>" — final
+		// segment is exactly SALT_LENGTH(20) + 43 = 63 bytes. Anything
+		// else is either store-format mismatch or panic-shaped input.
 		{"caching_sha2: empty", mysql.AUTH_CACHING_SHA2_PASSWORD, []byte{}},
 		{"caching_sha2: missing $A$ prefix", mysql.AUTH_CACHING_SHA2_PASSWORD, []byte("not-a-hash")},
-		{"caching_sha2: wrong hash type 'B'", mysql.AUTH_CACHING_SHA2_PASSWORD, []byte("$B$005$saltsaltsaltsaltsalt$hashhashhashhashhashhashhashhashhashhash43")},
+		// 4-part split with the wrong digest type letter. parts[3] is
+		// the right length so we know the test is exercising the type
+		// check, not the length or part-count check.
+		{"caching_sha2: wrong hash type 'B'", mysql.AUTH_CACHING_SHA2_PASSWORD, append(append([]byte("$B$005$"), mkBytes(cachingSha2SaltLen, 's')...), mkBytes(cachingSha2HashLen, 'h')...)},
+		// Iter field is non-empty but contains a non-hex char.
+		{"caching_sha2: non-hex iterations", mysql.AUTH_CACHING_SHA2_PASSWORD, append(append([]byte("$A$XYZ$"), mkBytes(cachingSha2SaltLen, 's')...), mkBytes(cachingSha2HashLen, 'h')...)},
 
 		// 4-part split, type 'A', iter present, but parts[3] is exactly
-		// SALT_LENGTH (20) bytes — i.e. salt only, no hash tail. Without
-		// the <= SALT_LENGTH check, auth.CheckHashingPassword would slice
-		// parts[3][:SALT_LENGTH] into the salt and then operate on an
-		// empty hash, panicking in upstream tidb. This case pins the
-		// "panic shape" dveeden flagged in PR review.
-		{"caching_sha2: parts[3] exactly SALT_LENGTH (panic shape)", mysql.AUTH_CACHING_SHA2_PASSWORD, []byte("$A$005$saltsaltsaltsaltsalt")},
+		// SALT_LENGTH bytes — salt only, no hash tail. The verifier
+		// would slice parts[3][:SALT_LENGTH] into the salt and run the
+		// equality check against an empty hash, but it wouldn't panic.
+		// We still reject because the resulting credential could never
+		// authenticate (the verifier always rebuilds salt+43 bytes).
+		{"caching_sha2: parts[3] salt-only, no hash tail", mysql.AUTH_CACHING_SHA2_PASSWORD, append([]byte("$A$005$"), mkBytes(cachingSha2SaltLen, 's')...)},
 		// 4-part split, type 'A', iter present, but parts[3] is shorter
-		// than SALT_LENGTH (1 byte). Same family as the panic shape
-		// above; included separately to make the "way too short" case
-		// unmistakable.
-		{"caching_sha2: parts[3] shorter than SALT_LENGTH", mysql.AUTH_CACHING_SHA2_PASSWORD, []byte("$A$005$x")},
+		// than SALT_LENGTH (1 byte). This is the actual panic shape:
+		// without the length check, auth.CheckHashingPassword's
+		// parts[3][:SALT_LENGTH] would slice past the end and panic.
+		{"caching_sha2: parts[3] shorter than SALT_LENGTH (panic shape)", mysql.AUTH_CACHING_SHA2_PASSWORD, []byte("$A$005$x")},
+		// Off-by-one in the final segment: one byte short and one byte
+		// over the exact 63-byte salt+hash length.
+		{"caching_sha2: parts[3] one byte short", mysql.AUTH_CACHING_SHA2_PASSWORD, append(append([]byte("$A$005$"), mkBytes(cachingSha2SaltLen, 's')...), mkBytes(cachingSha2HashLen-1, 'h')...)},
+		{"caching_sha2: parts[3] one byte over", mysql.AUTH_CACHING_SHA2_PASSWORD, append(append([]byte("$A$005$"), mkBytes(cachingSha2SaltLen, 's')...), mkBytes(cachingSha2HashLen+1, 'h')...)},
 
-		// sha256_password: "$<iter>$<salt>$<hashHex>" — iterations must be decimal.
+		// sha256_password: "$<iter-decimal>$<salt:16>$<hashHex:64>".
 		{"sha256: empty", mysql.AUTH_SHA256_PASSWORD, []byte{}},
 		{"sha256: not a hash", mysql.AUTH_SHA256_PASSWORD, []byte("plain-string")},
-		{"sha256: non-numeric iterations", mysql.AUTH_SHA256_PASSWORD, []byte("$A$saltsaltsaltsaltsalt$hashhashhashhashhashhashhashhash")},
+		{"sha256: non-numeric iterations", mysql.AUTH_SHA256_PASSWORD, append(append([]byte("$A$"), mkBytes(mysql.SALT_LENGTH, 's')...), append([]byte("$"), mkBytes(sha256HashHexLen, 'a')...)...)},
+		// Salt must be exactly mysql.SALT_LENGTH (16) — verifier slices
+		// parts[2][:SALT_LENGTH] and ignores trailing bytes, so anything
+		// other than exactly 16 is a store-format mismatch.
+		{"sha256: salt one byte short (panic shape)", mysql.AUTH_SHA256_PASSWORD, append(append([]byte("$5$"), mkBytes(mysql.SALT_LENGTH-1, 's')...), append([]byte("$"), mkBytes(sha256HashHexLen, 'a')...)...)},
+		{"sha256: salt one byte over", mysql.AUTH_SHA256_PASSWORD, append(append([]byte("$5$"), mkBytes(mysql.SALT_LENGTH+1, 's')...), append([]byte("$"), mkBytes(sha256HashHexLen, 'a')...)...)},
+		// Hash segment must be exactly 64 hex chars.
+		{"sha256: hash 63 chars", mysql.AUTH_SHA256_PASSWORD, append(append([]byte("$5$"), mkBytes(mysql.SALT_LENGTH, 's')...), append([]byte("$"), mkBytes(sha256HashHexLen-1, 'a')...)...)},
+		{"sha256: hash 64 non-hex chars", mysql.AUTH_SHA256_PASSWORD, append(append([]byte("$5$"), mkBytes(mysql.SALT_LENGTH, 's')...), append([]byte("$"), mkBytes(sha256HashHexLen, 'z')...)...)},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -228,6 +259,30 @@ func TestAddUserWithHashedPasswordRejectsBadFormat(t *testing.T) {
 			require.Contains(t, err.Error(), "invalid hashed password")
 		})
 	}
+}
+
+// TestValidateHashedPassword_AcceptsRealVerifierOutput is the inverse of
+// TestAddUserWithHashedPasswordRejectsBadFormat: it round-trips the
+// upstream hash producers (auth.NewHashPassword for caching_sha2,
+// mysql.NewSha256PasswordHash for sha256, mysql.NativePasswordHash for
+// native) through validateHashedPassword and asserts each is accepted.
+// This keeps the tightening from drifting away from what the verifier
+// actually emits.
+func TestValidateHashedPassword_AcceptsRealVerifierOutput(t *testing.T) {
+	require.NoError(t, validateHashedPassword(
+		mysql.AUTH_NATIVE_PASSWORD,
+		mysql.NativePasswordHash([]byte("s3cr3t")),
+	))
+	require.NoError(t, validateHashedPassword(
+		mysql.AUTH_CACHING_SHA2_PASSWORD,
+		[]byte(auth.NewHashPassword("s3cr3t", mysql.AUTH_CACHING_SHA2_PASSWORD)),
+	))
+	storedSha, err := mysql.NewSha256PasswordHash("s3cr3t")
+	require.NoError(t, err)
+	require.NoError(t, validateHashedPassword(
+		mysql.AUTH_SHA256_PASSWORD,
+		[]byte(storedSha),
+	))
 }
 
 // TestAddUserWithHashedPasswordCopiesSlice verifies the helper takes a
@@ -316,8 +371,8 @@ func TestAddUserHashed(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := NewInMemoryAuthenticationHandler(mysql.AUTH_NATIVE_PASSWORD)
-	handler.AddUserHashed("alice", hp)
-	handler.AddUserHashed("bob", hp)
+	require.NoError(t, handler.AddUserHashed("alice", hp))
+	require.NoError(t, handler.AddUserHashed("bob", hp))
 
 	for _, name := range []string{"alice", "bob"} {
 		cred, found, err := handler.GetCredential(name)
@@ -329,13 +384,71 @@ func TestAddUserHashed(t *testing.T) {
 	}
 
 	// Mutating one stored credential's slice must not bleed into the other:
-	// AddUserHashed clones on insert so the two users don't share storage.
+	// AddUserHashed clones on insert so the two users don't share storage,
+	// and GetCredential additionally returns a deep copy so a caller's
+	// mutation can't reach back into the user pool either.
 	cred, _, _ := handler.GetCredential("alice")
 	for i := range cred.HashedPasswords[0] {
 		cred.HashedPasswords[0][i] = 0xff
 	}
 	bobCred, _, _ := handler.GetCredential("bob")
 	require.Equal(t, hash, bobCred.HashedPasswords[0])
+	// Re-fetch alice: the prior mutation went into the returned copy, not
+	// into the stored credential, so the pool still holds the original hash.
+	aliceCred2, _, _ := handler.GetCredential("alice")
+	require.Equal(t, hash, aliceCred2.HashedPasswords[0])
+}
+
+// TestGetCredentialReturnsDeepCopy pins the invariant that GetCredential
+// returns a value the caller can freely mutate without affecting the stored
+// credential. This protects against a class of bug where a connection-handler
+// goroutine accidentally rewrites the at-rest hash and locks the user out.
+func TestGetCredentialReturnsDeepCopy(t *testing.T) {
+	handler := NewInMemoryAuthenticationHandler(mysql.AUTH_NATIVE_PASSWORD)
+	require.NoError(t, handler.AddUser("alice", "p1"))
+	require.NoError(t, handler.AddUserWithHashedPassword("bob", mysql.NativePasswordHash([]byte("p2"))))
+
+	for _, name := range []string{"alice", "bob"} {
+		first, _, err := handler.GetCredential(name)
+		require.NoError(t, err)
+		// Mutate every accessible byte / element through the returned value.
+		for i := range first.Passwords {
+			first.Passwords[i] = "TAINTED"
+		}
+		for i := range first.HashedPasswords {
+			for j := range first.HashedPasswords[i] {
+				first.HashedPasswords[i][j] = 0xff
+			}
+		}
+		second, _, err := handler.GetCredential(name)
+		require.NoError(t, err)
+		// Only compare fields that were actually mutated above. A user
+		// registered via AddUser has no HashedPasswords entry; a user
+		// registered via AddUserWithHashedPassword has no Passwords entry.
+		if len(first.Passwords) > 0 {
+			require.NotEqual(t, first.Passwords, second.Passwords, "%s: stored Passwords leaked through GetCredential", name)
+		}
+		if len(first.HashedPasswords) > 0 {
+			require.NotEqual(t, first.HashedPasswords[0], second.HashedPasswords[0], "%s: stored HashedPasswords leaked through GetCredential", name)
+		}
+	}
+}
+
+// TestAddUserHashedRejectsZeroValue covers the Finding #5 invariant:
+// passing the zero-value HashedPassword (empty plugin, nil data) must
+// return an error rather than silently registering a user that can
+// never authenticate but still surfaces as "found" via hasAnyCredential.
+func TestAddUserHashedRejectsZeroValue(t *testing.T) {
+	handler := NewInMemoryAuthenticationHandler(mysql.AUTH_NATIVE_PASSWORD)
+
+	err := handler.AddUserHashed("ghost", HashedPassword{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid hashed password")
+
+	// And the user is not in the pool: GetCredential should report not-found.
+	_, found, err := handler.GetCredential("ghost")
+	require.NoError(t, err)
+	require.False(t, found, "zero-value HashedPassword must not register the user")
 }
 
 // TestAddUserWithHashedPassword_CachingSha2 runs the same end-to-end
@@ -345,6 +458,17 @@ func TestAddUserHashed(t *testing.T) {
 // callers should pass in. Because caching_sha2's full-auth flow sends
 // the plaintext on the wire, the server must be configured with TLS
 // (or an RSA key); we use the same tlsConf as the other server tests.
+//
+// The test exercises both auth paths separately:
+//
+//  1. First connection with the matching stored hash → cache miss,
+//     full-auth path runs, and the server populates
+//     cacheShaPassword with SHA256(SHA256(plaintext)).
+//  2. We then swap the stored hash to one that does NOT correspond to
+//     `plaintext`. A second connection with the original plaintext can
+//     therefore only succeed via the fast-auth path: the swapped hash
+//     would fail full-auth, so a successful Ping is positive evidence
+//     of a cache hit.
 func TestAddUserWithHashedPassword_CachingSha2(t *testing.T) {
 	const plaintext = "s3cr3t"
 	stored := []byte(auth.NewHashPassword(plaintext, mysql.AUTH_CACHING_SHA2_PASSWORD))
@@ -374,20 +498,44 @@ func TestAddUserWithHashedPassword_CachingSha2(t *testing.T) {
 		}
 	}()
 
-	// Correct plaintext under TLS → success. Two pings exercise both the
-	// full-auth path (cache miss) and the fast-auth path (cache hit).
-	dbOK, err := sql.Open("mysql", "alice:"+plaintext+"@tcp("+l.Addr().String()+")/test?tls=skip-verify")
-	require.NoError(t, err)
-	defer dbOK.Close()
-	dbOK.SetConnMaxLifetime(time.Second)
-	require.NoError(t, dbOK.Ping())
-	require.NoError(t, dbOK.Ping())
+	addr := l.Addr().String()
 
-	// Wrong plaintext → access denied.
-	dbBad, err := sql.Open("mysql", "alice:wrongpass@tcp("+l.Addr().String()+")/test?tls=skip-verify")
+	// Phase 1: first connection with the matching stored hash. This
+	// runs the full-auth path and populates the server's cache.
+	dbFull, err := sql.Open("mysql", "alice:"+plaintext+"@tcp("+addr+")/test?tls=skip-verify")
+	require.NoError(t, err)
+	defer dbFull.Close()
+	dbFull.SetConnMaxLifetime(time.Second)
+	require.NoError(t, dbFull.Ping())
+	// Drop the connection so the second Ping below cannot just reuse it
+	// and skip authentication entirely.
+	require.NoError(t, dbFull.Close())
+
+	// Phase 2: rotate the stored hash to one that does NOT correspond
+	// to `plaintext`. Full-auth from now on should fail; only the
+	// cached SHA256(SHA256(plaintext)) can let the original password
+	// authenticate.
+	otherStored := []byte(auth.NewHashPassword("different-plaintext", mysql.AUTH_CACHING_SHA2_PASSWORD))
+	require.NoError(t, handler.AddUserWithHashedPassword("alice", otherStored, mysql.AUTH_CACHING_SHA2_PASSWORD))
+
+	// Phase 3: a fresh connection with the original plaintext must
+	// still succeed — the only way that's possible now is via the
+	// fast-auth cache hit populated in Phase 1.
+	dbFast, err := sql.Open("mysql", "alice:"+plaintext+"@tcp("+addr+")/test?tls=skip-verify")
+	require.NoError(t, err)
+	defer dbFast.Close()
+	dbFast.SetConnMaxLifetime(time.Second)
+	dbFast.SetMaxIdleConns(0) // belt-and-braces: never reuse a pooled conn
+	require.NoError(t, dbFast.Ping(), "fast-auth cache hit should succeed even though stored hash no longer matches plaintext")
+
+	// Wrong plaintext → access denied (full-auth fails on otherStored,
+	// and the cache scrambleValidation fails on a wrong client scramble
+	// so it falls through to full-auth too).
+	dbBad, err := sql.Open("mysql", "alice:wrongpass@tcp("+addr+")/test?tls=skip-verify")
 	require.NoError(t, err)
 	defer dbBad.Close()
 	dbBad.SetConnMaxLifetime(time.Second)
+	dbBad.SetMaxIdleConns(0)
 	require.Error(t, dbBad.Ping())
 }
 
@@ -435,6 +583,43 @@ func TestAddUserWithHashedPassword_Sha256Password(t *testing.T) {
 	defer dbBad.Close()
 	dbBad.SetConnMaxLifetime(time.Second)
 	require.Error(t, dbBad.Ping())
+}
+
+// TestSafeVerifierWrappersRecover pins the Finding #2 invariant: the
+// recover-safe wrappers around the upstream verifier calls must convert
+// any slice-out-of-bounds panic on a malformed stored hash into a
+// boring (false, error) return, so a Credential constructed directly
+// (bypassing validateHashedPassword) cannot kill the connection
+// goroutine.
+func TestSafeVerifierWrappersRecover(t *testing.T) {
+	t.Run("safeSha256Check on parts[2] shorter than SALT_LENGTH", func(t *testing.T) {
+		// 4 $-segments, decimal iterations, but salt is 1 byte so the
+		// upstream verifier's parts[2][:SALT_LENGTH] would slice past the
+		// end and panic.
+		bad := []byte("$5$x$" + // iter=5, salt="x", hash=""
+			"deadbeef")
+		match, err := safeSha256Check(bad, "anything")
+		require.False(t, match)
+		require.Error(t, err)
+	})
+	t.Run("safeCachingSha2Check on parts[3] shorter than SALT_LENGTH", func(t *testing.T) {
+		// $A$, hex iter, then a final segment well below SALT_LENGTH.
+		bad := []byte("$A$005$x")
+		match, err := safeCachingSha2Check(bad, "anything", mysql.AUTH_CACHING_SHA2_PASSWORD)
+		require.False(t, match)
+		require.Error(t, err)
+	})
+	t.Run("safeNativeCompare on undersized hash", func(t *testing.T) {
+		// Native verifier is permissive about input shapes (it doesn't
+		// fixed-length-slice), so this case is mostly here to document
+		// that the wrapper exists and never panics regardless of input.
+		// An empty hash is enough to demonstrate "no panic, no match".
+		match, err := safeNativeCompare([]byte("client-data"), nil, make([]byte, 20))
+		require.False(t, match)
+		// err may be nil if the verifier itself doesn't panic on this
+		// shape; the contract is "no panic", not "always errors".
+		_ = err
+	})
 }
 
 func TestOnAuthFailureCalled(t *testing.T) {

--- a/server/authentication_handler_test.go
+++ b/server/authentication_handler_test.go
@@ -304,8 +304,9 @@ func TestAddUserWithHashedPasswordCopiesSlice(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found)
 	require.Len(t, cred.HashedPasswords, 1)
-	require.NotEqual(t, hash, cred.HashedPasswords[0])
-	require.Equal(t, mysql.NativePasswordHash([]byte(plaintext)), cred.HashedPasswords[0])
+	stored := cred.HashedPasswords[0].Bytes()
+	require.NotEqual(t, hash, stored)
+	require.Equal(t, mysql.NativePasswordHash([]byte(plaintext)), stored)
 }
 
 // TestNewHashedPassword covers the construction-time validation and the
@@ -380,29 +381,30 @@ func TestAddUserHashed(t *testing.T) {
 		require.True(t, found)
 		require.Equal(t, mysql.AUTH_NATIVE_PASSWORD, cred.AuthPluginName)
 		require.Len(t, cred.HashedPasswords, 1)
-		require.Equal(t, hash, cred.HashedPasswords[0])
+		require.Equal(t, hash, cred.HashedPasswords[0].Bytes())
 	}
 
-	// Mutating one stored credential's slice must not bleed into the other:
-	// AddUserHashed clones on insert so the two users don't share storage,
-	// and GetCredential additionally returns a deep copy so a caller's
-	// mutation can't reach back into the user pool either.
+	// HashedPassword's bytes are unreachable from outside the package
+	// (unexported field, Bytes returns a copy), so the only mutable
+	// surface a caller has on the returned credential is the outer
+	// slice itself. Replacing the entry through the returned copy must
+	// not affect the stored value, because GetCredential returns a
+	// shallow clone of that slice.
 	cred, _, _ := handler.GetCredential("alice")
-	for i := range cred.HashedPasswords[0] {
-		cred.HashedPasswords[0][i] = 0xff
-	}
-	bobCred, _, _ := handler.GetCredential("bob")
-	require.Equal(t, hash, bobCred.HashedPasswords[0])
-	// Re-fetch alice: the prior mutation went into the returned copy, not
-	// into the stored credential, so the pool still holds the original hash.
+	cred.HashedPasswords[0] = HashedPassword{}
 	aliceCred2, _, _ := handler.GetCredential("alice")
-	require.Equal(t, hash, aliceCred2.HashedPasswords[0])
+	require.Len(t, aliceCred2.HashedPasswords, 1)
+	require.Equal(t, hash, aliceCred2.HashedPasswords[0].Bytes())
+	bobCred, _, _ := handler.GetCredential("bob")
+	require.Equal(t, hash, bobCred.HashedPasswords[0].Bytes())
 }
 
 // TestGetCredentialReturnsDeepCopy pins the invariant that GetCredential
 // returns a value the caller can freely mutate without affecting the stored
-// credential. This protects against a class of bug where a connection-handler
-// goroutine accidentally rewrites the at-rest hash and locks the user out.
+// credential. With []HashedPassword the inner bytes are unreachable for
+// mutation already, so this test focuses on the two mutable surfaces a
+// caller does have: the Passwords slice elements and the HashedPasswords
+// slice elements.
 func TestGetCredentialReturnsDeepCopy(t *testing.T) {
 	handler := NewInMemoryAuthenticationHandler(mysql.AUTH_NATIVE_PASSWORD)
 	require.NoError(t, handler.AddUser("alice", "p1"))
@@ -411,14 +413,11 @@ func TestGetCredentialReturnsDeepCopy(t *testing.T) {
 	for _, name := range []string{"alice", "bob"} {
 		first, _, err := handler.GetCredential(name)
 		require.NoError(t, err)
-		// Mutate every accessible byte / element through the returned value.
 		for i := range first.Passwords {
 			first.Passwords[i] = "TAINTED"
 		}
 		for i := range first.HashedPasswords {
-			for j := range first.HashedPasswords[i] {
-				first.HashedPasswords[i][j] = 0xff
-			}
+			first.HashedPasswords[i] = HashedPassword{}
 		}
 		second, _, err := handler.GetCredential(name)
 		require.NoError(t, err)
@@ -432,6 +431,43 @@ func TestGetCredentialReturnsDeepCopy(t *testing.T) {
 			require.NotEqual(t, first.HashedPasswords[0], second.HashedPasswords[0], "%s: stored HashedPasswords leaked through GetCredential", name)
 		}
 	}
+}
+
+// TestAppendUserHashed verifies the rotation path: an existing user can
+// hold multiple HashedPassword entries, both of which authenticate, and
+// the helper rejects mismatched plugin / unknown user inputs.
+func TestAppendUserHashed(t *testing.T) {
+	hashOld := mysql.NativePasswordHash([]byte("old"))
+	hashNew := mysql.NativePasswordHash([]byte("new"))
+	hpOld, err := NewHashedPassword(mysql.AUTH_NATIVE_PASSWORD, hashOld)
+	require.NoError(t, err)
+	hpNew, err := NewHashedPassword(mysql.AUTH_NATIVE_PASSWORD, hashNew)
+	require.NoError(t, err)
+
+	handler := NewInMemoryAuthenticationHandler(mysql.AUTH_NATIVE_PASSWORD)
+	require.NoError(t, handler.AddUserHashed("alice", hpOld))
+	require.NoError(t, handler.AppendUserHashed("alice", hpNew))
+
+	cred, found, err := handler.GetCredential("alice")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, cred.HashedPasswords, 2, "rotation should retain both hashes")
+	require.Equal(t, hashOld, cred.HashedPasswords[0].Bytes())
+	require.Equal(t, hashNew, cred.HashedPasswords[1].Bytes())
+
+	// Unknown user must not be auto-created.
+	err = handler.AppendUserHashed("ghost", hpNew)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+
+	// Plugin mismatch on an existing user is rejected.
+	storedSha, err := mysql.NewSha256PasswordHash("anything")
+	require.NoError(t, err)
+	hpSha, err := NewHashedPassword(mysql.AUTH_SHA256_PASSWORD, []byte(storedSha))
+	require.NoError(t, err)
+	err = handler.AppendUserHashed("alice", hpSha)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "existing credential uses")
 }
 
 // TestAddUserHashedRejectsZeroValue covers the Finding #5 invariant:

--- a/server/server_conf.go
+++ b/server/server_conf.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
@@ -35,6 +36,24 @@ type Server struct {
 	tlsConfig         *tls.Config
 	cacheShaPassword  *sync.Map // 'user@host' -> SHA256(SHA256(PASSWORD))
 	authProvider      AuthenticationProvider
+	log               *slog.Logger
+}
+
+// SetLogger overrides the slog.Logger this Server uses for diagnostics.
+// If never set (or set to nil), the Server falls back to slog.Default()
+// at log time. Intended for embedding-application use cases that want to
+// route server diagnostics into an existing structured-logging pipeline.
+func (s *Server) SetLogger(l *slog.Logger) {
+	s.log = l
+}
+
+// logger returns the configured slog.Logger or slog.Default() if none has
+// been set. Used internally by the auth code paths.
+func (s *Server) logger() *slog.Logger {
+	if s.log == nil {
+		return slog.Default()
+	}
+	return s.log
 }
 
 // NewDefaultServer: New mysql server with default settings.


### PR DESCRIPTION
## Summary

Adds an opt-in `Credential.HashedPasswords [][]byte` field alongside the existing `Passwords []string`, plus a corresponding helper `InMemoryAuthenticationHandler.AddUserWithHashedPassword(...)`. This lets callers configure user credentials when only the **server-side hash** is available, without ever supplying the plaintext.

This is the next step after #1040 (which removed plaintext-at-rest from the in-memory handler internally but kept the plaintext-only public API). Issue #1037 raised this exact use case and is still open — this PR addresses the API gap it identified.

## Why

Concrete motivation: a MySQL proxy (in our case [`takaidohigasi/mysql-interceptor`](https://github.com/takaidohigasi/mysql-interceptor)) that mirrors its user list from another source — another server's `mysql.user` table or a ProxySQL configuration — where passwords are stored as standard `mysql_native_password` hashes (`*XXXXXXXX...` 41-character form) and the plaintext is intentionally not held anywhere. The proxy needs to authenticate clients using only those hashes.

Today there is no clean way to do this: `Credential.Passwords` is plaintext-only, and even the new pluggable `AuthenticationProvider` (`NewServerWithAuth`) can't help because `Conn.salt` and `Conn.credential` are unexported, so a custom provider outside the `server` package can't run `mysql.CompareNativePassword(...)` itself.

## Behavior

- `compareNativePasswordAuthData` consults `HashedPasswords` first (cheaper per connect — no `SHA1(SHA1(plaintext))` step) and falls back to the existing plaintext path. A credential with **only** `HashedPasswords` set is fully usable.
- A new `Credential.hasAnyCredential()` helper is used by `acquireCredential` so hashed-only users aren't reported as `ER_NO_SUCH_USER`.
- `AddUserWithHashedPassword` validates the auth plugin up front: only `mysql_native_password` is supported in this PR (`caching_sha2_password` and `sha256_password` can be extended later if there's interest). Empty hashes are rejected so misconfigured callers fail loudly instead of silently registering an unauthenticatable user.
- Fully backward-compatible: existing callers using `AddUser(username, password)` are unaffected.

## Hash format

The bytes expected by `HashedPasswords` (for `mysql_native_password`) are the raw 20-byte `SHA1(SHA1(plaintext))` value — the same bytes that the existing `mysql.NativePasswordHash` returns and that `mysql.DecodePasswordHex(\"*XXXX...\")` produces from MySQL's standard hex form. Either helper works:

```go
// From a MySQL/ProxySQL stored hash string:
hash, _ := mysql.DecodePasswordHex("*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9")
handler.AddUserWithHashedPassword("alice", hash)

// Or directly from a known plaintext (rare in this use case, but for symmetry):
hash := mysql.NativePasswordHash([]byte("s3cr3t"))
handler.AddUserWithHashedPassword("alice", hash)
```

## Tests

- `TestAddUserWithHashedPassword` — end-to-end: registers a hashed user, then a real `database/sql` client (using the project's own driver) connects with the corresponding plaintext (success) and with a different plaintext (denied), all without the handler ever seeing the real password. Also round-trips through `EncodePasswordHex` / `DecodePasswordHex` to confirm the byte format matches.
- `TestAddUserWithHashedPasswordRejectsUnsupportedPlugin` — passing `caching_sha2_password` returns an explicit error.
- `TestAddUserWithHashedPasswordRejectsEmptyHash` — empty / nil hash returns an explicit error.

`go test -race ./server/...` passes; `go vet ./...` and `gofmt -l server/` clean.

## Diff size

3 files changed, 149 insertions(+), 4 deletions(−).

## Out of scope / follow-ups

- `caching_sha2_password` and `sha256_password` hashed-credential support — different stored-hash formats, separate change.
- Server-side rotation / cache invalidation for `caching_sha2_password` (existing concern called out in the package doc) — unchanged here.

Closes part of #1037.