### PR TITLE
Clear stale `*Field` entries on `Resultset.Reset`

### DIFF
--- a/mysql/resultset.go
+++ b/mysql/resultset.go
@@ -53,6 +53,8 @@ func (r *Resultset) returnToPool() {
 	resultsetPool.Put(r)
 }
 
+// Reset prepares the resultset for reuse. After Reset, all r.Fields entries
+// are nil and the caller must repopulate them.
 func (r *Resultset) Reset(fieldsCount int) {
 	r.RawPkg = r.RawPkg[:0]
 
@@ -74,6 +76,7 @@ func (r *Resultset) Reset(fieldsCount int) {
 		r.Fields = make([]*Field, fieldsCount)
 	} else {
 		r.Fields = r.Fields[:fieldsCount]
+		clear(r.Fields)
 	}
 }
 

--- a/mysql/resultset_test.go
+++ b/mysql/resultset_test.go
@@ -22,3 +22,30 @@ func TestGetIntNeg(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(-193), v)
 }
+
+// Direct check: Reset clears Fields when re-slicing within capacity.
+func TestResetClearsStaleFields(t *testing.T) {
+	r := &Resultset{
+		Fields: []*Field{{Name: []byte("stale")}},
+	}
+	r.Reset(1)
+	require.Nil(t, r.Fields[0])
+}
+
+// End-to-end check: a Resultset returned to the pool must hand the next
+// builder fresh nil Fields, not stale pointers from the previous caller.
+func TestBuildSimpleTextResultsetReusesPoolWithFreshFields(t *testing.T) {
+	// First call: populates Fields[0].Name = "old".
+	r1, err := BuildSimpleTextResultset([]string{"old"}, [][]any{{int64(1)}})
+	require.NoError(t, err)
+	require.Equal(t, []byte("old"), r1.Fields[0].Name)
+
+	// Hand r1 back to the pool, like Result.Close does.
+	resultsetPool.Put(r1)
+
+	// Second call: NewResultset pulls r1 back. Without the fix, Fields[0]
+	// would still be the "old" Field and Name would silently stay "old".
+	r2, err := BuildSimpleTextResultset([]string{"new"}, [][]any{{int64(2)}})
+	require.NoError(t, err)
+	require.Equal(t, []byte("new"), r2.Fields[0].Name)
+}


### PR DESCRIPTION
Right now `Resultset.Reset` re-slices `r.Fields` within the pooled backing array without clearing entries.

So builders that only fill nil slots would reuse a previous call's `Name` / `Charset` / `Flag` from whatever `Resultset` `sync.Pool` happened to return, which would corrupt column metadata across pool reuse.

Let's clear after the re-slice so that the slot is always nil before the builder fills it.

Note: This could be seen as a contract change, because external callers pooling `Resultset` instances and re-using the same `*Field` pointers across `Reset` calls would now have to repopulate `r.Fields` afterwards.