### PR TITLE
Type-aware encoder for streaming binary rows

### DIFF
--- a/mysql/resultset_helper.go
+++ b/mysql/resultset_helper.go
@@ -137,7 +137,11 @@ func toBinaryDate(t time.Time) ([]byte, error) {
 	if t.IsZero() {
 		return []byte{0}, nil
 	}
-	return packDate(uint16(t.Year()), uint8(t.Month()), uint8(t.Day())), nil
+	year := t.Year()
+	if year < 0 || year > 9999 {
+		return nil, errors.Errorf("year %d out of range (0-9999)", year)
+	}
+	return packDate(uint16(year), uint8(t.Month()), uint8(t.Day())), nil
 }
 
 // toBinaryTime encodes a time.Time as a length-prefixed packed binary TIME.
@@ -159,8 +163,12 @@ func toBinaryDateTime(t time.Time) ([]byte, error) {
 	if t.IsZero() {
 		return []byte{0}, nil
 	}
+	year := t.Year()
+	if year < 0 || year > 9999 {
+		return nil, errors.Errorf("year %d out of range (0-9999)", year)
+	}
 	return packDateTime(
-		uint16(t.Year()), uint8(t.Month()), uint8(t.Day()),
+		uint16(year), uint8(t.Month()), uint8(t.Day()),
 		uint8(t.Hour()), uint8(t.Minute()), uint8(t.Second()),
 		uint32(t.Nanosecond()/1000),
 	), nil

--- a/mysql/resultset_helper.go
+++ b/mysql/resultset_helper.go
@@ -1,10 +1,10 @@
 package mysql
 
 import (
-	"bytes"
-	"encoding/binary"
+	"database/sql/driver"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -51,45 +51,603 @@ func FormatTextValue(value any) ([]byte, error) {
 	}
 }
 
-func toBinaryDateTime(t time.Time) ([]byte, error) {
-	var buf bytes.Buffer
+// packDate emits the wire bytes for a DATE.
+//
+//	length | payload
+//	-------+------------------------
+//	     0 | (zero sentinel)
+//	     4 | year(2) month(1) day(1)
+func packDate(year uint16, month, day uint8) []byte {
+	if year == 0 && month == 0 && day == 0 {
+		return []byte{0}
+	}
+	return []byte{4, byte(year), byte(year >> 8), month, day}
+}
 
+// packDateTime emits the wire bytes for a DATETIME / TIMESTAMP. The length
+// shortens when trailing fields (time, then microseconds) are zero.
+//
+//	length | payload
+//	-------+-----------------------------------------------------------
+//	     0 | (zero sentinel)
+//	     4 | year(2) month(1) day(1)
+//	     7 | year(2) month(1) day(1) hour(1) min(1) sec(1)
+//	    11 | year(2) month(1) day(1) hour(1) min(1) sec(1) micro(4)
+func packDateTime(year uint16, month, day, hour, minute, sec uint8, micro uint32) []byte {
+	if year == 0 && month == 0 && day == 0 && hour == 0 && minute == 0 && sec == 0 && micro == 0 {
+		return []byte{0}
+	}
+	if micro > 0 {
+		return []byte{
+			11,
+			byte(year), byte(year >> 8), month, day,
+			hour, minute, sec,
+			byte(micro), byte(micro >> 8), byte(micro >> 16), byte(micro >> 24),
+		}
+	}
+	if hour > 0 || minute > 0 || sec > 0 {
+		return []byte{
+			7,
+			byte(year), byte(year >> 8), month, day,
+			hour, minute, sec,
+		}
+	}
+	return []byte{
+		4,
+		byte(year), byte(year >> 8), month, day,
+	}
+}
+
+// packTime emits the wire bytes for a TIME. MySQL TIME accepts hours up to
+// 838, expressed on the wire as (days*24 + hour). An all-zero TIME collapses
+// to the zero sentinel regardless of sign.
+//
+//	length | payload
+//	-------+--------------------------------------------------
+//	     0 | (zero sentinel)
+//	     8 | neg(1) days(4) hour(1) min(1) sec(1)
+//	    12 | neg(1) days(4) hour(1) min(1) sec(1) micro(4)
+func packTime(negative bool, days uint32, hour, minute, sec uint8, micro uint32) []byte {
+	if days == 0 && hour == 0 && minute == 0 && sec == 0 && micro == 0 {
+		return []byte{0}
+	}
+	var negByte byte
+	if negative {
+		negByte = 1
+	}
+	if micro > 0 {
+		return []byte{
+			12,
+			negByte,
+			byte(days), byte(days >> 8), byte(days >> 16), byte(days >> 24),
+			hour, minute, sec,
+			byte(micro), byte(micro >> 8), byte(micro >> 16), byte(micro >> 24),
+		}
+	}
+	return []byte{
+		8,
+		negByte,
+		byte(days), byte(days >> 8), byte(days >> 16), byte(days >> 24),
+		hour, minute, sec,
+	}
+}
+
+// toBinaryDate encodes a time.Time as a length-prefixed packed binary DATE.
+func toBinaryDate(t time.Time) ([]byte, error) {
 	if t.IsZero() {
+		return []byte{0}, nil
+	}
+	return packDate(uint16(t.Year()), uint8(t.Month()), uint8(t.Day())), nil
+}
+
+// toBinaryTime encodes a time.Time as a length-prefixed packed binary TIME.
+// For negative or >23h values, pass a string instead.
+func toBinaryTime(t time.Time) ([]byte, error) {
+	if t.IsZero() {
+		return []byte{0}, nil
+	}
+	return packTime(
+		false, 0,
+		uint8(t.Hour()), uint8(t.Minute()), uint8(t.Second()),
+		uint32(t.Nanosecond()/1000),
+	), nil
+}
+
+// toBinaryDateTime encodes a time.Time as a length-prefixed packed binary
+// DATETIME / TIMESTAMP.
+func toBinaryDateTime(t time.Time) ([]byte, error) {
+	if t.IsZero() {
+		return []byte{0}, nil
+	}
+	return packDateTime(
+		uint16(t.Year()), uint8(t.Month()), uint8(t.Day()),
+		uint8(t.Hour()), uint8(t.Minute()), uint8(t.Second()),
+		uint32(t.Nanosecond()/1000),
+	), nil
+}
+
+// parseDateString re-packs a "YYYY-MM-DD" DATE string (the form produced
+// by ParseBinary) into the wire's packed format. Empty input is rejected.
+func parseDateString(s string) ([]byte, error) {
+	if s == "" {
+		return nil, errors.Errorf("invalid DATE: empty string")
+	}
+	if s == "0000-00-00" {
+		return []byte{0}, nil
+	}
+	year, month, day, err := parseYMD(s)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid DATE %q", s)
+	}
+	return packDate(year, month, day), nil
+}
+
+// parseDateTimeString re-packs a "YYYY-MM-DD[ HH:MM:SS[.ffffff]]"
+// DATETIME / TIMESTAMP string into the wire's packed format.
+func parseDateTimeString(s string) ([]byte, error) {
+	if s == "" {
+		return nil, errors.Errorf("invalid DATETIME: empty string")
+	}
+	// Fast-path the canonical zero sentinels. Other zero-fraction widths
+	// fall through to packDateTime, which collapses all-zero values to []byte{0}.
+	if s == "0000-00-00 00:00:00" || s == "0000-00-00 00:00:00.000000" {
+		return []byte{0}, nil
+	}
+	datePart, timePart, hasSpace := strings.Cut(s, " ")
+	if hasSpace && timePart == "" {
+		// Reject "YYYY-MM-DD " with trailing whitespace; otherwise we
+		// silently emit a date-only encoding for malformed input.
+		return nil, errors.Errorf("invalid DATETIME %q: trailing whitespace without time part", s)
+	}
+	year, month, day, err := parseYMD(datePart)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid DATETIME %q", s)
+	}
+	var hour, minute, sec uint8
+	var micro uint32
+	if timePart != "" {
+		hour, minute, sec, micro, err = parseHMSFraction(timePart)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid DATETIME %q", s)
+		}
+	}
+	return packDateTime(year, month, day, hour, minute, sec, micro), nil
+}
+
+// parseTimeString re-packs a "[-]H+:MM:SS[.ffffff]" TIME string into the
+// wire's packed format. Hours may exceed 23 (up to 838) and are split into
+// days plus an in-day hour.
+func parseTimeString(s string) ([]byte, error) {
+	if s == "" {
+		return nil, errors.Errorf("invalid TIME: empty string")
+	}
+	// Fast-path the canonical zero sentinels. packTime collapses any all-zero
+	// value to []byte{0}, so "-00:00:00" still produces the right wire bytes.
+	if s == "00:00:00" || s == "00:00:00.000000" {
+		return []byte{0}, nil
+	}
+	negative := strings.HasPrefix(s, "-")
+	if negative {
+		s = s[1:]
+	}
+	hms, frac, hasDot := strings.Cut(s, ".")
+	if hasDot && frac == "" {
+		return nil, errors.Errorf("invalid TIME %q: trailing dot without fractional digits", s)
+	}
+	parts := strings.Split(hms, ":")
+	if len(parts) != 3 {
+		return nil, errors.Errorf("invalid TIME %q", s)
+	}
+	totalHours, err := strconv.ParseUint(parts[0], 10, 32)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid TIME %q", s)
+	}
+	if totalHours > 838 {
+		// MySQL TIME range is -838:59:59 to 838:59:59.
+		return nil, errors.Errorf("invalid TIME %q: hours %d exceed MySQL TIME maximum of 838", s, totalHours)
+	}
+	minute, err := strconv.ParseUint(parts[1], 10, 8)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid TIME %q: minute", s)
+	}
+	if minute > 59 {
+		return nil, errors.Errorf("invalid TIME %q: minute %d out of range", s, minute)
+	}
+	sec, err := strconv.ParseUint(parts[2], 10, 8)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid TIME %q: second", s)
+	}
+	if sec > 59 {
+		return nil, errors.Errorf("invalid TIME %q: second %d out of range", s, sec)
+	}
+	var micro uint32
+	if frac != "" {
+		micro, err = parseMicroseconds(frac)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid TIME %q", s)
+		}
+	}
+	days := uint32(totalHours / 24)
+	hour := uint8(totalHours % 24)
+	return packTime(negative, days, hour, uint8(minute), uint8(sec), micro), nil
+}
+
+func parseYMD(s string) (uint16, uint8, uint8, error) {
+	if len(s) != 10 || s[4] != '-' || s[7] != '-' {
+		return 0, 0, 0, errors.Errorf("expected YYYY-MM-DD")
+	}
+	year, err := strconv.ParseUint(s[0:4], 10, 16)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	month, err := strconv.ParseUint(s[5:7], 10, 8)
+	if err != nil || month > 12 {
+		return 0, 0, 0, errors.Errorf("month out of range")
+	}
+	day, err := strconv.ParseUint(s[8:10], 10, 8)
+	if err != nil || day > 31 {
+		return 0, 0, 0, errors.Errorf("day out of range")
+	}
+	return uint16(year), uint8(month), uint8(day), nil
+}
+
+func parseHMSFraction(s string) (uint8, uint8, uint8, uint32, error) {
+	hms, frac, hasDot := strings.Cut(s, ".")
+	if hasDot && frac == "" {
+		return 0, 0, 0, 0, errors.Errorf("trailing dot without fractional digits")
+	}
+	parts := strings.Split(hms, ":")
+	if len(parts) != 3 {
+		return 0, 0, 0, 0, errors.Errorf("expected HH:MM:SS")
+	}
+	hour, err := strconv.ParseUint(parts[0], 10, 8)
+	if err != nil {
+		return 0, 0, 0, 0, errors.Wrap(err, "hour")
+	}
+	if hour > 23 {
+		return 0, 0, 0, 0, errors.Errorf("hour %d out of range", hour)
+	}
+	minute, err := strconv.ParseUint(parts[1], 10, 8)
+	if err != nil {
+		return 0, 0, 0, 0, errors.Wrap(err, "minute")
+	}
+	if minute > 59 {
+		return 0, 0, 0, 0, errors.Errorf("minute %d out of range", minute)
+	}
+	sec, err := strconv.ParseUint(parts[2], 10, 8)
+	if err != nil {
+		return 0, 0, 0, 0, errors.Wrap(err, "second")
+	}
+	if sec > 59 {
+		return 0, 0, 0, 0, errors.Errorf("second %d out of range", sec)
+	}
+	var micro uint32
+	if frac != "" {
+		micro, err = parseMicroseconds(frac)
+		if err != nil {
+			return 0, 0, 0, 0, err
+		}
+	}
+	return uint8(hour), uint8(minute), uint8(sec), micro, nil
+}
+
+func parseMicroseconds(s string) (uint32, error) {
+	if len(s) > 6 {
+		// MySQL fractional seconds top out at 6 digits.
+		return 0, errors.Errorf("invalid microseconds %q: more than 6 digits", s)
+	}
+	for len(s) < 6 {
+		s += "0"
+	}
+	n, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, errors.Wrapf(err, "invalid microseconds %q", s)
+	}
+	return uint32(n), nil
+}
+
+// unwrapDriverValue unwraps database/sql driver wrappers (sql.NullString,
+// sql.NullInt64, anything implementing driver.Valuer) before encoding.
+// One level only, matching stdlib's database/sql/driver behavior.
+func unwrapDriverValue(value any) (any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	if v, ok := value.(driver.Valuer); ok {
+		return v.Value()
+	}
+	return value, nil
+}
+
+func coerceInt(value any) (int64, error) {
+	switch v := value.(type) {
+	case int8:
+		return int64(v), nil
+	case int16:
+		return int64(v), nil
+	case int32:
+		return int64(v), nil
+	case int:
+		return int64(v), nil
+	case int64:
+		return v, nil
+	case uint8:
+		return int64(v), nil
+	case uint16:
+		return int64(v), nil
+	case uint32:
+		return int64(v), nil
+	case uint:
+		if uint64(v) > math.MaxInt64 {
+			return 0, errors.Errorf("uint %d overflows int64", v)
+		}
+		return int64(v), nil
+	case uint64:
+		if v > math.MaxInt64 {
+			return 0, errors.Errorf("uint64 %d overflows int64", v)
+		}
+		return int64(v), nil
+	default:
+		return 0, errors.Errorf("cannot coerce %T to integer", value)
+	}
+}
+
+func coerceUint(value any) (uint64, error) {
+	switch v := value.(type) {
+	case int8:
+		if v < 0 {
+			return 0, errors.Errorf("negative value %d for unsigned column", v)
+		}
+		return uint64(v), nil
+	case int16:
+		if v < 0 {
+			return 0, errors.Errorf("negative value %d for unsigned column", v)
+		}
+		return uint64(v), nil
+	case int32:
+		if v < 0 {
+			return 0, errors.Errorf("negative value %d for unsigned column", v)
+		}
+		return uint64(v), nil
+	case int:
+		if v < 0 {
+			return 0, errors.Errorf("negative value %d for unsigned column", v)
+		}
+		return uint64(v), nil
+	case int64:
+		if v < 0 {
+			return 0, errors.Errorf("negative value %d for unsigned column", v)
+		}
+		return uint64(v), nil
+	case uint8:
+		return uint64(v), nil
+	case uint16:
+		return uint64(v), nil
+	case uint32:
+		return uint64(v), nil
+	case uint:
+		return uint64(v), nil
+	case uint64:
+		return v, nil
+	default:
+		return 0, errors.Errorf("cannot coerce %T to unsigned integer", value)
+	}
+}
+
+// coerceFloat64 converts a numeric Go value to float64 for binary encoding.
+// uint64 → float64 silently loses precision above 2^53; this matches MySQL.
+func coerceFloat64(value any) (float64, error) {
+	switch v := value.(type) {
+	case float32:
+		return float64(v), nil
+	case float64:
+		return v, nil
+	case int8:
+		return float64(v), nil
+	case int16:
+		return float64(v), nil
+	case int32:
+		return float64(v), nil
+	case int:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case uint8:
+		return float64(v), nil
+	case uint16:
+		return float64(v), nil
+	case uint32:
+		return float64(v), nil
+	case uint:
+		return float64(v), nil
+	case uint64:
+		return float64(v), nil
+	default:
+		return 0, errors.Errorf("cannot coerce %T to float", value)
+	}
+}
+
+// encodeIntegerColumn writes value at the per-type fixed width, range-
+// checking against the column's declared signedness.
+func encodeIntegerColumn(field *Field, value any) ([]byte, error) {
+	// MySQL BOOL / BOOLEAN are aliases for TINYINT(1); accept Go bool only
+	// for TINY (encoded as 1/0) and reject for wider integer types.
+	if b, ok := value.(bool); ok {
+		if field.Type != MYSQL_TYPE_TINY {
+			return nil, errors.Errorf("EncodeBinaryFieldValue: bool input not supported for column type %d (only TINY)", field.Type)
+		}
+		if b {
+			return []byte{1}, nil
+		}
+		return []byte{0}, nil
+	}
+	var width int
+	var smin, smax int64
+	var umax uint64
+	switch field.Type {
+	case MYSQL_TYPE_TINY:
+		width, smin, smax, umax = 1, math.MinInt8, math.MaxInt8, math.MaxUint8
+	case MYSQL_TYPE_SHORT, MYSQL_TYPE_YEAR:
+		// YEAR's wire bound is uint16; the 1901–2155 semantic range is the
+		// server's concern, not enforced here.
+		width, smin, smax, umax = 2, math.MinInt16, math.MaxInt16, math.MaxUint16
+	case MYSQL_TYPE_INT24:
+		// MEDIUMINT is 3 bytes on disk but 4 bytes on the wire.
+		width, smin, smax, umax = 4, -1<<23, 1<<23-1, 1<<24-1
+	case MYSQL_TYPE_LONG:
+		width, smin, smax, umax = 4, math.MinInt32, math.MaxInt32, math.MaxUint32
+	case MYSQL_TYPE_LONGLONG:
+		width, smin, smax, umax = 8, math.MinInt64, math.MaxInt64, math.MaxUint64
+	default:
+		return nil, errors.Errorf("not an integer type: %d", field.Type)
+	}
+	// MySQL YEAR is always unsigned (range 1901–2155 plus sentinel 0000), so
+	// force the unsigned path even if the caller forgot UNSIGNED_FLAG.
+	unsigned := field.Flag&UNSIGNED_FLAG != 0 || field.Type == MYSQL_TYPE_YEAR
+	if unsigned {
+		u, err := coerceUint(value)
+		if err != nil {
+			return nil, errors.Wrapf(err, "EncodeBinaryFieldValue (type %d)", field.Type)
+		}
+		if u > umax {
+			return nil, errors.Errorf("EncodeBinaryFieldValue (type %d): value %d exceeds unsigned max %d", field.Type, u, umax)
+		}
+		return Uint64ToBytes(u)[:width], nil
+	}
+	i, err := coerceInt(value)
+	if err != nil {
+		return nil, errors.Wrapf(err, "EncodeBinaryFieldValue (type %d)", field.Type)
+	}
+	if i < smin || i > smax {
+		return nil, errors.Errorf("EncodeBinaryFieldValue (type %d): value %d out of range [%d, %d]", field.Type, i, smin, smax)
+	}
+	return Uint64ToBytes(uint64(i))[:width], nil
+}
+
+// EncodeBinaryFieldValue encodes a single value for the binary protocol,
+// honoring the column's declared type. Range-checks integer values and
+// re-packs ParseBinary's formatted temporal strings into packed form.
+//
+// (nil, nil) signals NULL: the caller sets the row's NULL bitmap bit and
+// writes no payload. Emitted for literal nil, driver.Valuer→nil, and
+// MYSQL_TYPE_NULL.
+func EncodeBinaryFieldValue(field *Field, value any) ([]byte, error) {
+	if field == nil {
+		return nil, errors.Errorf("EncodeBinaryFieldValue: nil field")
+	}
+	if field.Type == MYSQL_TYPE_NULL {
+		return nil, nil
+	}
+	value, err := unwrapDriverValue(value)
+	if err != nil {
+		return nil, errors.Wrap(err, "EncodeBinaryFieldValue")
+	}
+	if value == nil {
 		return nil, nil
 	}
 
-	year, month, day := t.Year(), t.Month(), t.Day()
-	hour, minute, sec := t.Hour(), t.Minute(), t.Second()
-	nanosec := t.Nanosecond()
+	switch field.Type {
+	case MYSQL_TYPE_TINY, MYSQL_TYPE_SHORT, MYSQL_TYPE_YEAR,
+		MYSQL_TYPE_INT24, MYSQL_TYPE_LONG, MYSQL_TYPE_LONGLONG:
+		return encodeIntegerColumn(field, value)
 
-	if nanosec > 0 {
-		buf.WriteByte(byte(11))
-		_ = binary.Write(&buf, binary.LittleEndian, uint16(year))
-		buf.WriteByte(byte(month))
-		buf.WriteByte(byte(day))
-		buf.WriteByte(byte(hour))
-		buf.WriteByte(byte(minute))
-		buf.WriteByte(byte(sec))
-		_ = binary.Write(&buf, binary.LittleEndian, uint32(nanosec/1000))
-	} else if hour > 0 || minute > 0 || sec > 0 {
-		buf.WriteByte(byte(7))
-		_ = binary.Write(&buf, binary.LittleEndian, uint16(year))
-		buf.WriteByte(byte(month))
-		buf.WriteByte(byte(day))
-		buf.WriteByte(byte(hour))
-		buf.WriteByte(byte(minute))
-		buf.WriteByte(byte(sec))
-	} else {
-		buf.WriteByte(byte(4))
-		_ = binary.Write(&buf, binary.LittleEndian, uint16(year))
-		buf.WriteByte(byte(month))
-		buf.WriteByte(byte(day))
+	case MYSQL_TYPE_FLOAT:
+		f, err := coerceFloat64(value)
+		if err != nil {
+			return nil, errors.Wrap(err, "EncodeBinaryFieldValue (FLOAT)")
+		}
+		f32 := float32(f)
+		// Reject finite inputs that overflow float32 to ±Inf; preserve
+		// genuine ±Inf and NaN. Underflow narrows to 0, matching MySQL.
+		if math.IsInf(float64(f32), 0) && !math.IsInf(f, 0) {
+			return nil, errors.Errorf("EncodeBinaryFieldValue (FLOAT): value %g exceeds float32 range", f)
+		}
+		return Uint32ToBytes(math.Float32bits(f32)), nil
+
+	case MYSQL_TYPE_DOUBLE:
+		f, err := coerceFloat64(value)
+		if err != nil {
+			return nil, errors.Wrap(err, "EncodeBinaryFieldValue (DOUBLE)")
+		}
+		return Uint64ToBytes(math.Float64bits(f)), nil
+
+	case MYSQL_TYPE_DECIMAL, MYSQL_TYPE_NEWDECIMAL,
+		MYSQL_TYPE_VARCHAR, MYSQL_TYPE_VAR_STRING, MYSQL_TYPE_STRING,
+		MYSQL_TYPE_TINY_BLOB, MYSQL_TYPE_MEDIUM_BLOB, MYSQL_TYPE_LONG_BLOB, MYSQL_TYPE_BLOB,
+		MYSQL_TYPE_BIT, MYSQL_TYPE_ENUM, MYSQL_TYPE_SET,
+		MYSQL_TYPE_VECTOR, MYSQL_TYPE_GEOMETRY, MYSQL_TYPE_JSON:
+		switch v := value.(type) {
+		case []byte:
+			if v == nil {
+				// Typed-nil []byte → NULL. The top-level nil check doesn't
+				// catch typed nils inside an interface.
+				return nil, nil
+			}
+			return PutLengthEncodedString(v), nil
+		case string:
+			return PutLengthEncodedString(utils.StringToByteSlice(v)), nil
+		default:
+			return nil, errors.Errorf("EncodeBinaryFieldValue: unsupported value type %T for field type %d", value, field.Type)
+		}
+
+	case MYSQL_TYPE_DATE, MYSQL_TYPE_NEWDATE:
+		switch v := value.(type) {
+		case time.Time:
+			return toBinaryDate(v)
+		case []byte:
+			if v == nil {
+				return nil, nil
+			}
+			return parseDateString(utils.ByteSliceToString(v))
+		case string:
+			return parseDateString(v)
+		default:
+			return nil, errors.Errorf("EncodeBinaryFieldValue: unsupported value type %T for DATE", value)
+		}
+
+	case MYSQL_TYPE_TIMESTAMP, MYSQL_TYPE_DATETIME:
+		switch v := value.(type) {
+		case time.Time:
+			return toBinaryDateTime(v)
+		case []byte:
+			if v == nil {
+				return nil, nil
+			}
+			return parseDateTimeString(utils.ByteSliceToString(v))
+		case string:
+			return parseDateTimeString(v)
+		default:
+			return nil, errors.Errorf("EncodeBinaryFieldValue: unsupported value type %T for DATETIME/TIMESTAMP", value)
+		}
+
+	case MYSQL_TYPE_TIME:
+		switch v := value.(type) {
+		case time.Time:
+			return toBinaryTime(v)
+		case []byte:
+			if v == nil {
+				return nil, nil
+			}
+			return parseTimeString(utils.ByteSliceToString(v))
+		case string:
+			return parseTimeString(v)
+		default:
+			return nil, errors.Errorf("EncodeBinaryFieldValue: unsupported value type %T for TIME", value)
+		}
+
+	default:
+		// TIMESTAMP2 / DATETIME2 / TIME2 are binlog-internal, not on the wire.
+		return nil, errors.Errorf("EncodeBinaryFieldValue: unsupported field type %d", field.Type)
 	}
-
-	return buf.Bytes(), nil
 }
 
 // FormatBinaryValue formats a value for binary protocol.
+//
+// Deprecated: use EncodeBinaryFieldValue, which honors the column's declared
+// field type and width. FormatBinaryValue always emits 8 bytes for any
+// integer Go type, producing wire bytes the client cannot parse for
+// narrow-width columns. Zero time.Time → (nil, nil) is preserved for
+// backward compat.
 func FormatBinaryValue(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case int8:
@@ -121,6 +679,9 @@ func FormatBinaryValue(value any) ([]byte, error) {
 	case string:
 		return utils.StringToByteSlice(v), nil
 	case time.Time:
+		if v.IsZero() {
+			return nil, nil
+		}
 		return toBinaryDateTime(v)
 	default:
 		return nil, errors.Errorf("invalid type %T", value)

--- a/mysql/resultset_helper.go
+++ b/mysql/resultset_helper.go
@@ -138,6 +138,8 @@ func toBinaryDate(t time.Time) ([]byte, error) {
 		return []byte{0}, nil
 	}
 	year := t.Year()
+	// MySQL DATE/DATETIME cap at year 9999 and the wire year is a 2-byte
+	// unsigned int. https://dev.mysql.com/doc/refman/8.0/en/datetime.html
 	if year < 0 || year > 9999 {
 		return nil, errors.Errorf("year %d out of range (0-9999)", year)
 	}
@@ -145,7 +147,8 @@ func toBinaryDate(t time.Time) ([]byte, error) {
 }
 
 // toBinaryTime encodes a time.Time as a length-prefixed packed binary TIME.
-// For negative or >23h values, pass a string instead.
+// A time.Time is always non-negative and under 24h; negative or >=24h TIME
+// values arrive as strings and go through parseTimeString instead.
 func toBinaryTime(t time.Time) ([]byte, error) {
 	if t.IsZero() {
 		return []byte{0}, nil
@@ -211,15 +214,19 @@ func parseDateTimeString(s string) ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid DATETIME %q", s)
 	}
-	var hour, minute, sec uint8
+	var hour uint32
+	var minute, sec uint8
 	var micro uint32
 	if timePart != "" {
 		hour, minute, sec, micro, err = parseHMSFraction(timePart)
 		if err != nil {
 			return nil, errors.Wrapf(err, "invalid DATETIME %q", s)
 		}
+		if hour > 23 {
+			return nil, errors.Errorf("invalid DATETIME %q: hour %d out of range", s, hour)
+		}
 	}
-	return packDateTime(year, month, day, hour, minute, sec, micro), nil
+	return packDateTime(year, month, day, uint8(hour), minute, sec, micro), nil
 }
 
 // parseTimeString re-packs a "[-]H+:MM:SS[.ffffff]" TIME string into the
@@ -238,46 +245,15 @@ func parseTimeString(s string) ([]byte, error) {
 	if negative {
 		s = s[1:]
 	}
-	hms, frac, hasDot := strings.Cut(s, ".")
-	if hasDot && frac == "" {
-		return nil, errors.Errorf("invalid TIME %q: trailing dot without fractional digits", s)
-	}
-	parts := strings.Split(hms, ":")
-	if len(parts) != 3 {
-		return nil, errors.Errorf("invalid TIME %q", s)
-	}
-	totalHours, err := strconv.ParseUint(parts[0], 10, 32)
+	hour, minute, sec, micro, err := parseHMSFraction(s)
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid TIME %q", s)
 	}
-	if totalHours > 838 {
+	if hour > 838 {
 		// MySQL TIME range is -838:59:59 to 838:59:59.
-		return nil, errors.Errorf("invalid TIME %q: hours %d exceed MySQL TIME maximum of 838", s, totalHours)
+		return nil, errors.Errorf("invalid TIME %q: hours %d exceed MySQL TIME maximum of 838", s, hour)
 	}
-	minute, err := strconv.ParseUint(parts[1], 10, 8)
-	if err != nil {
-		return nil, errors.Wrapf(err, "invalid TIME %q: minute", s)
-	}
-	if minute > 59 {
-		return nil, errors.Errorf("invalid TIME %q: minute %d out of range", s, minute)
-	}
-	sec, err := strconv.ParseUint(parts[2], 10, 8)
-	if err != nil {
-		return nil, errors.Wrapf(err, "invalid TIME %q: second", s)
-	}
-	if sec > 59 {
-		return nil, errors.Errorf("invalid TIME %q: second %d out of range", s, sec)
-	}
-	var micro uint32
-	if frac != "" {
-		micro, err = parseMicroseconds(frac)
-		if err != nil {
-			return nil, errors.Wrapf(err, "invalid TIME %q", s)
-		}
-	}
-	days := uint32(totalHours / 24)
-	hour := uint8(totalHours % 24)
-	return packTime(negative, days, hour, uint8(minute), uint8(sec), micro), nil
+	return packTime(negative, hour/24, uint8(hour%24), minute, sec, micro), nil
 }
 
 func parseYMD(s string) (uint16, uint8, uint8, error) {
@@ -299,7 +275,9 @@ func parseYMD(s string) (uint16, uint8, uint8, error) {
 	return uint16(year), uint8(month), uint8(day), nil
 }
 
-func parseHMSFraction(s string) (uint8, uint8, uint8, uint32, error) {
+// parseHMSFraction parses "HH:MM:SS[.ffffff]". The hour is returned unbounded
+// so each caller can apply its own maximum: 23 for DATETIME, 838 for TIME.
+func parseHMSFraction(s string) (uint32, uint8, uint8, uint32, error) {
 	hms, frac, hasDot := strings.Cut(s, ".")
 	if hasDot && frac == "" {
 		return 0, 0, 0, 0, errors.Errorf("trailing dot without fractional digits")
@@ -308,12 +286,9 @@ func parseHMSFraction(s string) (uint8, uint8, uint8, uint32, error) {
 	if len(parts) != 3 {
 		return 0, 0, 0, 0, errors.Errorf("expected HH:MM:SS")
 	}
-	hour, err := strconv.ParseUint(parts[0], 10, 8)
+	hour, err := strconv.ParseUint(parts[0], 10, 32)
 	if err != nil {
 		return 0, 0, 0, 0, errors.Wrap(err, "hour")
-	}
-	if hour > 23 {
-		return 0, 0, 0, 0, errors.Errorf("hour %d out of range", hour)
 	}
 	minute, err := strconv.ParseUint(parts[1], 10, 8)
 	if err != nil {
@@ -336,7 +311,7 @@ func parseHMSFraction(s string) (uint8, uint8, uint8, uint32, error) {
 			return 0, 0, 0, 0, err
 		}
 	}
-	return uint8(hour), uint8(minute), uint8(sec), micro, nil
+	return uint32(hour), uint8(minute), uint8(sec), micro, nil
 }
 
 func parseMicroseconds(s string) (uint32, error) {
@@ -344,12 +319,13 @@ func parseMicroseconds(s string) (uint32, error) {
 		// MySQL fractional seconds top out at 6 digits.
 		return 0, errors.Errorf("invalid microseconds %q: more than 6 digits", s)
 	}
-	for len(s) < 6 {
-		s += "0"
-	}
 	n, err := strconv.ParseUint(s, 10, 32)
 	if err != nil {
 		return 0, errors.Wrapf(err, "invalid microseconds %q", s)
+	}
+	// Left-align the fraction to microseconds: ".5" is 500000 µs, not 5.
+	for i := len(s); i < 6; i++ {
+		n *= 10
 	}
 	return uint32(n), nil
 }
@@ -586,11 +562,9 @@ func EncodeBinaryFieldValue(field *Field, value any) ([]byte, error) {
 		MYSQL_TYPE_VECTOR, MYSQL_TYPE_GEOMETRY, MYSQL_TYPE_JSON:
 		switch v := value.(type) {
 		case []byte:
-			if v == nil {
-				// Typed-nil []byte → NULL. The top-level nil check doesn't
-				// catch typed nils inside an interface.
-				return nil, nil
-			}
+			// ParseBinary yields []byte(nil) for empty strings, so a nil []byte
+			// is an empty string here, not NULL; NULLs are caught by the
+			// value == nil check at the top of the function.
 			return PutLengthEncodedString(v), nil
 		case string:
 			return PutLengthEncodedString(utils.StringToByteSlice(v)), nil

--- a/mysql/resultset_helper_test.go
+++ b/mysql/resultset_helper_test.go
@@ -1,0 +1,546 @@
+package mysql
+
+import (
+	"database/sql"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// encodeBinaryRow assembles a binary-protocol row (header + NULL bitmap +
+// payload) using EncodeBinaryFieldValue. Mirrors the production row
+// builders, including the (nil, nil) NULL signal.
+func encodeBinaryRow(t *testing.T, fields []*Field, values []any) []byte {
+	t.Helper()
+	require.Equal(t, len(fields), len(values), "fields/values length mismatch")
+	bitmapLen := (len(fields) + 7 + 2) >> 3
+	nullBitmap := make([]byte, bitmapLen)
+	var payload []byte
+	for i, v := range values {
+		b, err := EncodeBinaryFieldValue(fields[i], v)
+		require.NoError(t, err, "field %d (%s)", i, fields[i].Name)
+		if b == nil {
+			nullBitmap[(i+2)/8] |= 1 << (uint(i+2) % 8)
+			continue
+		}
+		payload = append(payload, b...)
+	}
+	row := []byte{0x00}
+	row = append(row, nullBitmap...)
+	row = append(row, payload...)
+	return row
+}
+
+// roundTrip encodes a row then parses it back.
+func roundTrip(t *testing.T, fields []*Field, values []any) []FieldValue {
+	t.Helper()
+	raw := encodeBinaryRow(t, fields, values)
+	parsed, err := RowData(raw).ParseBinary(fields, nil)
+	require.NoError(t, err)
+	return parsed
+}
+
+func TestEncodeBinaryFieldValueIntegers(t *testing.T) {
+	t.Run("widths and signedness", func(t *testing.T) {
+		fields := []*Field{
+			{Name: []byte("c_tiny"), Type: MYSQL_TYPE_TINY},
+			{Name: []byte("c_utiny"), Type: MYSQL_TYPE_TINY, Flag: UNSIGNED_FLAG},
+			{Name: []byte("c_short"), Type: MYSQL_TYPE_SHORT},
+			{Name: []byte("c_year"), Type: MYSQL_TYPE_YEAR, Flag: UNSIGNED_FLAG},
+			{Name: []byte("c_int24"), Type: MYSQL_TYPE_INT24},
+			{Name: []byte("c_long"), Type: MYSQL_TYPE_LONG},
+			{Name: []byte("c_ulong"), Type: MYSQL_TYPE_LONG, Flag: UNSIGNED_FLAG},
+			{Name: []byte("c_ll"), Type: MYSQL_TYPE_LONGLONG},
+			{Name: []byte("c_ull"), Type: MYSQL_TYPE_LONGLONG, Flag: UNSIGNED_FLAG},
+		}
+		row := roundTrip(t, fields, []any{
+			int8(-7), uint8(200),
+			int16(-12345), uint16(2026),
+			int32(-1234567), int32(2147483600), uint32(4294967290),
+			int64(math.MinInt64), uint64(math.MaxUint64),
+		})
+		require.Equal(t, int64(-7), row[0].AsInt64())
+		require.Equal(t, uint64(200), row[1].AsUint64())
+		require.Equal(t, int64(-12345), row[2].AsInt64())
+		require.Equal(t, uint64(2026), row[3].AsUint64())
+		require.Equal(t, int64(-1234567), row[4].AsInt64())
+		require.Equal(t, int64(2147483600), row[5].AsInt64())
+		require.Equal(t, uint64(4294967290), row[6].AsUint64())
+		require.Equal(t, int64(math.MinInt64), row[7].AsInt64())
+		require.Equal(t, uint64(math.MaxUint64), row[8].AsUint64())
+	})
+
+	t.Run("signed range errors", func(t *testing.T) {
+		f := &Field{Type: MYSQL_TYPE_TINY}
+		_, err := EncodeBinaryFieldValue(f, int64(500))
+		require.Error(t, err)
+		_, err = EncodeBinaryFieldValue(f, int64(-500))
+		require.Error(t, err)
+	})
+
+	t.Run("unsigned rejects negative", func(t *testing.T) {
+		f := &Field{Type: MYSQL_TYPE_TINY, Flag: UNSIGNED_FLAG}
+		_, err := EncodeBinaryFieldValue(f, int64(-1))
+		require.Error(t, err)
+	})
+
+	t.Run("unsigned range errors", func(t *testing.T) {
+		f := &Field{Type: MYSQL_TYPE_SHORT, Flag: UNSIGNED_FLAG}
+		_, err := EncodeBinaryFieldValue(f, uint64(70000))
+		require.Error(t, err)
+	})
+
+	t.Run("INT24 boundary", func(t *testing.T) {
+		f := &Field{Type: MYSQL_TYPE_INT24}
+		_, err := EncodeBinaryFieldValue(f, int64(1<<23-1))
+		require.NoError(t, err)
+		_, err = EncodeBinaryFieldValue(f, int64(1<<23))
+		require.Error(t, err)
+	})
+
+	t.Run("YEAR forced unsigned without UNSIGNED_FLAG", func(t *testing.T) {
+		// YEAR is always unsigned, even if the caller forgot UNSIGNED_FLAG.
+		fields := []*Field{{Name: []byte("c_year"), Type: MYSQL_TYPE_YEAR}}
+		row := roundTrip(t, fields, []any{uint16(2155)})
+		require.Equal(t, uint64(2155), row[0].AsUint64())
+		_, err := EncodeBinaryFieldValue(fields[0], int16(-1))
+		require.Error(t, err)
+	})
+}
+
+func TestEncodeBinaryFieldValueFloats(t *testing.T) {
+	t.Run("FLOAT round-trip", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_FLOAT}}
+		row := roundTrip(t, fields, []any{float32(3.5)})
+		require.InDelta(t, 3.5, row[0].AsFloat64(), 1e-6)
+	})
+
+	t.Run("FLOAT rejects finite input that overflows to ±Inf", func(t *testing.T) {
+		f := &Field{Type: MYSQL_TYPE_FLOAT}
+		_, err := EncodeBinaryFieldValue(f, float64(1e40))
+		require.Error(t, err)
+		_, err = EncodeBinaryFieldValue(f, float64(-1e40))
+		require.Error(t, err)
+	})
+
+	t.Run("FLOAT preserves caller-supplied Inf and NaN", func(t *testing.T) {
+		f := &Field{Type: MYSQL_TYPE_FLOAT}
+		_, err := EncodeBinaryFieldValue(f, math.Inf(1))
+		require.NoError(t, err)
+		_, err = EncodeBinaryFieldValue(f, math.Inf(-1))
+		require.NoError(t, err)
+		_, err = EncodeBinaryFieldValue(f, math.NaN())
+		require.NoError(t, err)
+	})
+
+	t.Run("DOUBLE round-trip", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_DOUBLE}}
+		row := roundTrip(t, fields, []any{float64(2.718281828459045)})
+		require.InDelta(t, 2.718281828459045, row[0].AsFloat64(), 1e-12)
+	})
+
+	t.Run("DOUBLE accepts integer input as float", func(t *testing.T) {
+		// Regression: FormatBinaryValue used to return int bits, which
+		// reinterpret as float64 garbage.
+		fields := []*Field{{Type: MYSQL_TYPE_DOUBLE}}
+		row := roundTrip(t, fields, []any{int64(42)})
+		require.InDelta(t, 42.0, row[0].AsFloat64(), 1e-12)
+	})
+}
+
+func TestEncodeBinaryFieldValueTemporals(t *testing.T) {
+	t.Run("DATE round-trip from string", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_DATE}}
+		row := roundTrip(t, fields, []any{"2026-04-28"})
+		require.Equal(t, "2026-04-28", string(row[0].AsString()))
+	})
+
+	t.Run("DATE zero sentinel", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_DATE}}
+		row := roundTrip(t, fields, []any{"0000-00-00"})
+		require.Equal(t, "0000-00-00", string(row[0].AsString()))
+	})
+
+	t.Run("DATETIME round-trip from string with fractional seconds", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_DATETIME}}
+		row := roundTrip(t, fields, []any{"2026-04-28 09:30:15.123456"})
+		require.Equal(t, "2026-04-28 09:30:15.123456", string(row[0].AsString()))
+	})
+
+	t.Run("DATETIME date-only string", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_DATETIME}}
+		row := roundTrip(t, fields, []any{"2026-04-28"})
+		require.Equal(t, "2026-04-28 00:00:00", string(row[0].AsString()))
+	})
+
+	t.Run("DATETIME zero sentinel", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_DATETIME}}
+		row := roundTrip(t, fields, []any{"0000-00-00 00:00:00"})
+		require.Equal(t, "0000-00-00 00:00:00", string(row[0].AsString()))
+	})
+
+	t.Run("TIMESTAMP round-trip", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_TIMESTAMP}}
+		row := roundTrip(t, fields, []any{"2026-04-28 09:30:15"})
+		require.Equal(t, "2026-04-28 09:30:15", string(row[0].AsString()))
+	})
+
+	t.Run("TIME round-trip", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_TIME}}
+		row := roundTrip(t, fields, []any{"12:34:56"})
+		require.Equal(t, "12:34:56", string(row[0].AsString()))
+	})
+
+	t.Run("TIME negative", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_TIME}}
+		row := roundTrip(t, fields, []any{"-12:34:56"})
+		require.Equal(t, "-12:34:56", string(row[0].AsString()))
+	})
+
+	t.Run("TIME large hour (>24)", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_TIME}}
+		row := roundTrip(t, fields, []any{"100:00:00"})
+		require.Equal(t, "100:00:00", string(row[0].AsString()))
+	})
+
+	t.Run("TIME with fractional seconds", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_TIME}}
+		row := roundTrip(t, fields, []any{"12:34:56.123456"})
+		require.Equal(t, "12:34:56.123456", string(row[0].AsString()))
+	})
+
+	t.Run("TIME zero sentinel", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_TIME}}
+		row := roundTrip(t, fields, []any{"00:00:00"})
+		require.Equal(t, "00:00:00", string(row[0].AsString()))
+	})
+
+	t.Run("TIME bytes input from parser", func(t *testing.T) {
+		// FieldValue.Value() returns []byte for TIME columns.
+		fields := []*Field{{Type: MYSQL_TYPE_TIME}}
+		row := roundTrip(t, fields, []any{[]byte("13:45:00")})
+		require.Equal(t, "13:45:00", string(row[0].AsString()))
+	})
+
+	t.Run("invalid DATE string errors", func(t *testing.T) {
+		f := &Field{Type: MYSQL_TYPE_DATE}
+		_, err := EncodeBinaryFieldValue(f, "not-a-date")
+		require.Error(t, err)
+	})
+
+	t.Run("invalid TIME string errors", func(t *testing.T) {
+		f := &Field{Type: MYSQL_TYPE_TIME}
+		_, err := EncodeBinaryFieldValue(f, "12:34")
+		require.Error(t, err)
+	})
+}
+
+func TestEncodeBinaryFieldValueNullables(t *testing.T) {
+	t.Run("sql.NullString valid", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_VARCHAR}}
+		row := roundTrip(t, fields, []any{sql.NullString{String: "hi", Valid: true}})
+		require.Equal(t, "hi", string(row[0].AsString()))
+	})
+
+	t.Run("sql.NullString invalid encodes as nil (NULL bitmap)", func(t *testing.T) {
+		// Encoder returns (nil, nil) for an invalid Null wrapper; row
+		// builders set the NULL bit and write no payload.
+		f := &Field{Type: MYSQL_TYPE_VARCHAR}
+		b, err := EncodeBinaryFieldValue(f, sql.NullString{Valid: false})
+		require.NoError(t, err)
+		require.Nil(t, b)
+	})
+
+	t.Run("sql.NullInt64 valid", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_LONGLONG}}
+		row := roundTrip(t, fields, []any{sql.NullInt64{Int64: 42, Valid: true}})
+		require.Equal(t, int64(42), row[0].AsInt64())
+	})
+
+	t.Run("sql.NullFloat64 valid", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_DOUBLE}}
+		row := roundTrip(t, fields, []any{sql.NullFloat64{Float64: 3.14, Valid: true}})
+		require.InDelta(t, 3.14, row[0].AsFloat64(), 1e-9)
+	})
+}
+
+// TestEncodeBinaryFieldValueNullableRowAlignment regresses the NULL-bitmap
+// alignment bug: a Null wrapper with Valid:false is non-nil, so a row
+// builder that only checks `v == nil` skips the bit and shifts subsequent
+// columns by one byte. The fix routes literal nil, driver.Valuer→nil, and
+// MYSQL_TYPE_NULL through a single (nil, nil) signal.
+func TestEncodeBinaryFieldValueNullableRowAlignment(t *testing.T) {
+	t.Run("sql.NullString Valid:false followed by non-NULL column", func(t *testing.T) {
+		fields := []*Field{
+			{Name: []byte("c_first"), Type: MYSQL_TYPE_VARCHAR},
+			{Name: []byte("c_second"), Type: MYSQL_TYPE_VARCHAR},
+		}
+		row := roundTrip(t, fields, []any{
+			sql.NullString{Valid: false},
+			"after",
+		})
+		require.Nil(t, row[0].Value(), "column 0 must be NULL, not shifted")
+		require.Equal(t, "after", string(row[1].AsString()),
+			"column 1 must round-trip intact, not consume column 0's bytes")
+	})
+
+	t.Run("sql.NullInt64 Valid:false followed by non-NULL column", func(t *testing.T) {
+		fields := []*Field{
+			{Name: []byte("c_first"), Type: MYSQL_TYPE_LONGLONG},
+			{Name: []byte("c_second"), Type: MYSQL_TYPE_VARCHAR},
+		}
+		row := roundTrip(t, fields, []any{
+			sql.NullInt64{Valid: false},
+			"after",
+		})
+		require.Nil(t, row[0].Value())
+		require.Equal(t, "after", string(row[1].AsString()))
+	})
+
+	t.Run("MYSQL_TYPE_NULL column followed by non-NULL column", func(t *testing.T) {
+		fields := []*Field{
+			{Name: []byte("c_null"), Type: MYSQL_TYPE_NULL},
+			{Name: []byte("c_second"), Type: MYSQL_TYPE_VARCHAR},
+		}
+		row := roundTrip(t, fields, []any{
+			"ignored",
+			"after",
+		})
+		require.Nil(t, row[0].Value())
+		require.Equal(t, "after", string(row[1].AsString()))
+	})
+}
+
+// TestEncodeBinaryFieldValueProxyRoundTrip simulates the proxy flow: parse
+// an upstream row, take Value() per column, encode again, parse again, and
+// check the values match. Pre-fix, Value() returned ASCII for DATE/DATETIME/
+// TIME and the encoder length-encoded that ASCII, producing unparseable bytes.
+func TestEncodeBinaryFieldValueProxyRoundTrip(t *testing.T) {
+	fields := []*Field{
+		{Name: []byte("c_tiny"), Type: MYSQL_TYPE_TINY},
+		{Name: []byte("c_short"), Type: MYSQL_TYPE_SHORT, Flag: UNSIGNED_FLAG},
+		{Name: []byte("c_long"), Type: MYSQL_TYPE_LONG},
+		{Name: []byte("c_ll"), Type: MYSQL_TYPE_LONGLONG, Flag: UNSIGNED_FLAG},
+		{Name: []byte("c_float"), Type: MYSQL_TYPE_FLOAT},
+		{Name: []byte("c_double"), Type: MYSQL_TYPE_DOUBLE},
+		{Name: []byte("c_varchar"), Type: MYSQL_TYPE_VARCHAR},
+		{Name: []byte("c_blob"), Type: MYSQL_TYPE_BLOB},
+		{Name: []byte("c_decimal"), Type: MYSQL_TYPE_NEWDECIMAL},
+		{Name: []byte("c_json"), Type: MYSQL_TYPE_JSON},
+		{Name: []byte("c_date"), Type: MYSQL_TYPE_DATE},
+		{Name: []byte("c_datetime"), Type: MYSQL_TYPE_DATETIME},
+		{Name: []byte("c_timestamp"), Type: MYSQL_TYPE_TIMESTAMP},
+		{Name: []byte("c_time"), Type: MYSQL_TYPE_TIME},
+	}
+	original := []any{
+		int8(-7),
+		uint16(2026),
+		int32(-1234567),
+		uint64(9223372036854775000),
+		float32(3.5),
+		float64(2.718281828459045),
+		"hello",
+		[]byte{0x00, 0x01, 0x02},
+		"1234.5678",
+		[]byte(`{"k":"v"}`),
+		"2026-04-28",
+		"2026-04-28 09:30:15.123456",
+		"2026-04-28 09:30:15",
+		"-100:34:56",
+	}
+
+	// First leg: encode original → parse → take Value() per field.
+	parsed1 := roundTrip(t, fields, original)
+	intermediate := make([]any, len(fields))
+	for i, fv := range parsed1 {
+		intermediate[i] = fv.Value()
+	}
+
+	// Second leg: encode the intermediate values → parse again.
+	parsed2 := roundTrip(t, fields, intermediate)
+
+	// Both passes must agree.
+	for i := range fields {
+		require.Equal(t, parsed1[i].Value(), parsed2[i].Value(),
+			"column %d (%s) diverged on round-trip", i, fields[i].Name)
+	}
+}
+
+// TestEncodeBinaryFieldValueBool exercises the bool path used by sql.NullBool
+// and bare bool values destined for TINYINT(1) (MySQL's "BOOL" alias).
+func TestEncodeBinaryFieldValueBool(t *testing.T) {
+	t.Run("bare bool true → 1", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_TINY, Flag: UNSIGNED_FLAG}}
+		row := roundTrip(t, fields, []any{true})
+		require.Equal(t, uint64(1), row[0].AsUint64())
+	})
+
+	t.Run("bare bool false → 0", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_TINY, Flag: UNSIGNED_FLAG}}
+		row := roundTrip(t, fields, []any{false})
+		require.Equal(t, uint64(0), row[0].AsUint64())
+	})
+
+	t.Run("sql.NullBool valid:true", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_TINY, Flag: UNSIGNED_FLAG}}
+		row := roundTrip(t, fields, []any{sql.NullBool{Bool: true, Valid: true}})
+		require.Equal(t, uint64(1), row[0].AsUint64())
+	})
+
+	t.Run("sql.NullBool valid:false → NULL", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_TINY, Flag: UNSIGNED_FLAG}}
+		row := roundTrip(t, fields, []any{sql.NullBool{Valid: false}})
+		require.Nil(t, row[0].Value())
+	})
+
+	t.Run("bool rejected for FLOAT", func(t *testing.T) {
+		f := &Field{Type: MYSQL_TYPE_FLOAT}
+		_, err := EncodeBinaryFieldValue(f, true)
+		require.Error(t, err)
+	})
+
+	t.Run("bool rejected for non-TINY integer types", func(t *testing.T) {
+		// MySQL BOOL is strictly TINYINT(1); accepting bool for wider int
+		// types would silently paper over caller bugs.
+		for _, fieldType := range []byte{
+			MYSQL_TYPE_SHORT, MYSQL_TYPE_INT24, MYSQL_TYPE_LONG, MYSQL_TYPE_LONGLONG,
+		} {
+			f := &Field{Type: fieldType}
+			_, err := EncodeBinaryFieldValue(f, true)
+			require.Error(t, err, "bool must be rejected for column type %d", fieldType)
+		}
+	})
+}
+
+func TestEncodeBinaryFieldValueValidationErrors(t *testing.T) {
+	t.Run("DATETIME with trailing whitespace and no time part rejects", func(t *testing.T) {
+		f := &Field{Type: MYSQL_TYPE_DATETIME}
+		_, err := EncodeBinaryFieldValue(f, "2026-04-28 ")
+		require.Error(t, err)
+	})
+
+	t.Run("DATE max 4-digit year accepted, 5-digit string rejected at format check", func(t *testing.T) {
+		f := &Field{Type: MYSQL_TYPE_DATE}
+		_, err := EncodeBinaryFieldValue(f, "9999-01-01")
+		require.NoError(t, err)
+		// "10000-01-01" is len=11, failing the strict YYYY-MM-DD format check.
+		_, err = EncodeBinaryFieldValue(f, "10000-01-01")
+		require.Error(t, err)
+	})
+
+	t.Run("TIME with >6 fractional digits rejects", func(t *testing.T) {
+		f := &Field{Type: MYSQL_TYPE_TIME}
+		_, err := EncodeBinaryFieldValue(f, "12:34:56.1234567")
+		require.Error(t, err)
+	})
+
+	t.Run("TIME with hours > 838 rejects", func(t *testing.T) {
+		f := &Field{Type: MYSQL_TYPE_TIME}
+		_, err := EncodeBinaryFieldValue(f, "839:00:00")
+		require.Error(t, err)
+		_, err = EncodeBinaryFieldValue(f, "838:59:59")
+		require.NoError(t, err)
+	})
+
+	t.Run("TIME at the absolute maximum 838:59:59.999999 round-trips", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_TIME}}
+		row := roundTrip(t, fields, []any{"838:59:59.999999"})
+		require.Equal(t, "838:59:59.999999", string(row[0].AsString()))
+	})
+
+	t.Run("DATETIME with invalid time-part rejects", func(t *testing.T) {
+		f := &Field{Type: MYSQL_TYPE_DATETIME}
+		_, err := EncodeBinaryFieldValue(f, "2026-04-28 25:00:00")
+		require.Error(t, err)
+	})
+
+	t.Run("trailing-dot fraction rejected for TIME and DATETIME", func(t *testing.T) {
+		fTime := &Field{Type: MYSQL_TYPE_TIME}
+		_, err := EncodeBinaryFieldValue(fTime, "12:34:56.")
+		require.Error(t, err)
+
+		fDt := &Field{Type: MYSQL_TYPE_DATETIME}
+		_, err = EncodeBinaryFieldValue(fDt, "2026-04-28 12:34:56.")
+		require.Error(t, err)
+	})
+
+	t.Run("empty string rejected for DATE / DATETIME / TIME", func(t *testing.T) {
+		for _, fieldType := range []byte{
+			MYSQL_TYPE_DATE, MYSQL_TYPE_DATETIME, MYSQL_TYPE_TIMESTAMP, MYSQL_TYPE_TIME,
+		} {
+			f := &Field{Type: fieldType}
+			_, err := EncodeBinaryFieldValue(f, "")
+			require.Error(t, err, "empty string must be rejected for column type %d", fieldType)
+		}
+	})
+
+	t.Run("negative all-zero TIME collapses to zero sentinel", func(t *testing.T) {
+		fields := []*Field{{Type: MYSQL_TYPE_TIME}}
+		row := roundTrip(t, fields, []any{"-00:00:00"})
+		// The wire format has no negative-zero TIME.
+		require.Equal(t, "00:00:00", string(row[0].AsString()))
+	})
+
+	t.Run("unsupported field type errors", func(t *testing.T) {
+		// TIMESTAMP2 is binlog-internal, not valid on the resultset wire.
+		f := &Field{Type: MYSQL_TYPE_TIMESTAMP2}
+		_, err := EncodeBinaryFieldValue(f, "2026-04-28 09:30:15")
+		require.Error(t, err)
+	})
+
+	t.Run("nil *Field rejected, not panicked", func(t *testing.T) {
+		_, err := EncodeBinaryFieldValue(nil, int64(1))
+		require.Error(t, err)
+	})
+}
+
+// TestEncodeBinaryFieldValueTypedNilSlice verifies a typed-nil []byte
+// (e.g. var b []byte) encodes as NULL, not an empty length-encoded string.
+// The interface holding the typed nil is itself non-nil, so the top-level
+// nil check misses it; each []byte branch handles it explicitly.
+func TestEncodeBinaryFieldValueTypedNilSlice(t *testing.T) {
+	var b []byte
+
+	t.Run("VARCHAR typed-nil []byte → NULL, next column intact", func(t *testing.T) {
+		fields := []*Field{
+			{Name: []byte("c_first"), Type: MYSQL_TYPE_VARCHAR},
+			{Name: []byte("c_second"), Type: MYSQL_TYPE_VARCHAR},
+		}
+		row := roundTrip(t, fields, []any{b, "after"})
+		require.Nil(t, row[0].Value(), "typed-nil []byte must encode as NULL")
+		require.Equal(t, "after", string(row[1].AsString()))
+	})
+
+	t.Run("DATE typed-nil []byte → NULL", func(t *testing.T) {
+		fields := []*Field{{Name: []byte("c_date"), Type: MYSQL_TYPE_DATE}}
+		row := roundTrip(t, fields, []any{b})
+		require.Nil(t, row[0].Value())
+	})
+
+	t.Run("DATETIME typed-nil []byte → NULL", func(t *testing.T) {
+		fields := []*Field{{Name: []byte("c_dt"), Type: MYSQL_TYPE_DATETIME}}
+		row := roundTrip(t, fields, []any{b})
+		require.Nil(t, row[0].Value())
+	})
+
+	t.Run("TIME typed-nil []byte → NULL", func(t *testing.T) {
+		fields := []*Field{{Name: []byte("c_time"), Type: MYSQL_TYPE_TIME}}
+		row := roundTrip(t, fields, []any{b})
+		require.Nil(t, row[0].Value())
+	})
+
+	t.Run("empty non-nil []byte still aligns the wire (next column intact)", func(t *testing.T) {
+		// FieldValue's parser collapses a zero-length string back to a
+		// typed-nil slice, so .Value() can't distinguish empty from NULL.
+		// We instead verify wire alignment: column 1 round-trips intact
+		// only if column 0 wrote a length=0 prefix, which is what
+		// differentiates empty from NULL on the wire.
+		fields := []*Field{
+			{Name: []byte("c_first"), Type: MYSQL_TYPE_VARCHAR},
+			{Name: []byte("c_second"), Type: MYSQL_TYPE_VARCHAR},
+		}
+		row := roundTrip(t, fields, []any{[]byte{}, "after"})
+		require.Equal(t, "after", string(row[1].AsString()))
+	})
+}

--- a/mysql/resultset_helper_test.go
+++ b/mysql/resultset_helper_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -427,6 +428,20 @@ func TestEncodeBinaryFieldValueValidationErrors(t *testing.T) {
 		// "10000-01-01" is len=11, failing the strict YYYY-MM-DD format check.
 		_, err = EncodeBinaryFieldValue(f, "10000-01-01")
 		require.Error(t, err)
+	})
+
+	t.Run("DATE / DATETIME from time.Time with year out of range rejects", func(t *testing.T) {
+		// time.Time.Year() returns an int with no upstream bound; the
+		// uint16 cast in pack* would silently truncate. Reject explicitly.
+		fDate := &Field{Type: MYSQL_TYPE_DATE}
+		fDt := &Field{Type: MYSQL_TYPE_DATETIME}
+		for _, year := range []int{-1, 10000, 70000} {
+			tm := time.Date(year, 1, 1, 0, 0, 0, 0, time.UTC)
+			_, err := EncodeBinaryFieldValue(fDate, tm)
+			require.Error(t, err, "DATE year %d must be rejected", year)
+			_, err = EncodeBinaryFieldValue(fDt, tm)
+			require.Error(t, err, "DATETIME year %d must be rejected", year)
+		}
 	})
 
 	t.Run("TIME with >6 fractional digits rejects", func(t *testing.T) {

--- a/mysql/resultset_helper_test.go
+++ b/mysql/resultset_helper_test.go
@@ -266,6 +266,32 @@ func TestEncodeBinaryFieldValueNullables(t *testing.T) {
 	})
 }
 
+// TestEncodeBinaryFieldValueEmptyStringNotNull regresses the empty-string vs
+// NULL confusion: RowData.ParseBinary yields []byte(nil) for an empty
+// length-encoded string, so a nil []byte for a string column must encode as a
+// length-0 string, not NULL. Genuine NULLs come from the literal-nil path.
+func TestEncodeBinaryFieldValueEmptyStringNotNull(t *testing.T) {
+	f := &Field{Type: MYSQL_TYPE_VARCHAR}
+
+	// A length-encoded empty string is a single length byte of 0x00.
+	for _, v := range []any{[]byte(nil), []byte{}, ""} {
+		b, err := EncodeBinaryFieldValue(f, v)
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x00}, b, "empty value %#v must encode as a length-0 string, not NULL", v)
+	}
+
+	b, err := EncodeBinaryFieldValue(f, nil)
+	require.NoError(t, err)
+	require.Nil(t, b)
+
+	// Proxy flow: an empty string parsed off the wire comes back as []byte(nil),
+	// and re-encoding it must stay an empty string rather than flip to NULL.
+	row := roundTrip(t, []*Field{f}, []any{""})
+	reencoded, err := EncodeBinaryFieldValue(f, row[0].Value())
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x00}, reencoded)
+}
+
 // TestEncodeBinaryFieldValueNullableRowAlignment regresses the NULL-bitmap
 // alignment bug: a Null wrapper with Valid:false is non-nil, so a row
 // builder that only checks `v == nil` skips the bit and shifts subsequent
@@ -511,21 +537,13 @@ func TestEncodeBinaryFieldValueValidationErrors(t *testing.T) {
 }
 
 // TestEncodeBinaryFieldValueTypedNilSlice verifies a typed-nil []byte
-// (e.g. var b []byte) encodes as NULL, not an empty length-encoded string.
-// The interface holding the typed nil is itself non-nil, so the top-level
-// nil check misses it; each []byte branch handles it explicitly.
+// (e.g. var b []byte) for temporal columns encodes as NULL: a nil temporal has
+// no meaningful empty value. String-like columns instead treat it as an empty
+// string (see TestEncodeBinaryFieldValueEmptyStringNotNull). The interface
+// holding the typed nil is itself non-nil, so the top-level nil check misses
+// it; each []byte branch handles it explicitly.
 func TestEncodeBinaryFieldValueTypedNilSlice(t *testing.T) {
 	var b []byte
-
-	t.Run("VARCHAR typed-nil []byte → NULL, next column intact", func(t *testing.T) {
-		fields := []*Field{
-			{Name: []byte("c_first"), Type: MYSQL_TYPE_VARCHAR},
-			{Name: []byte("c_second"), Type: MYSQL_TYPE_VARCHAR},
-		}
-		row := roundTrip(t, fields, []any{b, "after"})
-		require.Nil(t, row[0].Value(), "typed-nil []byte must encode as NULL")
-		require.Equal(t, "after", string(row[1].AsString()))
-	})
 
 	t.Run("DATE typed-nil []byte → NULL", func(t *testing.T) {
 		fields := []*Field{{Name: []byte("c_date"), Type: MYSQL_TYPE_DATE}}

--- a/mysql/util_test.go
+++ b/mysql/util_test.go
@@ -117,7 +117,10 @@ func TestToBinaryDateTime(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-			if len(got) == 0 {
+			// A zero time.Time encodes as a single zero length byte (the
+			// MySQL "0000-00-00 00:00:00" sentinel).
+			if test.Data.IsZero() {
+				require.Equal(t, []byte{0}, got)
 				return
 			}
 			tmp := test.Expect(int(got[0]), got[1:])

--- a/server/resp.go
+++ b/server/resp.go
@@ -227,10 +227,13 @@ func (c *Conn) writeStreamBinaryRows(sr *mysql.StreamResult) error {
 	data := make([]byte, 4, 1024)
 	columnCount := len(sr.Fields)
 	bitmapLen := (columnCount + 7 + 2) >> 3
+	// Reused across rows; data's append copies the bytes before each
+	// iteration mutates them.
+	nullBitmap := make([]byte, bitmapLen)
 
 	for row := range sr.RowsChan() {
 		data = data[0:4]
-		nullBitmap := make([]byte, bitmapLen)
+		clear(nullBitmap)
 
 		// Binary row header: 0x00
 		data = append(data, 0x00)
@@ -238,23 +241,17 @@ func (c *Conn) writeStreamBinaryRows(sr *mysql.StreamResult) error {
 		data = append(data, nullBitmap...)
 
 		for j, v := range row {
-			if v == nil {
-				// Set null bit: bit position = (column index + 2)
-				nullBitmap[(j+2)/8] |= 1 << (uint(j+2) % 8)
-				continue
-			}
-
-			b, err := mysql.FormatBinaryValue(v)
+			b, err := mysql.EncodeBinaryFieldValue(sr.Fields[j], v)
 			if err != nil {
 				return err
 			}
-
-			// For VAR_STRING type, use length-encoded string
-			if sr.Fields[j].Type == mysql.MYSQL_TYPE_VAR_STRING {
-				data = append(data, mysql.PutLengthEncodedString(b)...)
-			} else {
-				data = append(data, b...)
+			if b == nil {
+				// Encoder signaled NULL. Bit position is (column index + 2)
+				// per the binary protocol.
+				nullBitmap[(j+2)/8] |= 1 << (uint(j+2) % 8)
+				continue
 			}
+			data = append(data, b...)
 		}
 
 		// Copy null bitmap to the correct position

--- a/server/resp.go
+++ b/server/resp.go
@@ -265,10 +265,13 @@ func (c *Conn) writeStreamBinaryRows(sr *mysql.StreamResult) error {
 	data := make([]byte, 4, 1024)
 	columnCount := len(sr.Fields)
 	bitmapLen := (columnCount + 7 + 2) >> 3
+	// Reused across rows; data's append copies the bytes before each
+	// iteration mutates them.
+	nullBitmap := make([]byte, bitmapLen)
 
 	for row := range sr.RowsChan() {
 		data = data[0:4]
-		nullBitmap := make([]byte, bitmapLen)
+		clear(nullBitmap)
 
 		// Binary row header: 0x00
 		data = append(data, 0x00)
@@ -276,23 +279,17 @@ func (c *Conn) writeStreamBinaryRows(sr *mysql.StreamResult) error {
 		data = append(data, nullBitmap...)
 
 		for j, v := range row {
-			if v == nil {
-				// Set null bit: bit position = (column index + 2)
-				nullBitmap[(j+2)/8] |= 1 << (uint(j+2) % 8)
-				continue
-			}
-
-			b, err := mysql.FormatBinaryValue(v)
+			b, err := mysql.EncodeBinaryFieldValue(sr.Fields[j], v)
 			if err != nil {
 				return err
 			}
-
-			// For VAR_STRING type, use length-encoded string
-			if sr.Fields[j].Type == mysql.MYSQL_TYPE_VAR_STRING {
-				data = append(data, mysql.PutLengthEncodedString(b)...)
-			} else {
-				data = append(data, b...)
+			if b == nil {
+				// Encoder signaled NULL. Bit position is (column index + 2)
+				// per the binary protocol.
+				nullBitmap[(j+2)/8] |= 1 << (uint(j+2) % 8)
+				continue
 			}
+			data = append(data, b...)
 		}
 
 		// Copy null bitmap to the correct position

--- a/server/resp_test.go
+++ b/server/resp_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/packet"
@@ -515,6 +516,30 @@ func TestStreamResultEmptyResult(t *testing.T) {
 	require.True(t, len(clientConn.WriteBuffered) > 0)
 }
 
+// extractBinaryRowPackets parses the test write buffer and returns packets
+// starting with the 0x00 binary-row header. The streaming path never emits
+// an OK packet (also 0x00) inline, so the marker is unambiguous here.
+func extractBinaryRowPackets(data []byte) [][]byte {
+	var rowPackets [][]byte
+	pos := 0
+	for pos < len(data) {
+		if pos+4 > len(data) {
+			break
+		}
+		pktLen := int(uint32(data[pos]) | uint32(data[pos+1])<<8 | uint32(data[pos+2])<<16)
+		pos += 4
+		if pos+pktLen > len(data) {
+			break
+		}
+		pktData := data[pos : pos+pktLen]
+		pos += pktLen
+		if len(pktData) > 0 && pktData[0] == 0x00 {
+			rowPackets = append(rowPackets, pktData)
+		}
+	}
+	return rowPackets
+}
+
 // TestConnWriteStreamResultsetBinary tests binary protocol streaming with data parsing.
 func TestConnWriteStreamResultsetBinary(t *testing.T) {
 	clientConn := &mockconn.MockConn{MultiWrite: true}
@@ -534,32 +559,9 @@ func TestConnWriteStreamResultsetBinary(t *testing.T) {
 		sr.WriteRow(ctx, []any{int64(2), "bob"})
 	}()
 
-	err := conn.WriteValue(sr.AsResult())
-	require.NoError(t, err)
+	require.NoError(t, conn.WriteValue(sr.AsResult()))
 
-	// Parse packets from the buffer
-	data := clientConn.WriteBuffered
-	var rowPackets [][]byte
-	pos := 0
-	for pos < len(data) {
-		if pos+4 > len(data) {
-			break
-		}
-		// Packet header: 3 bytes length + 1 byte sequence
-		pktLen := int(uint32(data[pos]) | uint32(data[pos+1])<<8 | uint32(data[pos+2])<<16)
-		pos += 4
-		if pos+pktLen > len(data) {
-			break
-		}
-		pktData := data[pos : pos+pktLen]
-		pos += pktLen
-
-		// Binary row packets start with 0x00 header
-		if len(pktData) > 0 && pktData[0] == 0x00 {
-			rowPackets = append(rowPackets, pktData)
-		}
-	}
-
+	rowPackets := extractBinaryRowPackets(clientConn.WriteBuffered)
 	require.Len(t, rowPackets, 2, "Should have 2 binary row packets")
 
 	// Parse first row
@@ -595,30 +597,9 @@ func TestConnWriteStreamResultsetBinaryWithNull(t *testing.T) {
 		sr.WriteRow(ctx, []any{"data", nil})
 	}()
 
-	err := conn.WriteValue(sr.AsResult())
-	require.NoError(t, err)
+	require.NoError(t, conn.WriteValue(sr.AsResult()))
 
-	// Parse packets
-	data := clientConn.WriteBuffered
-	var rowPackets [][]byte
-	pos := 0
-	for pos < len(data) {
-		if pos+4 > len(data) {
-			break
-		}
-		pktLen := int(uint32(data[pos]) | uint32(data[pos+1])<<8 | uint32(data[pos+2])<<16)
-		pos += 4
-		if pos+pktLen > len(data) {
-			break
-		}
-		pktData := data[pos : pos+pktLen]
-		pos += pktLen
-
-		if len(pktData) > 0 && pktData[0] == 0x00 {
-			rowPackets = append(rowPackets, pktData)
-		}
-	}
-
+	rowPackets := extractBinaryRowPackets(clientConn.WriteBuffered)
 	require.Len(t, rowPackets, 2)
 
 	// Parse first row: NULL, "value"
@@ -632,4 +613,179 @@ func TestConnWriteStreamResultsetBinaryWithNull(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "data", string(row2[0].AsString()))
 	require.Nil(t, row2[1].Value()) // NULL
+}
+
+// TestConnWriteStreamResultsetBinaryNarrowIntegers verifies the streaming
+// binary writer respects the declared column width for fixed-width integers
+// (TINY/SHORT/INT24/LONG/LONGLONG, signed and unsigned). Pre-fix, the writer
+// always emitted 8 bytes regardless of declared type.
+func TestConnWriteStreamResultsetBinaryNarrowIntegers(t *testing.T) {
+	clientConn := &mockconn.MockConn{MultiWrite: true}
+	conn := &Conn{Conn: packet.NewConn(clientConn)}
+
+	fields := []*mysql.Field{
+		{Name: []byte("c_tiny"), Type: mysql.MYSQL_TYPE_TINY},
+		{Name: []byte("c_utiny"), Type: mysql.MYSQL_TYPE_TINY, Flag: mysql.UNSIGNED_FLAG},
+		{Name: []byte("c_short"), Type: mysql.MYSQL_TYPE_SHORT},
+		{Name: []byte("c_year"), Type: mysql.MYSQL_TYPE_YEAR, Flag: mysql.UNSIGNED_FLAG},
+		{Name: []byte("c_int24"), Type: mysql.MYSQL_TYPE_INT24},
+		{Name: []byte("c_long"), Type: mysql.MYSQL_TYPE_LONG},
+		{Name: []byte("c_longlong"), Type: mysql.MYSQL_TYPE_LONGLONG},
+	}
+	sr := mysql.NewStreamResult(fields, 1, true)
+
+	go func() {
+		defer sr.Close()
+		ctx := context.Background()
+		sr.WriteRow(ctx, []any{
+			int8(-7), uint8(200),
+			int16(-12345), uint16(2026),
+			int32(-1234567), int32(2147483600),
+			int64(9223372036854775000),
+		})
+	}()
+
+	require.NoError(t, conn.WriteValue(sr.AsResult()))
+
+	rowPackets := extractBinaryRowPackets(clientConn.WriteBuffered)
+	require.Len(t, rowPackets, 1)
+
+	row, err := mysql.RowData(rowPackets[0]).ParseBinary(fields, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(-7), row[0].AsInt64())
+	require.Equal(t, uint64(200), row[1].AsUint64())
+	require.Equal(t, int64(-12345), row[2].AsInt64())
+	require.Equal(t, uint64(2026), row[3].AsUint64())
+	require.Equal(t, int64(-1234567), row[4].AsInt64())
+	require.Equal(t, int64(2147483600), row[5].AsInt64())
+	require.Equal(t, int64(9223372036854775000), row[6].AsInt64())
+}
+
+// TestConnWriteStreamResultsetBinaryFloats verifies FLOAT is encoded as
+// 4 bytes of Float32bits (not truncated Float64bits) and DOUBLE as 8 bytes
+// of Float64bits.
+func TestConnWriteStreamResultsetBinaryFloats(t *testing.T) {
+	clientConn := &mockconn.MockConn{MultiWrite: true}
+	conn := &Conn{Conn: packet.NewConn(clientConn)}
+
+	fields := []*mysql.Field{
+		{Name: []byte("c_float"), Type: mysql.MYSQL_TYPE_FLOAT},
+		{Name: []byte("c_double"), Type: mysql.MYSQL_TYPE_DOUBLE},
+	}
+	sr := mysql.NewStreamResult(fields, 1, true)
+
+	go func() {
+		defer sr.Close()
+		sr.WriteRow(context.Background(), []any{float32(3.5), float64(2.718281828459045)})
+	}()
+
+	require.NoError(t, conn.WriteValue(sr.AsResult()))
+
+	rowPackets := extractBinaryRowPackets(clientConn.WriteBuffered)
+	require.Len(t, rowPackets, 1)
+
+	row, err := mysql.RowData(rowPackets[0]).ParseBinary(fields, nil)
+	require.NoError(t, err)
+	require.InDelta(t, 3.5, row[0].AsFloat64(), 1e-6)
+	require.InDelta(t, 2.718281828459045, row[1].AsFloat64(), 1e-12)
+}
+
+// TestConnWriteStreamResultsetBinaryLengthEncodedStrings verifies that
+// length-encoded variable-width types beyond MYSQL_TYPE_VAR_STRING (VARCHAR,
+// STRING, BLOB, DECIMAL, JSON) are length-prefixed on the wire.
+func TestConnWriteStreamResultsetBinaryLengthEncodedStrings(t *testing.T) {
+	clientConn := &mockconn.MockConn{MultiWrite: true}
+	conn := &Conn{Conn: packet.NewConn(clientConn)}
+
+	fields := []*mysql.Field{
+		{Name: []byte("c_varchar"), Type: mysql.MYSQL_TYPE_VARCHAR},
+		{Name: []byte("c_string"), Type: mysql.MYSQL_TYPE_STRING},
+		{Name: []byte("c_blob"), Type: mysql.MYSQL_TYPE_BLOB},
+		{Name: []byte("c_decimal"), Type: mysql.MYSQL_TYPE_NEWDECIMAL},
+		{Name: []byte("c_json"), Type: mysql.MYSQL_TYPE_JSON},
+	}
+	sr := mysql.NewStreamResult(fields, 1, true)
+
+	go func() {
+		defer sr.Close()
+		sr.WriteRow(context.Background(), []any{
+			"abc",
+			"hello",
+			[]byte{0x00, 0x01, 0x02},
+			"1234.5678",
+			[]byte(`{"k":"v"}`),
+		})
+	}()
+
+	require.NoError(t, conn.WriteValue(sr.AsResult()))
+
+	rowPackets := extractBinaryRowPackets(clientConn.WriteBuffered)
+	require.Len(t, rowPackets, 1)
+
+	row, err := mysql.RowData(rowPackets[0]).ParseBinary(fields, nil)
+	require.NoError(t, err)
+	require.Equal(t, "abc", string(row[0].AsString()))
+	require.Equal(t, "hello", string(row[1].AsString()))
+	require.Equal(t, []byte{0x00, 0x01, 0x02}, row[2].AsString())
+	require.Equal(t, "1234.5678", string(row[3].AsString()))
+	require.Equal(t, `{"k":"v"}`, string(row[4].AsString()))
+}
+
+// TestConnWriteStreamResultsetBinaryTemporals verifies that DATE / DATETIME /
+// TIMESTAMP / TIME columns receive a length-prefixed packed binary
+// representation when written from a time.Time value.
+func TestConnWriteStreamResultsetBinaryTemporals(t *testing.T) {
+	clientConn := &mockconn.MockConn{MultiWrite: true}
+	conn := &Conn{Conn: packet.NewConn(clientConn)}
+
+	fields := []*mysql.Field{
+		{Name: []byte("c_date"), Type: mysql.MYSQL_TYPE_DATE},
+		{Name: []byte("c_datetime"), Type: mysql.MYSQL_TYPE_DATETIME},
+		{Name: []byte("c_timestamp"), Type: mysql.MYSQL_TYPE_TIMESTAMP},
+	}
+	sr := mysql.NewStreamResult(fields, 1, true)
+
+	dt := time.Date(2026, time.April, 28, 9, 30, 15, 0, time.UTC)
+	go func() {
+		defer sr.Close()
+		sr.WriteRow(context.Background(), []any{dt, dt, dt})
+	}()
+
+	require.NoError(t, conn.WriteValue(sr.AsResult()))
+
+	rowPackets := extractBinaryRowPackets(clientConn.WriteBuffered)
+	require.Len(t, rowPackets, 1)
+
+	row, err := mysql.RowData(rowPackets[0]).ParseBinary(fields, nil)
+	require.NoError(t, err)
+	require.Equal(t, "2026-04-28", string(row[0].AsString()))
+	require.Equal(t, "2026-04-28 09:30:15", string(row[1].AsString()))
+	require.Equal(t, "2026-04-28 09:30:15", string(row[2].AsString()))
+}
+
+// TestConnWriteStreamResultsetBinaryTime verifies the streaming binary writer
+// emits a length-prefixed packed TIME payload with no embedded date.
+func TestConnWriteStreamResultsetBinaryTime(t *testing.T) {
+	clientConn := &mockconn.MockConn{MultiWrite: true}
+	conn := &Conn{Conn: packet.NewConn(clientConn)}
+
+	fields := []*mysql.Field{
+		{Name: []byte("c_time"), Type: mysql.MYSQL_TYPE_TIME},
+	}
+	sr := mysql.NewStreamResult(fields, 1, true)
+
+	tm := time.Date(0, 1, 1, 12, 34, 56, 0, time.UTC)
+	go func() {
+		defer sr.Close()
+		sr.WriteRow(context.Background(), []any{tm})
+	}()
+
+	require.NoError(t, conn.WriteValue(sr.AsResult()))
+
+	rowPackets := extractBinaryRowPackets(clientConn.WriteBuffered)
+	require.Len(t, rowPackets, 1)
+
+	row, err := mysql.RowData(rowPackets[0]).ParseBinary(fields, nil)
+	require.NoError(t, err)
+	require.Equal(t, "12:34:56", string(row[0].AsString()))
 }

--- a/server/resp_test.go
+++ b/server/resp_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/packet"
@@ -545,6 +546,30 @@ func TestStreamResultEmptyResult(t *testing.T) {
 	require.True(t, len(clientConn.WriteBuffered) > 0)
 }
 
+// extractBinaryRowPackets parses the test write buffer and returns packets
+// starting with the 0x00 binary-row header. The streaming path never emits
+// an OK packet (also 0x00) inline, so the marker is unambiguous here.
+func extractBinaryRowPackets(data []byte) [][]byte {
+	var rowPackets [][]byte
+	pos := 0
+	for pos < len(data) {
+		if pos+4 > len(data) {
+			break
+		}
+		pktLen := int(uint32(data[pos]) | uint32(data[pos+1])<<8 | uint32(data[pos+2])<<16)
+		pos += 4
+		if pos+pktLen > len(data) {
+			break
+		}
+		pktData := data[pos : pos+pktLen]
+		pos += pktLen
+		if len(pktData) > 0 && pktData[0] == 0x00 {
+			rowPackets = append(rowPackets, pktData)
+		}
+	}
+	return rowPackets
+}
+
 // TestConnWriteStreamResultsetBinary tests binary protocol streaming with data parsing.
 func TestConnWriteStreamResultsetBinary(t *testing.T) {
 	clientConn := &mockconn.MockConn{MultiWrite: true}
@@ -564,32 +589,9 @@ func TestConnWriteStreamResultsetBinary(t *testing.T) {
 		sr.WriteRow(ctx, []any{int64(2), "bob"})
 	}()
 
-	err := conn.WriteValue(sr.AsResult())
-	require.NoError(t, err)
+	require.NoError(t, conn.WriteValue(sr.AsResult()))
 
-	// Parse packets from the buffer
-	data := clientConn.WriteBuffered
-	var rowPackets [][]byte
-	pos := 0
-	for pos < len(data) {
-		if pos+4 > len(data) {
-			break
-		}
-		// Packet header: 3 bytes length + 1 byte sequence
-		pktLen := int(uint32(data[pos]) | uint32(data[pos+1])<<8 | uint32(data[pos+2])<<16)
-		pos += 4
-		if pos+pktLen > len(data) {
-			break
-		}
-		pktData := data[pos : pos+pktLen]
-		pos += pktLen
-
-		// Binary row packets start with 0x00 header
-		if len(pktData) > 0 && pktData[0] == 0x00 {
-			rowPackets = append(rowPackets, pktData)
-		}
-	}
-
+	rowPackets := extractBinaryRowPackets(clientConn.WriteBuffered)
 	require.Len(t, rowPackets, 2, "Should have 2 binary row packets")
 
 	// Parse first row
@@ -625,30 +627,9 @@ func TestConnWriteStreamResultsetBinaryWithNull(t *testing.T) {
 		sr.WriteRow(ctx, []any{"data", nil})
 	}()
 
-	err := conn.WriteValue(sr.AsResult())
-	require.NoError(t, err)
+	require.NoError(t, conn.WriteValue(sr.AsResult()))
 
-	// Parse packets
-	data := clientConn.WriteBuffered
-	var rowPackets [][]byte
-	pos := 0
-	for pos < len(data) {
-		if pos+4 > len(data) {
-			break
-		}
-		pktLen := int(uint32(data[pos]) | uint32(data[pos+1])<<8 | uint32(data[pos+2])<<16)
-		pos += 4
-		if pos+pktLen > len(data) {
-			break
-		}
-		pktData := data[pos : pos+pktLen]
-		pos += pktLen
-
-		if len(pktData) > 0 && pktData[0] == 0x00 {
-			rowPackets = append(rowPackets, pktData)
-		}
-	}
-
+	rowPackets := extractBinaryRowPackets(clientConn.WriteBuffered)
 	require.Len(t, rowPackets, 2)
 
 	// Parse first row: NULL, "value"
@@ -662,4 +643,179 @@ func TestConnWriteStreamResultsetBinaryWithNull(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "data", string(row2[0].AsString()))
 	require.Nil(t, row2[1].Value()) // NULL
+}
+
+// TestConnWriteStreamResultsetBinaryNarrowIntegers verifies the streaming
+// binary writer respects the declared column width for fixed-width integers
+// (TINY/SHORT/INT24/LONG/LONGLONG, signed and unsigned). Pre-fix, the writer
+// always emitted 8 bytes regardless of declared type.
+func TestConnWriteStreamResultsetBinaryNarrowIntegers(t *testing.T) {
+	clientConn := &mockconn.MockConn{MultiWrite: true}
+	conn := &Conn{Conn: packet.NewConn(clientConn)}
+
+	fields := []*mysql.Field{
+		{Name: []byte("c_tiny"), Type: mysql.MYSQL_TYPE_TINY},
+		{Name: []byte("c_utiny"), Type: mysql.MYSQL_TYPE_TINY, Flag: mysql.UNSIGNED_FLAG},
+		{Name: []byte("c_short"), Type: mysql.MYSQL_TYPE_SHORT},
+		{Name: []byte("c_year"), Type: mysql.MYSQL_TYPE_YEAR, Flag: mysql.UNSIGNED_FLAG},
+		{Name: []byte("c_int24"), Type: mysql.MYSQL_TYPE_INT24},
+		{Name: []byte("c_long"), Type: mysql.MYSQL_TYPE_LONG},
+		{Name: []byte("c_longlong"), Type: mysql.MYSQL_TYPE_LONGLONG},
+	}
+	sr := mysql.NewStreamResult(fields, 1, true)
+
+	go func() {
+		defer sr.Close()
+		ctx := context.Background()
+		sr.WriteRow(ctx, []any{
+			int8(-7), uint8(200),
+			int16(-12345), uint16(2026),
+			int32(-1234567), int32(2147483600),
+			int64(9223372036854775000),
+		})
+	}()
+
+	require.NoError(t, conn.WriteValue(sr.AsResult()))
+
+	rowPackets := extractBinaryRowPackets(clientConn.WriteBuffered)
+	require.Len(t, rowPackets, 1)
+
+	row, err := mysql.RowData(rowPackets[0]).ParseBinary(fields, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(-7), row[0].AsInt64())
+	require.Equal(t, uint64(200), row[1].AsUint64())
+	require.Equal(t, int64(-12345), row[2].AsInt64())
+	require.Equal(t, uint64(2026), row[3].AsUint64())
+	require.Equal(t, int64(-1234567), row[4].AsInt64())
+	require.Equal(t, int64(2147483600), row[5].AsInt64())
+	require.Equal(t, int64(9223372036854775000), row[6].AsInt64())
+}
+
+// TestConnWriteStreamResultsetBinaryFloats verifies FLOAT is encoded as
+// 4 bytes of Float32bits (not truncated Float64bits) and DOUBLE as 8 bytes
+// of Float64bits.
+func TestConnWriteStreamResultsetBinaryFloats(t *testing.T) {
+	clientConn := &mockconn.MockConn{MultiWrite: true}
+	conn := &Conn{Conn: packet.NewConn(clientConn)}
+
+	fields := []*mysql.Field{
+		{Name: []byte("c_float"), Type: mysql.MYSQL_TYPE_FLOAT},
+		{Name: []byte("c_double"), Type: mysql.MYSQL_TYPE_DOUBLE},
+	}
+	sr := mysql.NewStreamResult(fields, 1, true)
+
+	go func() {
+		defer sr.Close()
+		sr.WriteRow(context.Background(), []any{float32(3.5), float64(2.718281828459045)})
+	}()
+
+	require.NoError(t, conn.WriteValue(sr.AsResult()))
+
+	rowPackets := extractBinaryRowPackets(clientConn.WriteBuffered)
+	require.Len(t, rowPackets, 1)
+
+	row, err := mysql.RowData(rowPackets[0]).ParseBinary(fields, nil)
+	require.NoError(t, err)
+	require.InDelta(t, 3.5, row[0].AsFloat64(), 1e-6)
+	require.InDelta(t, 2.718281828459045, row[1].AsFloat64(), 1e-12)
+}
+
+// TestConnWriteStreamResultsetBinaryLengthEncodedStrings verifies that
+// length-encoded variable-width types beyond MYSQL_TYPE_VAR_STRING (VARCHAR,
+// STRING, BLOB, DECIMAL, JSON) are length-prefixed on the wire.
+func TestConnWriteStreamResultsetBinaryLengthEncodedStrings(t *testing.T) {
+	clientConn := &mockconn.MockConn{MultiWrite: true}
+	conn := &Conn{Conn: packet.NewConn(clientConn)}
+
+	fields := []*mysql.Field{
+		{Name: []byte("c_varchar"), Type: mysql.MYSQL_TYPE_VARCHAR},
+		{Name: []byte("c_string"), Type: mysql.MYSQL_TYPE_STRING},
+		{Name: []byte("c_blob"), Type: mysql.MYSQL_TYPE_BLOB},
+		{Name: []byte("c_decimal"), Type: mysql.MYSQL_TYPE_NEWDECIMAL},
+		{Name: []byte("c_json"), Type: mysql.MYSQL_TYPE_JSON},
+	}
+	sr := mysql.NewStreamResult(fields, 1, true)
+
+	go func() {
+		defer sr.Close()
+		sr.WriteRow(context.Background(), []any{
+			"abc",
+			"hello",
+			[]byte{0x00, 0x01, 0x02},
+			"1234.5678",
+			[]byte(`{"k":"v"}`),
+		})
+	}()
+
+	require.NoError(t, conn.WriteValue(sr.AsResult()))
+
+	rowPackets := extractBinaryRowPackets(clientConn.WriteBuffered)
+	require.Len(t, rowPackets, 1)
+
+	row, err := mysql.RowData(rowPackets[0]).ParseBinary(fields, nil)
+	require.NoError(t, err)
+	require.Equal(t, "abc", string(row[0].AsString()))
+	require.Equal(t, "hello", string(row[1].AsString()))
+	require.Equal(t, []byte{0x00, 0x01, 0x02}, row[2].AsString())
+	require.Equal(t, "1234.5678", string(row[3].AsString()))
+	require.Equal(t, `{"k":"v"}`, string(row[4].AsString()))
+}
+
+// TestConnWriteStreamResultsetBinaryTemporals verifies that DATE / DATETIME /
+// TIMESTAMP / TIME columns receive a length-prefixed packed binary
+// representation when written from a time.Time value.
+func TestConnWriteStreamResultsetBinaryTemporals(t *testing.T) {
+	clientConn := &mockconn.MockConn{MultiWrite: true}
+	conn := &Conn{Conn: packet.NewConn(clientConn)}
+
+	fields := []*mysql.Field{
+		{Name: []byte("c_date"), Type: mysql.MYSQL_TYPE_DATE},
+		{Name: []byte("c_datetime"), Type: mysql.MYSQL_TYPE_DATETIME},
+		{Name: []byte("c_timestamp"), Type: mysql.MYSQL_TYPE_TIMESTAMP},
+	}
+	sr := mysql.NewStreamResult(fields, 1, true)
+
+	dt := time.Date(2026, time.April, 28, 9, 30, 15, 0, time.UTC)
+	go func() {
+		defer sr.Close()
+		sr.WriteRow(context.Background(), []any{dt, dt, dt})
+	}()
+
+	require.NoError(t, conn.WriteValue(sr.AsResult()))
+
+	rowPackets := extractBinaryRowPackets(clientConn.WriteBuffered)
+	require.Len(t, rowPackets, 1)
+
+	row, err := mysql.RowData(rowPackets[0]).ParseBinary(fields, nil)
+	require.NoError(t, err)
+	require.Equal(t, "2026-04-28", string(row[0].AsString()))
+	require.Equal(t, "2026-04-28 09:30:15", string(row[1].AsString()))
+	require.Equal(t, "2026-04-28 09:30:15", string(row[2].AsString()))
+}
+
+// TestConnWriteStreamResultsetBinaryTime verifies the streaming binary writer
+// emits a length-prefixed packed TIME payload with no embedded date.
+func TestConnWriteStreamResultsetBinaryTime(t *testing.T) {
+	clientConn := &mockconn.MockConn{MultiWrite: true}
+	conn := &Conn{Conn: packet.NewConn(clientConn)}
+
+	fields := []*mysql.Field{
+		{Name: []byte("c_time"), Type: mysql.MYSQL_TYPE_TIME},
+	}
+	sr := mysql.NewStreamResult(fields, 1, true)
+
+	tm := time.Date(0, 1, 1, 12, 34, 56, 0, time.UTC)
+	go func() {
+		defer sr.Close()
+		sr.WriteRow(context.Background(), []any{tm})
+	}()
+
+	require.NoError(t, conn.WriteValue(sr.AsResult()))
+
+	rowPackets := extractBinaryRowPackets(clientConn.WriteBuffered)
+	require.Len(t, rowPackets, 1)
+
+	row, err := mysql.RowData(rowPackets[0]).ParseBinary(fields, nil)
+	require.NoError(t, err)
+	require.Equal(t, "12:34:56", string(row[0].AsString()))
 }


### PR DESCRIPTION
Currently, the streaming binary path produces malformed wire bytes for several column types:

* narrow integers (`TINY`, `SHORT`, `INT24`, `LONG`) get 8 bytes regardless of declared width
* `FLOAT` is encoded as `Float64bits` truncated to 4 bytes, which is wrong
* variable-length types other than `VAR_STRING` get unframed payloads
* temporals are sent as parser-formatted ASCII instead of the packed binary form

This PR adds a new `EncodeBinaryFieldValue` function and routes `writeStreamBinaryRows` through it. This new encoder honors the declared column type for width, framing, and packing.

Out-of-range and malformed inputs are now rejected loudly instead of silently corrupting the wire:

* per-type integer widths with range checks
* `Float32bits` for `FLOAT`, with overflow rejection
* length-encoded variable-width types
* packed temporals, re-packed from formatted strings as needed
* `MYSQL_TYPE_YEAR` forced unsigned
* `bool` only for `MYSQL_TYPE_TINY`
* empty strings, trailing whitespace and dots, microseconds over 6 digits, and `TIME` hours over 838 are rejected

`BuildSimpleBinaryResultset` is untouched, but consolidating it onto the new encoder is coming in a follow-up PR.