### PR TITLE
replication: support MySQL 8.4 semi-sync variable names

### DIFF
--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -393,18 +393,24 @@ func (b *BinlogSyncer) enableSemiSync() error {
 		return nil
 	}
 
-	r, err := b.c.Execute("SHOW VARIABLES LIKE 'rpl_semi_sync_master_enabled';")
+	// MySQL 8.0.26 renamed rpl_semi_sync_master_enabled to
+	// rpl_semi_sync_source_enabled (keeping the old name as an alias) and
+	// 8.4.0 removed the alias, so accept either spelling.
+	r, err := b.c.Execute("SHOW VARIABLES WHERE Variable_name IN ('rpl_semi_sync_master_enabled', 'rpl_semi_sync_source_enabled')")
 	if err != nil {
 		return errors.Trace(err)
 	}
 	s, _ := r.GetString(0, 1)
 	if s != "ON" {
-		b.cfg.Logger.Error("master does not support semi synchronous replication, use no semi-sync")
+		b.cfg.Logger.Error("source does not support semi synchronous replication, use no semi-sync")
 		b.cfg.SemiSyncEnabled = false
 		return nil
 	}
 
-	_, err = b.c.Execute(`SET @rpl_semi_sync_slave = 1;`)
+	// MySQL 8.0.26 also renamed the @rpl_semi_sync_slave session variable
+	// to @rpl_semi_sync_replica. These are user variables, so setting both
+	// is harmless on either server version.
+	_, err = b.c.Execute(`SET @rpl_semi_sync_slave = 1, @rpl_semi_sync_replica = 1;`)
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
## Summary

- MySQL 8.0.26 renamed `rpl_semi_sync_master_enabled` → `rpl_semi_sync_source_enabled` and `@rpl_semi_sync_slave` → `@rpl_semi_sync_replica`, keeping the old names as aliases.
- MySQL 8.4.0 removed the old aliases entirely, so `BinlogSyncer.enableSemiSync()` failed to detect or enable semi-sync against 8.4+ servers.
- Accept either spelling in the `SHOW VARIABLES` query and set both session user-variables, mirroring the approach already used in this file for `@master_binlog_checksum`/`@source_binlog_checksum` (line 345), the heartbeat variables (line 360), and `@slave_uuid`/`@replica_uuid` (line 375).

Addresses one of the remaining items in #866.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./replication/...`
- [x] Both updated SQL statements run cleanly on MySQL 8.4.9 (`SHOW VARIABLES WHERE Variable_name IN (...)` returns the surviving `_source_enabled` row; `SET @rpl_semi_sync_slave = 1, @rpl_semi_sync_replica = 1` succeeds — user variables are not validated against the server symbol table).
- [x] `TestSyncerSuite/TestMysqlSemiPositionSync` passes against MySQL 8.4.9 with the `rpl_semi_sync_source` plugin loaded; server-side `Rpl_semi_sync_source_yes_tx` increments during the run, confirming the test client is recognized as a real semi-sync replica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)