### PR TITLE
canal: add transactional position sync

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -269,7 +269,9 @@ func (c *Canal) Close() {
 	}
 	c.connLock.Unlock()
 
-	_ = c.eventHandler.OnPosSynced(nil, c.master.Position(), c.master.GTIDSet(), true)
+	if !c.cfg.TransactionalPosSync {
+		_ = c.eventHandler.OnPosSynced(nil, c.master.Position(), c.master.GTIDSet(), true)
+	}
 }
 
 func (c *Canal) WaitDumpDone() <-chan struct{} {

--- a/canal/config.go
+++ b/canal/config.go
@@ -97,8 +97,7 @@ type Config struct {
 	DisableFlushBinlogWhileWaiting bool `toml:"disable_flush_binlog_while_waiting"`
 
 	// TransactionalPosSync avoids syncing positions that may belong to an unfinished transaction.
-	// When enabled, BEGIN QueryEvent does not call OnPosSynced, XIDEvent calls it with force=true,
-	// and Close does not force a final OnPosSynced call.
+	// When enabled, commit events call OnPosSynced with force=true.
 	TransactionalPosSync bool `toml:"transactional_pos_sync"`
 
 	// Set TLS config

--- a/canal/config.go
+++ b/canal/config.go
@@ -96,6 +96,11 @@ type Config struct {
 	// and requires additional privileges.
 	DisableFlushBinlogWhileWaiting bool `toml:"disable_flush_binlog_while_waiting"`
 
+	// TransactionalPosSync avoids syncing positions that may belong to an unfinished transaction.
+	// When enabled, BEGIN QueryEvent does not call OnPosSynced, XIDEvent calls it with force=true,
+	// and Close does not force a final OnPosSynced call.
+	TransactionalPosSync bool `toml:"transactional_pos_sync"`
+
 	// Set TLS config
 	TLSConfig *tls.Config
 

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -13,7 +13,10 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 )
 
-var beginQuery = []byte("BEGIN")
+var (
+	beginQuery  = []byte("BEGIN")
+	commitQuery = []byte("COMMIT")
+)
 
 func (c *Canal) startSyncer() (*replication.BinlogStreamer, error) {
 	gset := c.master.GTIDSet()
@@ -144,8 +147,13 @@ func (c *Canal) handleEvent(ev *replication.BinlogEvent) error {
 			return errors.Trace(err)
 		}
 	case *replication.QueryEvent:
-		if c.cfg.TransactionalPosSync && isBeginQuery(e.Query) {
-			return nil
+		if c.cfg.TransactionalPosSync {
+			if bytes.Equal(e.Query, beginQuery) {
+				return nil
+			}
+			if bytes.Equal(e.Query, commitQuery) {
+				force = true
+			}
 		}
 		stmts, _, err := c.parser.Parse(string(e.Query), "", "")
 		if err != nil {
@@ -192,13 +200,6 @@ func (c *Canal) handleEvent(ev *replication.BinlogEvent) error {
 	}
 
 	return nil
-}
-
-func isBeginQuery(query []byte) bool {
-	stmt := bytes.TrimSpace(query)
-	stmt = bytes.TrimRight(stmt, ";")
-	stmt = bytes.TrimSpace(stmt)
-	return bytes.EqualFold(stmt, beginQuery)
 }
 
 type node struct {

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -2,6 +2,7 @@ package canal
 
 import (
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
@@ -118,6 +119,9 @@ func (c *Canal) handleEvent(ev *replication.BinlogEvent) error {
 		return nil
 	case *replication.XIDEvent:
 		savePos = true
+		if c.cfg.TransactionalPosSync {
+			force = true
+		}
 		// try to save the position later
 		if err := c.eventHandler.OnXID(ev.Header, pos); err != nil {
 			return errors.Trace(err)
@@ -138,6 +142,9 @@ func (c *Canal) handleEvent(ev *replication.BinlogEvent) error {
 			return errors.Trace(err)
 		}
 	case *replication.QueryEvent:
+		if c.cfg.TransactionalPosSync && isBeginQuery(e.Query) {
+			return nil
+		}
 		stmts, _, err := c.parser.Parse(string(e.Query), "", "")
 		if err != nil {
 			// The parser does not understand all syntax.
@@ -183,6 +190,13 @@ func (c *Canal) handleEvent(ev *replication.BinlogEvent) error {
 	}
 
 	return nil
+}
+
+func isBeginQuery(query []byte) bool {
+	stmt := strings.TrimSpace(string(query))
+	stmt = strings.TrimRight(stmt, ";")
+	stmt = strings.TrimSpace(stmt)
+	return strings.EqualFold(stmt, "BEGIN")
 }
 
 type node struct {

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -1,8 +1,8 @@
 package canal
 
 import (
+	"bytes"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
@@ -12,6 +12,8 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 )
+
+var beginQuery = []byte("BEGIN")
 
 func (c *Canal) startSyncer() (*replication.BinlogStreamer, error) {
 	gset := c.master.GTIDSet()
@@ -193,10 +195,10 @@ func (c *Canal) handleEvent(ev *replication.BinlogEvent) error {
 }
 
 func isBeginQuery(query []byte) bool {
-	stmt := strings.TrimSpace(string(query))
-	stmt = strings.TrimRight(stmt, ";")
-	stmt = strings.TrimSpace(stmt)
-	return strings.EqualFold(stmt, "BEGIN")
+	stmt := bytes.TrimSpace(query)
+	stmt = bytes.TrimRight(stmt, ";")
+	stmt = bytes.TrimSpace(stmt)
+	return bytes.EqualFold(stmt, beginQuery)
 }
 
 type node struct {

--- a/canal/sync_test.go
+++ b/canal/sync_test.go
@@ -1,10 +1,217 @@
 package canal
 
 import (
+	"context"
+	"io"
+	"log/slog"
 	"testing"
 
+	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/replication"
+	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/stretchr/testify/require"
 )
+
+type posSyncCall struct {
+	header *replication.EventHeader
+	pos    mysql.Position
+	set    string
+	force  bool
+}
+
+type posSyncRecorder struct {
+	DummyEventHandler
+
+	calls []posSyncCall
+}
+
+func (h *posSyncRecorder) OnPosSynced(header *replication.EventHeader, pos mysql.Position, set mysql.GTIDSet, force bool) error {
+	call := posSyncCall{
+		header: header,
+		pos:    pos,
+		force:  force,
+	}
+	if set != nil {
+		call.set = set.String()
+	}
+	h.calls = append(h.calls, call)
+	return nil
+}
+
+func newPosSyncTestCanal(t *testing.T, transactionalPosSync bool) (*Canal, *posSyncRecorder) {
+	t.Helper()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cfg := NewDefaultConfig()
+	cfg.Logger = logger
+	cfg.TransactionalPosSync = transactionalPosSync
+
+	ctx, cancel := context.WithCancel(context.Background())
+	handler := &posSyncRecorder{}
+	c := &Canal{
+		cfg:          cfg,
+		parser:       parser.New(),
+		master:       &masterInfo{logger: logger},
+		syncer:       replication.NewBinlogSyncer(replication.BinlogSyncerConfig{ServerID: 1, Flavor: mysql.MySQLFlavor, Logger: logger}),
+		eventHandler: handler,
+		ctx:          ctx,
+		cancel:       cancel,
+	}
+
+	return c, handler
+}
+
+func mustParseMysqlGTIDSet(t *testing.T, value string) mysql.GTIDSet {
+	t.Helper()
+
+	set, err := mysql.ParseGTIDSet(mysql.MySQLFlavor, value)
+	require.NoError(t, err)
+	return set
+}
+
+func TestIsBeginQuery(t *testing.T) {
+	tests := []struct {
+		query string
+		want  bool
+	}{
+		{query: "BEGIN", want: true},
+		{query: " begin ; ", want: true},
+		{query: "BEGIN WORK"},
+		{query: "START TRANSACTION"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			require.Equal(t, tt.want, isBeginQuery([]byte(tt.query)))
+		})
+	}
+}
+
+func TestHandleEventBeginPositionSync(t *testing.T) {
+	const sid = "24bc7850-2c58-11ee-be56-0242ac120002"
+
+	tests := []struct {
+		name                 string
+		transactionalPosSync bool
+		wantCalls            int
+		wantPos              mysql.Position
+		wantGTIDSet          string
+	}{
+		{
+			name:        "legacy syncs begin position",
+			wantCalls:   1,
+			wantPos:     mysql.Position{Name: "mysql-bin.000001", Pos: 456},
+			wantGTIDSet: sid + ":1-2",
+		},
+		{
+			name:                 "transactional sync skips begin position",
+			transactionalPosSync: true,
+			wantPos:              mysql.Position{Name: "mysql-bin.000001", Pos: 123},
+			wantGTIDSet:          sid + ":1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, handler := newPosSyncTestCanal(t, tt.transactionalPosSync)
+			c.master.Update(mysql.Position{Name: "mysql-bin.000001", Pos: 123})
+			c.master.UpdateGTIDSet(mustParseMysqlGTIDSet(t, sid+":1"))
+
+			err := c.handleEvent(&replication.BinlogEvent{
+				Header: &replication.EventHeader{
+					Timestamp: 10,
+					LogPos:    456,
+					EventType: replication.QUERY_EVENT,
+				},
+				Event: &replication.QueryEvent{
+					Query: []byte("BEGIN"),
+					GSet:  mustParseMysqlGTIDSet(t, sid+":1-2"),
+				},
+			})
+			require.NoError(t, err)
+
+			require.Len(t, handler.calls, tt.wantCalls)
+			require.Equal(t, tt.wantPos, c.master.Position())
+			require.Equal(t, tt.wantGTIDSet, c.master.GTIDSet().String())
+			if tt.wantCalls > 0 {
+				require.Equal(t, tt.wantPos, handler.calls[0].pos)
+				require.Equal(t, tt.wantGTIDSet, handler.calls[0].set)
+				require.False(t, handler.calls[0].force)
+			}
+		})
+	}
+}
+
+func TestHandleEventXIDForcePositionSync(t *testing.T) {
+	const sid = "24bc7850-2c58-11ee-be56-0242ac120002"
+
+	tests := []struct {
+		name                 string
+		transactionalPosSync bool
+		wantForce            bool
+	}{
+		{name: "legacy keeps xid force false"},
+		{name: "transactional sync forces xid", transactionalPosSync: true, wantForce: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, handler := newPosSyncTestCanal(t, tt.transactionalPosSync)
+			c.master.Update(mysql.Position{Name: "mysql-bin.000001", Pos: 123})
+			c.master.UpdateGTIDSet(mustParseMysqlGTIDSet(t, sid+":1"))
+
+			err := c.handleEvent(&replication.BinlogEvent{
+				Header: &replication.EventHeader{
+					Timestamp: 10,
+					LogPos:    789,
+					EventType: replication.XID_EVENT,
+				},
+				Event: &replication.XIDEvent{
+					XID:  1,
+					GSet: mustParseMysqlGTIDSet(t, sid+":1-2"),
+				},
+			})
+			require.NoError(t, err)
+
+			require.Len(t, handler.calls, 1)
+			require.Equal(t, mysql.Position{Name: "mysql-bin.000001", Pos: 789}, handler.calls[0].pos)
+			require.Equal(t, sid+":1-2", handler.calls[0].set)
+			require.Equal(t, tt.wantForce, handler.calls[0].force)
+			require.Equal(t, sid+":1-2", c.master.GTIDSet().String())
+		})
+	}
+}
+
+func TestClosePositionSync(t *testing.T) {
+	const sid = "24bc7850-2c58-11ee-be56-0242ac120002"
+
+	tests := []struct {
+		name                 string
+		transactionalPosSync bool
+		wantCalls            int
+	}{
+		{name: "legacy forces position sync on close", wantCalls: 1},
+		{name: "transactional sync skips close position sync", transactionalPosSync: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, handler := newPosSyncTestCanal(t, tt.transactionalPosSync)
+			c.master.Update(mysql.Position{Name: "mysql-bin.000001", Pos: 123})
+			c.master.UpdateGTIDSet(mustParseMysqlGTIDSet(t, sid+":1"))
+
+			c.Close()
+
+			require.Len(t, handler.calls, tt.wantCalls)
+			if tt.wantCalls > 0 {
+				require.Nil(t, handler.calls[0].header)
+				require.Equal(t, mysql.Position{Name: "mysql-bin.000001", Pos: 123}, handler.calls[0].pos)
+				require.Equal(t, sid+":1", handler.calls[0].set)
+				require.True(t, handler.calls[0].force)
+			}
+		})
+	}
+}
 
 func TestGetShowBinaryLogQuery(t *testing.T) {
 	tests := []struct {

--- a/canal/sync_test.go
+++ b/canal/sync_test.go
@@ -69,24 +69,6 @@ func mustParseMysqlGTIDSet(t *testing.T, value string) mysql.GTIDSet {
 	return set
 }
 
-func TestIsBeginQuery(t *testing.T) {
-	tests := []struct {
-		query string
-		want  bool
-	}{
-		{query: "BEGIN", want: true},
-		{query: " begin ; ", want: true},
-		{query: "BEGIN WORK"},
-		{query: "START TRANSACTION"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.query, func(t *testing.T) {
-			require.Equal(t, tt.want, isBeginQuery([]byte(tt.query)))
-		})
-	}
-}
-
 func TestHandleEventBeginPositionSync(t *testing.T) {
 	const sid = "24bc7850-2c58-11ee-be56-0242ac120002"
 
@@ -138,6 +120,46 @@ func TestHandleEventBeginPositionSync(t *testing.T) {
 				require.Equal(t, tt.wantGTIDSet, handler.calls[0].set)
 				require.False(t, handler.calls[0].force)
 			}
+		})
+	}
+}
+
+func TestHandleEventCommitPositionSync(t *testing.T) {
+	const sid = "24bc7850-2c58-11ee-be56-0242ac120002"
+
+	tests := []struct {
+		name                 string
+		transactionalPosSync bool
+		wantForce            bool
+	}{
+		{name: "legacy keeps commit force false"},
+		{name: "transactional sync forces commit", transactionalPosSync: true, wantForce: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, handler := newPosSyncTestCanal(t, tt.transactionalPosSync)
+			c.master.Update(mysql.Position{Name: "mysql-bin.000001", Pos: 123})
+			c.master.UpdateGTIDSet(mustParseMysqlGTIDSet(t, sid+":1"))
+
+			err := c.handleEvent(&replication.BinlogEvent{
+				Header: &replication.EventHeader{
+					Timestamp: 10,
+					LogPos:    789,
+					EventType: replication.QUERY_EVENT,
+				},
+				Event: &replication.QueryEvent{
+					Query: []byte("COMMIT"),
+					GSet:  mustParseMysqlGTIDSet(t, sid+":1-2"),
+				},
+			})
+			require.NoError(t, err)
+
+			require.Len(t, handler.calls, 1)
+			require.Equal(t, mysql.Position{Name: "mysql-bin.000001", Pos: 789}, handler.calls[0].pos)
+			require.Equal(t, sid+":1-2", handler.calls[0].set)
+			require.Equal(t, tt.wantForce, handler.calls[0].force)
+			require.Equal(t, sid+":1-2", c.master.GTIDSet().String())
 		})
 	}
 }


### PR DESCRIPTION
Fixes #1090.

## Summary
- Add `Config.TransactionalPosSync` as an opt-in mode for crash-safe Canal position sync semantics.
- In that mode, skip `OnPosSynced` for `BEGIN` QueryEvent so the GTID set is not advanced before the transaction is processed.
- Report XID position sync with `force=true`, and avoid the final forced `OnPosSynced` from `Canal.Close()`.
- Add offline unit tests for legacy behavior, transactional behavior, XID force sync, close behavior, and `BEGIN` detection.

## Validation
- `go test ./canal -run 'TestIsBeginQuery|TestHandleEventBeginPositionSync|TestHandleEventXIDForcePositionSync|TestClosePositionSync|TestGetShowBinaryLogQuery'`
- `go test ./canal -run '^$'`
- `go test ./... -run '^$'`
- `git diff --check`

Full `go test ./canal` requires a local MySQL instance; without one it fails at `127.0.0.1:3306: connect: connection refused`.
