### PR TITLE
canal: fix ignore_tables separator and accept quoted identifiers

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -181,7 +181,7 @@ func (c *Canal) prepareDumper() error {
 		if db, table, ok := splitDBTable(ignoreTable); ok {
 			c.dumper.AddIgnoreTables(db, table)
 		} else {
-			slog.Warn("failed to parse ignored tables", "ignoreTable", ignoreTable)
+			c.cfg.Logger.Warn("failed to parse ignored tables", "ignoreTable", ignoreTable)
 		}
 	}
 

--- a/canal/canal.go
+++ b/canal/canal.go
@@ -222,6 +222,7 @@ func parseIdent(s string) (ident, rest string, ok bool) {
 		return s, "", true
 	}
 	var buf strings.Builder
+	buf.Grow(len(s))
 	for i := 1; i < len(s); i++ {
 		if s[i] != '`' {
 			buf.WriteByte(s[i])

--- a/canal/canal.go
+++ b/canal/canal.go
@@ -180,6 +180,8 @@ func (c *Canal) prepareDumper() error {
 	for _, ignoreTable := range c.cfg.Dump.IgnoreTables {
 		if db, table, ok := splitDBTable(ignoreTable); ok {
 			c.dumper.AddIgnoreTables(db, table)
+		} else {
+			slog.Warn("failed to parse ignored tables", "ignoreTable", ignoreTable)
 		}
 	}
 
@@ -194,8 +196,7 @@ func (c *Canal) prepareDumper() error {
 
 // splitDBTable parses an entry from DumpConfig.IgnoreTables into a database
 // and table name. Both the plain `db.table` form and the MySQL-quoted form
-// `` `db`.`table` `` (or any mix) are accepted. Inside backticks any character
-// is allowed and a literal backtick is written as ``.
+// `db`.`table` (or any mix) are accepted.
 func splitDBTable(s string) (db, table string, ok bool) {
 	db, rest, ok := parseIdent(s)
 	if !ok || !strings.HasPrefix(rest, ".") {

--- a/canal/canal.go
+++ b/canal/canal.go
@@ -178,8 +178,8 @@ func (c *Canal) prepareDumper() error {
 	c.dumper.SetHexBlob(true)
 
 	for _, ignoreTable := range c.cfg.Dump.IgnoreTables {
-		if seps := strings.Split(ignoreTable, ","); len(seps) == 2 {
-			c.dumper.AddIgnoreTables(seps[0], seps[1])
+		if db, table, ok := splitDBTable(ignoreTable); ok {
+			c.dumper.AddIgnoreTables(db, table)
 		}
 	}
 
@@ -190,6 +190,50 @@ func (c *Canal) prepareDumper() error {
 	}
 
 	return nil
+}
+
+// splitDBTable parses an entry from DumpConfig.IgnoreTables into a database
+// and table name. Both the plain `db.table` form and the MySQL-quoted form
+// `` `db`.`table` `` (or any mix) are accepted. Inside backticks any character
+// is allowed and a literal backtick is written as ``.
+func splitDBTable(s string) (db, table string, ok bool) {
+	db, rest, ok := parseIdent(s)
+	if !ok || !strings.HasPrefix(rest, ".") {
+		return "", "", false
+	}
+	table, rest, ok = parseIdent(rest[1:])
+	if !ok || rest != "" || db == "" || table == "" {
+		return "", "", false
+	}
+	return db, table, true
+}
+
+// parseIdent consumes one MySQL identifier from the start of s and returns
+// the identifier value and any unconsumed remainder.
+func parseIdent(s string) (ident, rest string, ok bool) {
+	if s == "" {
+		return "", s, false
+	}
+	if s[0] != '`' {
+		if i := strings.IndexByte(s, '.'); i >= 0 {
+			return s[:i], s[i:], true
+		}
+		return s, "", true
+	}
+	var buf strings.Builder
+	for i := 1; i < len(s); i++ {
+		if s[i] != '`' {
+			buf.WriteByte(s[i])
+			continue
+		}
+		if i+1 < len(s) && s[i+1] == '`' {
+			buf.WriteByte('`')
+			i++
+			continue
+		}
+		return buf.String(), s[i+1:], true
+	}
+	return "", s, false
 }
 
 func (c *Canal) GetDelay() uint32 {

--- a/canal/canal_test.go
+++ b/canal/canal_test.go
@@ -481,3 +481,39 @@ func TestIncludeExcludeTableRegex(t *testing.T) {
 	require.False(t, c.checkTableMatch("test.canal_test_inner"))
 	require.False(t, c.checkTableMatch("mysql.canal_test_inner"))
 }
+
+func TestSplitDBTable(t *testing.T) {
+	cases := []struct {
+		in    string
+		db    string
+		table string
+		ok    bool
+	}{
+		{"db.table", "db", "table", true},
+		{"`db`.`table`", "db", "table", true},
+		{"`db`.table", "db", "table", true},
+		{"db.`table`", "db", "table", true},
+		// Quoted identifiers may contain dots and other special characters.
+		{"`my.db`.`my.table`", "my.db", "my.table", true},
+		{"`db with space`.`tbl`", "db with space", "tbl", true},
+		{"`a-b`.`c-d`", "a-b", "c-d", true},
+		// `` inside a quoted identifier is an escaped backtick.
+		{"`db``x`.`tbl`", "db`x", "tbl", true},
+		// Unicode in quoted identifier.
+		{"`数据库`.`表`", "数据库", "表", true},
+		// Invalid inputs.
+		{"db", "", "", false},
+		{"db.table.extra", "", "", false},
+		{".table", "", "", false},
+		{"db.", "", "", false},
+		{"`db.table", "", "", false},
+		{"`db`tbl", "", "", false},
+		{"", "", "", false},
+	}
+	for _, tc := range cases {
+		db, table, ok := splitDBTable(tc.in)
+		require.Equal(t, tc.ok, ok, "input=%q", tc.in)
+		require.Equal(t, tc.db, db, "input=%q", tc.in)
+		require.Equal(t, tc.table, table, "input=%q", tc.in)
+	}
+}

--- a/canal/config.go
+++ b/canal/config.go
@@ -27,7 +27,8 @@ type DumpConfig struct {
 
 	Databases []string `toml:"dbs"`
 
-	// Ignore table format is db.table
+	// Ignore table format is db.table; backtick-quoted identifiers are also
+	// accepted, e.g. `db`.`table`.
 	IgnoreTables []string `toml:"ignore_tables"`
 
 	// Dump only selected records. Quotes are mandatory


### PR DESCRIPTION
The DumpConfig.IgnoreTables docs say entries use the form db.table, but the parser split on "," instead of ".", so the setting never took effect. Parse entries with a small MySQL identifier parser so the documented db.table form works, along with backtick-quoted identifiers like `db`.`table` that may contain dots or other special characters.

Fixes #1143