### PR TITLE
canal: parse ignore_tables as a TOML sub-table (#1143)

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -177,10 +177,8 @@ func (c *Canal) prepareDumper() error {
 	// Use hex blob for mysqldump
 	c.dumper.SetHexBlob(true)
 
-	for _, ignoreTable := range c.cfg.Dump.IgnoreTables {
-		if seps := strings.Split(ignoreTable, ","); len(seps) == 2 {
-			c.dumper.AddIgnoreTables(seps[0], seps[1])
-		}
+	for db, tables := range c.cfg.Dump.IgnoreTables {
+		c.dumper.AddIgnoreTables(db, tables...)
 	}
 
 	if c.cfg.Dump.DiscardErr {

--- a/canal/config.go
+++ b/canal/config.go
@@ -27,8 +27,15 @@ type DumpConfig struct {
 
 	Databases []string `toml:"dbs"`
 
-	// Ignore table format is db.table
-	IgnoreTables []string `toml:"ignore_tables"`
+	// IgnoreTables maps database names to a list of tables to ignore.
+	//
+	// In TOML this is expressed as a sub-table where each key is a database
+	// name and the value is a list of tables, for example:
+	//
+	//	[dump.ignore_tables]
+	//	mydb = ["t1", "t2"]
+	//	"weird.db.name" = ["other"]
+	IgnoreTables map[string][]string `toml:"ignore_tables"`
 
 	// Dump only selected records. Quotes are mandatory
 	Where string `toml:"where"`

--- a/canal/config_test.go
+++ b/canal/config_test.go
@@ -1,0 +1,25 @@
+package canal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigIgnoreTables(t *testing.T) {
+	data := `
+addr = "127.0.0.1:3306"
+user = "root"
+
+[dump.ignore_tables]
+mydb = ["t1", "t2"]
+"weird.db.name" = ["other"]
+`
+	cfg, err := NewConfig(data)
+	require.NoError(t, err)
+
+	require.Equal(t, map[string][]string{
+		"mydb":          {"t1", "t2"},
+		"weird.db.name": {"other"},
+	}, cfg.Dump.IgnoreTables)
+}


### PR DESCRIPTION
Switch DumpConfig.IgnoreTables from []string with home-grown "db,table" splitting to map[string][]string so the TOML decoder handles the db -> tables mapping directly. This also lets db names contain dots when quoted, e.g. "weird.db.name" = ["other"].


Closes #1143 