### PR TITLE
Add option RenderJSONAsMySQLText

### DIFF
--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -79,37 +79,28 @@ type BinlogSyncerConfig struct {
 	// FloatWithTrailingZero structure for floats.
 	UseFloatWithTrailingZero bool
 
-	// RenderJSONAsMySQLText, when true, makes RowsEvent JSON-column values
-	// render as MySQL's textual JSON output (the representation MySQL
-	// returns from "SELECT json_col" or "CAST(json_col AS char)"), instead
-	// of routing the value through a Go intermediate (map/slice/float64/
-	// decimal) followed by json.Marshal. See renderJSONAsMySQLText in
-	// json_mysql_text.go for known divergences from MySQL's exact output.
+	// RenderJSONAsMySQLText, when true, preserves each JSONB value's
+	// original type tag (DOUBLE 1.0 stays "1.0"; NEWDECIMAL stays
+	// unquoted) in RowsEvent JSON columns. The default decode->json.Marshal
+	// path is lossy for DOUBLE and NEWDECIMAL, which matters when replaying
+	// the output back into a MySQL JSON column.
 	//
-	// The default behaviour is lossy in two ways that bite anyone replaying
-	// the decoded string back into a MySQL JSON column (e.g. binlog-based
-	// replication / migration tools):
-	//
-	//  * JSONB_DOUBLE: a whole-number double like 1.0 round-trips through
-	//    float64 + json.Marshal as "1", which MySQL re-parses as a JSON
-	//    INTEGER. UseFloatWithTrailingZero addresses this subset.
-	//  * JSONB_OPAQUE / NEWDECIMAL: SQL decimals such as
-	//    JSON_OBJECT('x', 1.0) decode to a Go string "1.0", which
-	//    json.Marshal then quotes -- so the value lands in the target as
-	//    the JSON STRING "1.0" rather than the original DECIMAL.
-	//    UseDecimal does not help: shopspring/decimal still marshals as a
-	//    quoted string by default and Decimal.String() trims trailing
-	//    zeros (1.0 -> "1").
-	//
-	// With RenderJSONAsMySQLText=true the decoder emits text directly from
-	// the JSONB byte stream, preserving each value's MySQL JSON type tag.
-	// Recommended when the consumer plans to feed the string back into a
-	// MySQL JSON column.
-	//
-	// Note: when RenderJSONAsMySQLText is enabled, UseDecimal and
-	// UseFloatWithTrailingZero have no effect on JSON-column values --
-	// the renderer always emits MySQL-canonical text for decimals and
-	// trailing-zero doubles. Both flags still apply to non-JSON columns.
+	// Side effects to be aware of when enabling this on existing pipelines:
+	//   - UseDecimal and UseFloatWithTrailingZero have no effect on JSON
+	//     columns (the renderer always emits MySQL-style text).
+	//   - Object key order changes from lexicographic (Go map iteration
+	//     via json.Marshal) to JSONB key order (length-then-bytes), which
+	//     matches MySQL's own text output.
+	//   - JSON OPAQUE values of unrecognised inner types are emitted as
+	//     "base64:typeN:<b64>" (matching mysqld) instead of the raw
+	//     payload bytes.
+	//   - JSON DATE values render as "YYYY-MM-DD" instead of the legacy
+	//     "YYYY-MM-DD 00:00:00.000000".
+	//   - IgnoreJSONDecodeError applies slightly more leniently: an empty
+	//     or 1-byte-short top-level payload becomes "null" instead of an
+	//     error.
+	//   - Only applies to JSON columns; non-JSON DECIMAL/DATE/etc. columns
+	//     are unaffected.
 	RenderJSONAsMySQLText bool
 
 	// RecvBufferSize sets the size in bytes of the operating system's receive buffer associated with the connection.

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -79,23 +79,33 @@ type BinlogSyncerConfig struct {
 	// FloatWithTrailingZero structure for floats.
 	UseFloatWithTrailingZero bool
 
-	// RenderJSONAsMySQLText, when true, preserves each JSONB value's
-	// original type tag (DOUBLE 1.0 stays "1.0"; NEWDECIMAL stays
-	// unquoted) in RowsEvent JSON columns. The default decode->json.Marshal
-	// path is lossy for DOUBLE and NEWDECIMAL, which matters when replaying
-	// the output back into a MySQL JSON column.
+	// RenderJSONAsMySQLText, when true, makes the JSONB decoder emit text
+	// that is faithful to each value's original JSONB type tag where the
+	// JSON text grammar can express it. The default decode->json.Marshal
+	// path is lossy for DOUBLE and (less importantly) NEWDECIMAL, which
+	// matters when replaying the output back into a MySQL JSON column.
 	//
-	// Side effects to be aware of when enabling this on existing pipelines:
-	//   - UseDecimal and UseFloatWithTrailingZero have no effect on JSON
-	//     columns (the renderer always emits MySQL-style text).
-	//   - Object key order changes from lexicographic (Go map iteration
-	//     via json.Marshal) to JSONB key order (length-then-bytes), which
-	//     matches MySQL's own text output.
-	//   - JSON OPAQUE values of unrecognised inner types are emitted as
+	// Per-tag behaviour:
+	//   - JSONB_DOUBLE 1.0 renders as "1.0" (not "1"), so MySQL re-stores
+	//     it as JSONB_DOUBLE rather than JSONB_INT.
+	//   - JSONB_OPAQUE NEWDECIMAL renders as an unquoted number rather
+	//     than a quoted string. Note that MySQL's JSON text grammar has
+	//     no syntax for a decimal literal: re-inserting the text creates
+	//     a JSON DOUBLE, not the original JSONB_OPAQUE NEWDECIMAL. The
+	//     numeric value is preserved, the opaque type tag is not.
+	//   - JSONB_OPAQUE DATE renders as "YYYY-MM-DD" (not the legacy
+	//     "YYYY-MM-DD 00:00:00.000000").
+	//   - JSONB_OPAQUE values of unrecognised inner types render as
 	//     "base64:typeN:<b64>" (matching mysqld) instead of the raw
 	//     payload bytes.
-	//   - JSON DATE values render as "YYYY-MM-DD" instead of the legacy
-	//     "YYYY-MM-DD 00:00:00.000000".
+	//   - Object key order is preserved from the JSONB stream
+	//     (length-then-bytes) instead of the lexicographic order Go maps
+	//     produce, matching MySQL's own text output.
+	//
+	// Other notes:
+	//   - UseDecimal and UseFloatWithTrailingZero have no effect on JSON
+	//     columns when this is enabled (the renderer always emits
+	//     MySQL-style text).
 	//   - Only applies to JSON columns; non-JSON DECIMAL/DATE/etc. columns
 	//     are unaffected.
 	RenderJSONAsMySQLText bool

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -79,6 +79,39 @@ type BinlogSyncerConfig struct {
 	// FloatWithTrailingZero structure for floats.
 	UseFloatWithTrailingZero bool
 
+	// RenderJSONAsMySQLText, when true, makes RowsEvent JSON-column values
+	// render as MySQL's textual JSON output (the representation MySQL
+	// returns from "SELECT json_col" or "CAST(json_col AS char)"), instead
+	// of routing the value through a Go intermediate (map/slice/float64/
+	// decimal) followed by json.Marshal. See renderJSONAsMySQLText in
+	// json_mysql_text.go for known divergences from MySQL's exact output.
+	//
+	// The default behaviour is lossy in two ways that bite anyone replaying
+	// the decoded string back into a MySQL JSON column (e.g. binlog-based
+	// replication / migration tools):
+	//
+	//  * JSONB_DOUBLE: a whole-number double like 1.0 round-trips through
+	//    float64 + json.Marshal as "1", which MySQL re-parses as a JSON
+	//    INTEGER. UseFloatWithTrailingZero addresses this subset.
+	//  * JSONB_OPAQUE / NEWDECIMAL: SQL decimals such as
+	//    JSON_OBJECT('x', 1.0) decode to a Go string "1.0", which
+	//    json.Marshal then quotes -- so the value lands in the target as
+	//    the JSON STRING "1.0" rather than the original DECIMAL.
+	//    UseDecimal does not help: shopspring/decimal still marshals as a
+	//    quoted string by default and Decimal.String() trims trailing
+	//    zeros (1.0 -> "1").
+	//
+	// With RenderJSONAsMySQLText=true the decoder emits text directly from
+	// the JSONB byte stream, preserving each value's MySQL JSON type tag.
+	// Recommended when the consumer plans to feed the string back into a
+	// MySQL JSON column.
+	//
+	// Note: when RenderJSONAsMySQLText is enabled, UseDecimal and
+	// UseFloatWithTrailingZero have no effect on JSON-column values --
+	// the renderer always emits MySQL-canonical text for decimals and
+	// trailing-zero doubles. Both flags still apply to non-JSON columns.
+	RenderJSONAsMySQLText bool
+
 	// RecvBufferSize sets the size in bytes of the operating system's receive buffer associated with the connection.
 	RecvBufferSize int
 
@@ -211,6 +244,7 @@ func NewBinlogSyncer(cfg BinlogSyncerConfig) *BinlogSyncer {
 	b.parser.SetTimestampStringLocation(b.cfg.TimestampStringLocation)
 	b.parser.SetUseDecimal(b.cfg.UseDecimal)
 	b.parser.SetUseFloatWithTrailingZero(b.cfg.UseFloatWithTrailingZero)
+	b.parser.SetRenderJSONAsMySQLText(b.cfg.RenderJSONAsMySQLText)
 	b.parser.SetVerifyChecksum(b.cfg.VerifyChecksum)
 	b.parser.SetPayloadDecoderConcurrency(cfg.PayloadDecoderConcurrency)
 	b.parser.SetRowsEventDecodeFunc(b.cfg.RowsEventDecodeFunc)

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -96,9 +96,6 @@ type BinlogSyncerConfig struct {
 	//     payload bytes.
 	//   - JSON DATE values render as "YYYY-MM-DD" instead of the legacy
 	//     "YYYY-MM-DD 00:00:00.000000".
-	//   - IgnoreJSONDecodeError applies slightly more leniently: an empty
-	//     or 1-byte-short top-level payload becomes "null" instead of an
-	//     error.
 	//   - Only applies to JSON columns; non-JSON DECIMAL/DATE/etc. columns
 	//     are unaffected.
 	RenderJSONAsMySQLText bool

--- a/replication/json_binary.go
+++ b/replication/json_binary.go
@@ -141,7 +141,10 @@ func jsonbGetValueEntrySize(isSmall bool) int {
 // common JSON encoding data. When RenderJSONAsMySQLText is set on the
 // parent RowsEvent the decoder wraps leaf values in MySQL-text marshalers
 // (see json_mysql_text.go) so json.Marshal produces MySQL's textual JSON
-// form, preserving each JSONB value's original type tag.
+// form, faithful to each JSONB value's original type tag where the JSON
+// text grammar can express it. NEWDECIMAL is the one tag that cannot be
+// preserved on text round-trip (no decimal literal in JSON); see
+// BinlogSyncerConfig.RenderJSONAsMySQLText for the full caveat list.
 func (e *RowsEvent) decodeJSONBinary(data []byte) ([]byte, error) {
 	d := jsonBinaryDecoder{
 		useDecimal:               e.useDecimal,

--- a/replication/json_binary.go
+++ b/replication/json_binary.go
@@ -138,7 +138,20 @@ func jsonbGetValueEntrySize(isSmall bool) int {
 
 // decodeJSONBinary decodes the JSON binary encoding data and returns
 // the common JSON encoding data.
+//
+// When RenderJSONAsMySQLText is set on the parent RowsEvent the bytes are
+// rendered directly to MySQL-style JSON text via the renderer in
+// json_mysql_text.go, preserving each JSONB value's original type tag
+// (INT vs DOUBLE-with-trailing-zero vs OPAQUE/NEWDECIMAL etc.). Otherwise
+// the legacy path runs: decode to a Go value tree, then json.Marshal.
+// The two paths produce different byte sequences for the same input (the
+// renderer adds spaces after ':' and ',', preserves "1.0" doubles, etc.)
+// -- callers comparing outputs byte-for-byte should pick one and stick.
 func (e *RowsEvent) decodeJSONBinary(data []byte) ([]byte, error) {
+	if e.renderJSONAsMySQLText {
+		return renderJSONAsMySQLText(data, e.ignoreJSONDecodeErr)
+	}
+
 	d := jsonBinaryDecoder{
 		useDecimal:               e.useDecimal,
 		useFloatWithTrailingZero: e.useFloatWithTrailingZero,

--- a/replication/json_binary.go
+++ b/replication/json_binary.go
@@ -151,7 +151,7 @@ func (e *RowsEvent) decodeJSONBinary(data []byte) ([]byte, error) {
 	}
 
 	if d.isDataShort(data, 1) {
-		if d.mysqlTextMode && d.ignoreDecodeErr {
+		if d.ignoreDecodeErr {
 			return []byte("null"), nil
 		}
 		return nil, d.err
@@ -159,7 +159,7 @@ func (e *RowsEvent) decodeJSONBinary(data []byte) ([]byte, error) {
 
 	v := d.decodeValue(data[0], data[1:])
 	if d.err != nil {
-		if d.mysqlTextMode && d.ignoreDecodeErr {
+		if d.ignoreDecodeErr {
 			return []byte("null"), nil
 		}
 		return nil, d.err
@@ -488,7 +488,7 @@ func (d *jsonBinaryDecoder) decodeOpaque(data []byte) any {
 	case mysql.MYSQL_TYPE_DATE:
 		// Historically dates have been decoded the same as datetime (including the time portion).
 		// This is mostly harmless, but in text-mode we want to ensure that
-		// the time portion is emitted.
+		// the time portion is omitted.
 		return d.decodeDateTime(data, d.mysqlTextMode)
 	case mysql.MYSQL_TYPE_DATETIME, mysql.MYSQL_TYPE_TIMESTAMP:
 		return d.decodeDateTime(data, false)

--- a/replication/json_binary.go
+++ b/replication/json_binary.go
@@ -1,6 +1,7 @@
 package replication
 
 import (
+	"encoding/base64"
 	"fmt"
 	"math"
 	"strconv"
@@ -136,34 +137,31 @@ func jsonbGetValueEntrySize(isSmall bool) int {
 	return jsonbValueEntrySizeLarge
 }
 
-// decodeJSONBinary decodes the JSON binary encoding data and returns
-// the common JSON encoding data.
-//
-// When RenderJSONAsMySQLText is set on the parent RowsEvent the bytes are
-// rendered directly to MySQL-style JSON text via the renderer in
-// json_mysql_text.go, preserving each JSONB value's original type tag
-// (INT vs DOUBLE-with-trailing-zero vs OPAQUE/NEWDECIMAL etc.). Otherwise
-// the legacy path runs: decode to a Go value tree, then json.Marshal.
-// The two paths produce different byte sequences for the same input (the
-// renderer adds spaces after ':' and ',', preserves "1.0" doubles, etc.)
-// -- callers comparing outputs byte-for-byte should pick one and stick.
+// decodeJSONBinary decodes the JSON binary encoding data and returns the
+// common JSON encoding data. When RenderJSONAsMySQLText is set on the
+// parent RowsEvent the decoder wraps leaf values in MySQL-text marshalers
+// (see json_mysql_text.go) so json.Marshal produces MySQL's textual JSON
+// form, preserving each JSONB value's original type tag.
 func (e *RowsEvent) decodeJSONBinary(data []byte) ([]byte, error) {
-	if e.renderJSONAsMySQLText {
-		return renderJSONAsMySQLText(data, e.ignoreJSONDecodeErr)
-	}
-
 	d := jsonBinaryDecoder{
 		useDecimal:               e.useDecimal,
 		useFloatWithTrailingZero: e.useFloatWithTrailingZero,
 		ignoreDecodeErr:          e.ignoreJSONDecodeErr,
+		mysqlTextMode:            e.renderJSONAsMySQLText,
 	}
 
 	if d.isDataShort(data, 1) {
+		if d.mysqlTextMode && d.ignoreDecodeErr {
+			return []byte("null"), nil
+		}
 		return nil, d.err
 	}
 
 	v := d.decodeValue(data[0], data[1:])
 	if d.err != nil {
+		if d.mysqlTextMode && d.ignoreDecodeErr {
+			return []byte("null"), nil
+		}
 		return nil, d.err
 	}
 
@@ -174,6 +172,7 @@ type jsonBinaryDecoder struct {
 	useDecimal               bool
 	useFloatWithTrailingZero bool
 	ignoreDecodeErr          bool
+	mysqlTextMode            bool
 	err                      error
 }
 
@@ -206,12 +205,19 @@ func (d *jsonBinaryDecoder) decodeValue(tp byte, data []byte) any {
 	case JSONB_UINT64:
 		return d.decodeUint64(data)
 	case JSONB_DOUBLE:
+		if d.mysqlTextMode {
+			return jsonMySQLDouble(d.decodeDouble(data))
+		}
 		if d.useFloatWithTrailingZero {
 			return d.decodeDoubleWithTrailingZero(data)
 		}
 		return d.decodeDouble(data)
 	case JSONB_STRING:
-		return d.decodeString(data)
+		s := d.decodeString(data)
+		if d.mysqlTextMode {
+			return jsonString(s)
+		}
+		return s
 	case JSONB_OPAQUE:
 		return d.decodeOpaque(data)
 	default:
@@ -312,6 +318,13 @@ func (d *jsonBinaryDecoder) decodeObjectOrArray(data []byte, isSmall bool, isObj
 
 	if !isObject {
 		return values
+	}
+
+	if d.mysqlTextMode {
+		// Preserve JSONB key order (length-then-bytes, which is what MySQL
+		// emits) instead of going through map[string]any, which json.Marshal
+		// would sort lexicographically.
+		return jsonObject{keys: keys, values: values}
 	}
 
 	m := make(map[string]any, count)
@@ -472,20 +485,47 @@ func (d *jsonBinaryDecoder) decodeOpaque(data []byte) any {
 		return d.decodeDecimal(data)
 	case mysql.MYSQL_TYPE_TIME:
 		return d.decodeTime(data)
-	case mysql.MYSQL_TYPE_DATE, mysql.MYSQL_TYPE_DATETIME, mysql.MYSQL_TYPE_TIMESTAMP:
-		return d.decodeDateTime(data)
+	case mysql.MYSQL_TYPE_DATE:
+		// Historically dates have been decoded the same as datetime (including the time portion).
+		// This is mostly harmless, but in text-mode we want to ensure that
+		// the time portion is emitted.
+		return d.decodeDateTime(data, d.mysqlTextMode)
+	case mysql.MYSQL_TYPE_DATETIME, mysql.MYSQL_TYPE_TIMESTAMP:
+		return d.decodeDateTime(data, false)
 	default:
+		if d.mysqlTextMode {
+			return "base64:type" + strconv.Itoa(int(tp)) + ":" + base64.StdEncoding.EncodeToString(data)
+		}
 		return utils.ByteSliceToString(data)
 	}
 }
 
 func (d *jsonBinaryDecoder) decodeDecimal(data []byte) any {
+	if d.isDataShort(data, 2) {
+		return nil
+	}
 	precision := int(data[0])
 	scale := int(data[1])
 
-	v, _, err := decodeDecimal(data[2:], precision, scale, d.useDecimal)
-	d.err = err
-
+	// MySQL renders JSON DECIMAL values unquoted; force the string form
+	// (useDecimal=false) so we can wrap it as a jsonRawNumber.
+	useDecimal := d.useDecimal
+	if d.mysqlTextMode {
+		useDecimal = false
+	}
+	v, _, err := decodeDecimal(data[2:], precision, scale, useDecimal)
+	if err != nil {
+		d.err = err
+		return nil
+	}
+	if d.mysqlTextMode {
+		s, ok := v.(string)
+		if !ok {
+			d.err = errors.Errorf("decimal decode returned %T, want string", v)
+			return nil
+		}
+		return jsonRawNumber(s)
+	}
 	return v
 }
 
@@ -511,9 +551,12 @@ func (d *jsonBinaryDecoder) decodeTime(data []byte) any {
 	return fmt.Sprintf("%s%02d:%02d:%02d.%06d", sign, hour, minute, sec, frac)
 }
 
-func (d *jsonBinaryDecoder) decodeDateTime(data []byte) any {
+func (d *jsonBinaryDecoder) decodeDateTime(data []byte, isDate bool) any {
 	v := d.decodeInt64(data)
 	if v == 0 {
+		if isDate {
+			return "0000-00-00"
+		}
 		return "0000-00-00 00:00:00"
 	}
 
@@ -535,6 +578,9 @@ func (d *jsonBinaryDecoder) decodeDateTime(data []byte) any {
 	second := hms % (1 << 6)
 	frac := v % (1 << 24)
 
+	if isDate {
+		return fmt.Sprintf("%04d-%02d-%02d", year, month, day)
+	}
 	return fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d.%06d", year, month, day, hour, minute, second, frac)
 }
 

--- a/replication/json_mysql_text.go
+++ b/replication/json_mysql_text.go
@@ -112,7 +112,7 @@ func formatMySQLDouble(f float64) string {
 // that may not form valid UTF-8.
 func writeJSONString(buf *bytes.Buffer, s []byte) {
 	const hexdigits = "0123456789abcdef"
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		c := s[i]
 		if c < 0x20 || c == '"' || c == '\\' {
 			switch c {

--- a/replication/json_mysql_text.go
+++ b/replication/json_mysql_text.go
@@ -11,16 +11,21 @@ import (
 // This file holds the MySQL-text marshalers used by jsonBinaryDecoder
 // when its mysqlTextMode flag is set. Wrapping the leaf decode returns
 // in these types lets the existing json.Marshal pass produce JSON text
-// that preserves each JSONB value's original type tag (DOUBLE 1.0 stays
-// "1.0"; NEWDECIMAL stays unquoted; etc.) and the JSONB key order, so
-// that re-inserting the text into a MySQL JSON column reproduces the
-// original JSONB binary.
+// that is faithful to each JSONB value's original type tag where the
+// JSON text grammar can express it (DOUBLE 1.0 stays "1.0"; NEWDECIMAL
+// stays unquoted; etc.) and preserves the JSONB key order.
 //
-// Note: the output is type-faithful, not byte-identical to MySQL's
-// "SELECT json_col" form. Inter-token whitespace is compact (no space
-// after ',' or ':'), and floating-point text differs in some
-// exponent/precision corner cases (see jsonMySQLDouble). Binary
-// round-trip through a JSON column is unaffected.
+// Caveats:
+//   - The output is type-faithful, not byte-identical to MySQL's
+//     "SELECT json_col" form. Inter-token whitespace is compact (no
+//     space after ',' or ':') and floating-point text differs in some
+//     exponent/precision corner cases (see jsonMySQLDouble).
+//   - NEWDECIMAL is the one tag that cannot be preserved on text
+//     round-trip: MySQL's JSON text grammar has no decimal literal, so
+//     re-inserting the unquoted number yields a JSON DOUBLE, not the
+//     original JSONB_OPAQUE NEWDECIMAL. The numeric value still
+//     round-trips; only the opaque type tag is lost. All other tags
+//     covered here do reproduce the original JSONB binary on re-insert.
 
 // jsonString carries a JSONB string payload as raw bytes so MarshalJSON
 // can pass non-ASCII bytes through verbatim. MySQL JSON is byte-

--- a/replication/json_mysql_text.go
+++ b/replication/json_mysql_text.go
@@ -2,434 +2,117 @@ package replication
 
 import (
 	"bytes"
-	"encoding/hex"
-	"fmt"
 	"math"
 	"strconv"
-	"unicode/utf8"
 
-	"github.com/go-mysql-org/go-mysql/mysql"
-	"github.com/pingcap/errors"
+	"github.com/goccy/go-json"
 )
 
-// renderJSONAsMySQLText walks a MySQL JSON binary (JSONB) byte stream and
-// emits a textual representation closely matching what MySQL produces from
-// "SELECT json_col" / "CAST(json_col AS char)". It is used when
-// RowsEvent.renderJSONAsMySQLText is true.
+// This file holds the MySQL-text marshalers used by jsonBinaryDecoder
+// when its mysqlTextMode flag is set. Wrapping the leaf decode returns
+// in these types lets the existing json.Marshal pass produce JSON text
+// that preserves each JSONB value's original type tag (DOUBLE 1.0 stays
+// "1.0"; NEWDECIMAL stays unquoted; etc.) and the JSONB key order, so
+// that re-inserting the text into a MySQL JSON column reproduces the
+// original JSONB binary.
 //
-// The default decoder routes every JSONB value through an intermediate Go
-// value (float64, shopspring/decimal, map[string]any, ...) and then
-// json.Marshal. That path silently changes the JSON *type tag*:
-//
-//   - JSONB_DOUBLE 1.0 -> float64(1.0) -> json.Marshal -> "1" (INTEGER)
-//   - JSONB_OPAQUE NEWDECIMAL "1.0" -> Go string "1.0" -> json.Marshal ->
-//     "\"1.0\"" (STRING)
-//
-// Replaying either of those into a MySQL JSON column changes the stored
-// binary representation. Callers feeding the decoded string back into a
-// MySQL JSON column (binlog-based replication / online schema change
-// tools) need the original type to survive the round-trip; this renderer
-// preserves the type tag by emitting text directly from the JSONB byte
-// stream without an intermediate Go-typed value.
-//
-// Known divergences from MySQL's exact textual form:
-//
-//   - Invalid UTF-8 bytes inside JSONB_STRING values are replaced with
-//     U+FFFD; MySQL preserves the raw bytes.
-//   - JSONB_OPAQUE values of an unrecognised inner type are rendered as
-//     "opaque:type=N:<hex>"; MySQL emits "base64:typeN:<base64>".
-//   - JSONB_DOUBLE values use Go's strconv shortest-round-trip formatting
-//     (whole numbers keep ".0"); MySQL uses its own my_gcvt rules and may
-//     differ in scientific-notation exponent padding for edge magnitudes.
-//
-// These are noted because consumers replaying the rendered text into a
-// MySQL JSON column will see those values land as JSON STRING rather
-// than the original JSONB type.
-func renderJSONAsMySQLText(data []byte, ignoreDecodeErr bool) ([]byte, error) {
-	r := &jsonMySQLTextRenderer{ignoreDecodeErr: ignoreDecodeErr}
-	if len(data) < 1 {
-		if ignoreDecodeErr {
-			return []byte("null"), nil
-		}
-		return nil, errors.New("json binary data is empty")
-	}
-	r.renderValue(data[0], data[1:])
-	if r.err != nil {
-		if ignoreDecodeErr {
-			// Return a valid JSON document (matches the legacy decoder's
-			// behaviour of returning Go nil -> json.Marshal -> "null"
-			// rather than leaking a half-written buffer).
-			return []byte("null"), nil
-		}
-		return nil, r.err
-	}
-	return r.buf.Bytes(), nil
+// Note: the output is type-faithful, not byte-identical to MySQL's
+// "SELECT json_col" form. Inter-token whitespace is compact (no space
+// after ',' or ':'), and floating-point text differs in some
+// exponent/precision corner cases (see jsonMySQLDouble). Binary
+// round-trip through a JSON column is unaffected.
+
+// jsonString carries a JSONB string payload as raw bytes so MarshalJSON
+// can pass non-ASCII bytes through verbatim. MySQL JSON is byte-
+// transparent, so bytes >= 0x20 (other than '"' and '\\') are written
+// without UTF-8 validation -- unlike the default encoding/json path which
+// replaces invalid UTF-8 with U+FFFD.
+type jsonString string
+
+func (s jsonString) MarshalJSON() ([]byte, error) {
+	buf := bytes.NewBuffer(make([]byte, 0, len(s)+2))
+	buf.WriteByte('"')
+	writeJSONString(buf, []byte(s))
+	buf.WriteByte('"')
+	return buf.Bytes(), nil
 }
 
-type jsonMySQLTextRenderer struct {
-	buf             bytes.Buffer
-	err             error
-	ignoreDecodeErr bool
+// jsonRawNumber emits its bytes unquoted. Used for JSONB OPAQUE
+// NEWDECIMAL values: MySQL renders these as plain numbers in JSON text,
+// not as quoted strings.
+type jsonRawNumber string
+
+func (n jsonRawNumber) MarshalJSON() ([]byte, error) {
+	return []byte(n), nil
 }
 
-func (r *jsonMySQLTextRenderer) setErr(err error) {
-	if r.err == nil {
-		r.err = err
-	}
+// jsonMySQLDouble formats a float64 close to the way MySQL does in JSON
+// text: whole-number doubles keep a trailing ".0" so MySQL re-stores
+// them as JSON DOUBLE rather than JSON INTEGER, and non-integer values
+// use the shortest round-trippable form. We can't reuse
+// FloatWithTrailingZero here because it formats non-integers with 'f'
+// (always plain decimal); MySQL uses scientific notation for some
+// magnitudes, which 'g' matches more closely.
+//
+// The output is NOT guaranteed to be byte-identical to MySQL's
+// my_gcvt-formatted text: Go's 'g' verb emits exponents as e.g.
+// "1.5e-05" where MySQL emits "1.5e-5", and the integer/scientific
+// crossover threshold differs. Binary round-trip through a MySQL JSON
+// column is unaffected (the same float64 produces the same JSONB
+// DOUBLE bytes); only the visible text form may differ.
+type jsonMySQLDouble float64
+
+func (f jsonMySQLDouble) MarshalJSON() ([]byte, error) {
+	return []byte(formatMySQLDouble(float64(f))), nil
 }
 
-func (r *jsonMySQLTextRenderer) isDataShort(data []byte, expected int) bool {
-	if r.err != nil {
-		return true
-	}
-	if len(data) < expected {
-		r.setErr(errors.Errorf("data len %d < expected %d", len(data), expected))
-		return true
-	}
-	return false
+// jsonObject preserves JSONB key order (length-then-bytes, which is what
+// MySQL emits) instead of going through map[string]any, which json.Marshal
+// would sort lexicographically.
+type jsonObject struct {
+	keys   []string
+	values []any
 }
 
-func (r *jsonMySQLTextRenderer) renderValue(tp byte, data []byte) {
-	if r.err != nil {
-		return
-	}
-	switch tp {
-	case JSONB_SMALL_OBJECT:
-		r.renderObjectOrArray(data, true, true)
-	case JSONB_LARGE_OBJECT:
-		r.renderObjectOrArray(data, false, true)
-	case JSONB_SMALL_ARRAY:
-		r.renderObjectOrArray(data, true, false)
-	case JSONB_LARGE_ARRAY:
-		r.renderObjectOrArray(data, false, false)
-	case JSONB_LITERAL:
-		r.renderLiteral(data)
-	case JSONB_INT16:
-		if r.isDataShort(data, 2) {
-			return
-		}
-		r.buf.WriteString(strconv.FormatInt(int64(mysql.ParseBinaryInt16(data[:2])), 10))
-	case JSONB_UINT16:
-		if r.isDataShort(data, 2) {
-			return
-		}
-		r.buf.WriteString(strconv.FormatUint(uint64(mysql.ParseBinaryUint16(data[:2])), 10))
-	case JSONB_INT32:
-		if r.isDataShort(data, 4) {
-			return
-		}
-		r.buf.WriteString(strconv.FormatInt(int64(mysql.ParseBinaryInt32(data[:4])), 10))
-	case JSONB_UINT32:
-		if r.isDataShort(data, 4) {
-			return
-		}
-		r.buf.WriteString(strconv.FormatUint(uint64(mysql.ParseBinaryUint32(data[:4])), 10))
-	case JSONB_INT64:
-		if r.isDataShort(data, 8) {
-			return
-		}
-		r.buf.WriteString(strconv.FormatInt(mysql.ParseBinaryInt64(data[:8]), 10))
-	case JSONB_UINT64:
-		if r.isDataShort(data, 8) {
-			return
-		}
-		r.buf.WriteString(strconv.FormatUint(mysql.ParseBinaryUint64(data[:8]), 10))
-	case JSONB_DOUBLE:
-		if r.isDataShort(data, 8) {
-			return
-		}
-		r.buf.WriteString(formatMySQLDouble(mysql.ParseBinaryFloat64(data[:8])))
-	case JSONB_STRING:
-		r.renderString(data)
-	case JSONB_OPAQUE:
-		r.renderOpaque(data)
-	default:
-		r.setErr(errors.Errorf("invalid json type %d", tp))
-	}
-}
-
-func (r *jsonMySQLTextRenderer) renderLiteral(data []byte) {
-	if r.isDataShort(data, 1) {
-		return
-	}
-	switch data[0] {
-	case JSONB_NULL_LITERAL:
-		r.buf.WriteString("null")
-	case JSONB_TRUE_LITERAL:
-		r.buf.WriteString("true")
-	case JSONB_FALSE_LITERAL:
-		r.buf.WriteString("false")
-	default:
-		r.setErr(errors.Errorf("invalid literal %c", data[0]))
-	}
-}
-
-func (r *jsonMySQLTextRenderer) renderObjectOrArray(data []byte, isSmall, isObject bool) {
-	offsetSize := jsonbGetOffsetSize(isSmall)
-	if r.isDataShort(data, 2*offsetSize) {
-		return
-	}
-	count := decodeJSONCount(data, isSmall)
-	size := decodeJSONCount(data[offsetSize:], isSmall)
-	if r.isDataShort(data, size) {
-		return
-	}
-
-	keyEntrySize := jsonbGetKeyEntrySize(isSmall)
-	valueEntrySize := jsonbGetValueEntrySize(isSmall)
-	headerSize := 2*offsetSize + count*valueEntrySize
-	if isObject {
-		headerSize += count * keyEntrySize
-	}
-	if headerSize > size {
-		r.setErr(errors.Errorf("header size %d > size %d", headerSize, size))
-		return
-	}
-
-	// Decode keys up front (only when iterating an object) so they can be
-	// emitted in order alongside the values.
-	var keys [][]byte
-	if isObject {
-		keys = make([][]byte, count)
-		for i := 0; i < count; i++ {
-			entryOffset := 2*offsetSize + keyEntrySize*i
-			keyOffset := decodeJSONCount(data[entryOffset:], isSmall)
-			keyLength := int(mysql.ParseBinaryUint16(data[entryOffset+offsetSize : entryOffset+offsetSize+2]))
-			if keyOffset < headerSize {
-				r.setErr(errors.Errorf("invalid key offset %d, must >= %d", keyOffset, headerSize))
-				return
-			}
-			if r.isDataShort(data, keyOffset+keyLength) {
-				return
-			}
-			keys[i] = data[keyOffset : keyOffset+keyLength]
-		}
-	}
-
-	if isObject {
-		r.buf.WriteByte('{')
-	} else {
-		r.buf.WriteByte('[')
-	}
-	for i := 0; i < count; i++ {
+func (o jsonObject) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, k := range o.keys {
 		if i > 0 {
-			r.buf.WriteString(", ")
+			buf.WriteByte(',')
 		}
-		if isObject {
-			r.buf.WriteByte('"')
-			writeJSONString(&r.buf, keys[i])
-			r.buf.WriteString(`": `)
+		buf.WriteByte('"')
+		writeJSONString(&buf, []byte(k))
+		buf.WriteString(`":`)
+		vb, err := json.Marshal(o.values[i])
+		if err != nil {
+			return nil, err
 		}
-
-		entryOffset := 2*offsetSize + valueEntrySize*i
-		if isObject {
-			entryOffset += keyEntrySize * count
-		}
-		tp := data[entryOffset]
-		if isInlineValue(tp, isSmall) {
-			r.renderValue(tp, data[entryOffset+1:entryOffset+valueEntrySize])
-			if r.err != nil {
-				return
-			}
-			continue
-		}
-		valueOffset := decodeJSONCount(data[entryOffset+1:], isSmall)
-		if r.isDataShort(data, valueOffset) {
-			return
-		}
-		r.renderValue(tp, data[valueOffset:])
-		if r.err != nil {
-			return
-		}
+		buf.Write(vb)
 	}
-	if isObject {
-		r.buf.WriteByte('}')
-	} else {
-		r.buf.WriteByte(']')
-	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
 }
 
-func (r *jsonMySQLTextRenderer) renderString(data []byte) {
-	l, n, err := decodeJSONVarLen(data)
-	if err != nil {
-		r.setErr(err)
-		return
-	}
-	if r.isDataShort(data, l+n) {
-		return
-	}
-	r.buf.WriteByte('"')
-	writeJSONString(&r.buf, data[n:n+l])
-	r.buf.WriteByte('"')
-}
-
-func (r *jsonMySQLTextRenderer) renderOpaque(data []byte) {
-	if r.isDataShort(data, 1) {
-		return
-	}
-	opaqueTp := data[0]
-	data = data[1:]
-	l, n, err := decodeJSONVarLen(data)
-	if err != nil {
-		r.setErr(err)
-		return
-	}
-	if r.isDataShort(data, l+n) {
-		return
-	}
-	payload := data[n : n+l]
-	switch opaqueTp {
-	case mysql.MYSQL_TYPE_NEWDECIMAL:
-		if len(payload) < 2 {
-			r.setErr(errors.Errorf("decimal payload too short: %d", len(payload)))
-			return
-		}
-		precision := int(payload[0])
-		scale := int(payload[1])
-		v, _, derr := decodeDecimal(payload[2:], precision, scale, false /*useDecimal*/)
-		if derr != nil {
-			r.setErr(derr)
-			return
-		}
-		// decodeDecimal returns the canonical text form when useDecimal=false.
-		// MySQL formats JSON DECIMAL values as plain numbers (no quotes), so
-		// write the value directly.
-		s, ok := v.(string)
-		if !ok {
-			r.setErr(errors.Errorf("decimal decode produced %T, expected string", v))
-			return
-		}
-		r.buf.WriteString(s)
-	case mysql.MYSQL_TYPE_TIME:
-		r.buf.WriteByte('"')
-		r.buf.WriteString(formatJSONTime(payload))
-		r.buf.WriteByte('"')
-	case mysql.MYSQL_TYPE_DATE, mysql.MYSQL_TYPE_DATETIME, mysql.MYSQL_TYPE_TIMESTAMP:
-		r.buf.WriteByte('"')
-		r.buf.WriteString(formatJSONDateTime(opaqueTp, payload))
-		r.buf.WriteByte('"')
-	default:
-		// MySQL serialises unknown opaque types as base64("opaque-binary").
-		// "SELECT json_col" yields "base64:typeNN:..."; emit the hex form
-		// surrounded by quotes so the consumer at least sees a stable string.
-		r.buf.WriteByte('"')
-		r.buf.WriteString("opaque:type=")
-		r.buf.WriteString(strconv.Itoa(int(opaqueTp)))
-		r.buf.WriteByte(':')
-		r.buf.WriteString(hex.EncodeToString(payload))
-		r.buf.WriteByte('"')
-	}
-}
-
-// formatMySQLDouble formats a float64 the way MySQL does in JSON text:
-// whole-number doubles keep a trailing ".0", and other values use the
-// shortest round-trippable decimal/scientific form that strconv produces.
-// This mirrors FloatWithTrailingZero.MarshalJSON.
 func formatMySQLDouble(f float64) string {
 	if math.IsNaN(f) || math.IsInf(f, 0) {
-		// MySQL refuses to store NaN/Inf in JSON; we should never see one,
-		// but emit a safe fallback rather than corrupt the surrounding doc.
+		// MySQL refuses to store NaN/Inf in JSON; emit a safe fallback
+		// rather than corrupt the surrounding document.
 		return "null"
 	}
-	if f == math.Trunc(f) && !math.IsInf(f, 0) {
-		// Use FormatFloat 'f' with 1 digit after the decimal so 1.0 stays
-		// "1.0". Matches FloatWithTrailingZero.MarshalJSON.
+	if f == math.Trunc(f) {
 		return strconv.FormatFloat(f, 'f', 1, 64)
 	}
 	return strconv.FormatFloat(f, 'g', -1, 64)
 }
 
-func formatJSONTime(payload []byte) string {
-	if len(payload) < 8 {
-		return "00:00:00"
-	}
-	v := mysql.ParseBinaryInt64(payload[:8])
-	if v == 0 {
-		return "00:00:00"
-	}
-	sign := ""
-	if v < 0 {
-		sign = "-"
-		v = -v
-	}
-	intPart := v >> 24
-	hour := (intPart >> 12) % (1 << 10)
-	minute := (intPart >> 6) % (1 << 6)
-	sec := intPart % (1 << 6)
-	frac := v % (1 << 24)
-	return fmt.Sprintf("%s%02d:%02d:%02d.%06d", sign, hour, minute, sec, frac)
-}
-
-func formatJSONDateTime(opaqueTp byte, payload []byte) string {
-	if len(payload) < 8 {
-		return "0000-00-00 00:00:00"
-	}
-	v := mysql.ParseBinaryInt64(payload[:8])
-	if v == 0 {
-		if opaqueTp == mysql.MYSQL_TYPE_DATE {
-			return "0000-00-00"
-		}
-		return "0000-00-00 00:00:00"
-	}
-	if v < 0 {
-		v = -v
-	}
-	intPart := v >> 24
-	ymd := intPart >> 17
-	ym := ymd >> 5
-	hms := intPart % (1 << 17)
-	year := ym / 13
-	month := ym % 13
-	day := ymd % (1 << 5)
-	hour := hms >> 12
-	minute := (hms >> 6) % (1 << 6)
-	second := hms % (1 << 6)
-	frac := v % (1 << 24)
-	if opaqueTp == mysql.MYSQL_TYPE_DATE {
-		return fmt.Sprintf("%04d-%02d-%02d", year, month, day)
-	}
-	return fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d.%06d", year, month, day, hour, minute, second, frac)
-}
-
-func decodeJSONCount(data []byte, isSmall bool) int {
-	if isSmall {
-		return int(mysql.ParseBinaryUint16(data[:2]))
-	}
-	return int(mysql.ParseBinaryUint32(data[:4]))
-}
-
-// decodeJSONVarLen decodes the variable-length integer used by JSONB. It
-// mirrors jsonBinaryDecoder.decodeVariableLength but is reusable without
-// holding an instance.
-func decodeJSONVarLen(data []byte) (length, consumed int, err error) {
-	maxCount := len(data)
-	if maxCount > 5 {
-		maxCount = 5
-	}
-	var l uint64
-	for pos := 0; pos < maxCount; pos++ {
-		v := data[pos]
-		l |= uint64(v&0x7F) << uint(7*pos)
-		if v&0x80 == 0 {
-			if l > math.MaxUint32 {
-				return 0, 0, errors.Errorf("variable length %d exceeds %d", l, int64(math.MaxUint32))
-			}
-			return int(l), pos + 1, nil
-		}
-	}
-	return 0, 0, errors.New("decode variable length failed")
-}
-
-// writeJSONString writes the contents of s as a JSON-escaped string
-// (without surrounding quotes). The escape set matches what
-// goccy/go-json produces for plain Go strings: control chars, quote,
-// backslash, plus invalid UTF-8 bytes as U+FFFD. The U+FFFD substitution
-// is lossy and diverges from MySQL, which preserves raw bytes — callers
-// that need exact round-tripping must ensure inputs are valid UTF-8.
+// writeJSONString writes s as the contents of a JSON string (no
+// surrounding quotes), with byte-transparent semantics: bytes >= 0x20
+// other than '"' and '\\' are written verbatim, including high-bit bytes
+// that may not form valid UTF-8.
 func writeJSONString(buf *bytes.Buffer, s []byte) {
 	const hexdigits = "0123456789abcdef"
-	i := 0
-	for i < len(s) {
+	for i := 0; i < len(s); i++ {
 		c := s[i]
 		if c < 0x20 || c == '"' || c == '\\' {
 			switch c {
@@ -452,21 +135,18 @@ func writeJSONString(buf *bytes.Buffer, s []byte) {
 				buf.WriteByte(hexdigits[c>>4])
 				buf.WriteByte(hexdigits[c&0xF])
 			}
-			i++
 			continue
 		}
-		if c < utf8.RuneSelf {
-			buf.WriteByte(c)
-			i++
-			continue
-		}
-		// Multi-byte UTF-8: pass through if valid, replace if not.
-		_, size := utf8.DecodeRune(s[i:])
-		if size == 1 {
-			buf.WriteString(`�`)
-		} else {
-			buf.Write(s[i : i+size])
-		}
-		i += size
+		buf.WriteByte(c)
 	}
+}
+
+// renderJSONAsMySQLText is a thin entry point used by tests. Production
+// code reaches this path through RowsEvent.decodeJSONBinary.
+func renderJSONAsMySQLText(data []byte, ignoreDecodeErr bool) ([]byte, error) {
+	e := &RowsEvent{
+		renderJSONAsMySQLText: true,
+		ignoreJSONDecodeErr:   ignoreDecodeErr,
+	}
+	return e.decodeJSONBinary(data)
 }

--- a/replication/json_mysql_text.go
+++ b/replication/json_mysql_text.go
@@ -1,0 +1,472 @@
+package replication
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"strconv"
+	"unicode/utf8"
+
+	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/pingcap/errors"
+)
+
+// renderJSONAsMySQLText walks a MySQL JSON binary (JSONB) byte stream and
+// emits a textual representation closely matching what MySQL produces from
+// "SELECT json_col" / "CAST(json_col AS char)". It is used when
+// RowsEvent.renderJSONAsMySQLText is true.
+//
+// The default decoder routes every JSONB value through an intermediate Go
+// value (float64, shopspring/decimal, map[string]any, ...) and then
+// json.Marshal. That path silently changes the JSON *type tag*:
+//
+//   - JSONB_DOUBLE 1.0 -> float64(1.0) -> json.Marshal -> "1" (INTEGER)
+//   - JSONB_OPAQUE NEWDECIMAL "1.0" -> Go string "1.0" -> json.Marshal ->
+//     "\"1.0\"" (STRING)
+//
+// Replaying either of those into a MySQL JSON column changes the stored
+// binary representation. Callers feeding the decoded string back into a
+// MySQL JSON column (binlog-based replication / online schema change
+// tools) need the original type to survive the round-trip; this renderer
+// preserves the type tag by emitting text directly from the JSONB byte
+// stream without an intermediate Go-typed value.
+//
+// Known divergences from MySQL's exact textual form:
+//
+//   - Invalid UTF-8 bytes inside JSONB_STRING values are replaced with
+//     U+FFFD; MySQL preserves the raw bytes.
+//   - JSONB_OPAQUE values of an unrecognised inner type are rendered as
+//     "opaque:type=N:<hex>"; MySQL emits "base64:typeN:<base64>".
+//   - JSONB_DOUBLE values use Go's strconv shortest-round-trip formatting
+//     (whole numbers keep ".0"); MySQL uses its own my_gcvt rules and may
+//     differ in scientific-notation exponent padding for edge magnitudes.
+//
+// These are noted because consumers replaying the rendered text into a
+// MySQL JSON column will see those values land as JSON STRING rather
+// than the original JSONB type.
+func renderJSONAsMySQLText(data []byte, ignoreDecodeErr bool) ([]byte, error) {
+	r := &jsonMySQLTextRenderer{ignoreDecodeErr: ignoreDecodeErr}
+	if len(data) < 1 {
+		if ignoreDecodeErr {
+			return []byte("null"), nil
+		}
+		return nil, errors.New("json binary data is empty")
+	}
+	r.renderValue(data[0], data[1:])
+	if r.err != nil {
+		if ignoreDecodeErr {
+			// Return a valid JSON document (matches the legacy decoder's
+			// behaviour of returning Go nil -> json.Marshal -> "null"
+			// rather than leaking a half-written buffer).
+			return []byte("null"), nil
+		}
+		return nil, r.err
+	}
+	return r.buf.Bytes(), nil
+}
+
+type jsonMySQLTextRenderer struct {
+	buf             bytes.Buffer
+	err             error
+	ignoreDecodeErr bool
+}
+
+func (r *jsonMySQLTextRenderer) setErr(err error) {
+	if r.err == nil {
+		r.err = err
+	}
+}
+
+func (r *jsonMySQLTextRenderer) isDataShort(data []byte, expected int) bool {
+	if r.err != nil {
+		return true
+	}
+	if len(data) < expected {
+		r.setErr(errors.Errorf("data len %d < expected %d", len(data), expected))
+		return true
+	}
+	return false
+}
+
+func (r *jsonMySQLTextRenderer) renderValue(tp byte, data []byte) {
+	if r.err != nil {
+		return
+	}
+	switch tp {
+	case JSONB_SMALL_OBJECT:
+		r.renderObjectOrArray(data, true, true)
+	case JSONB_LARGE_OBJECT:
+		r.renderObjectOrArray(data, false, true)
+	case JSONB_SMALL_ARRAY:
+		r.renderObjectOrArray(data, true, false)
+	case JSONB_LARGE_ARRAY:
+		r.renderObjectOrArray(data, false, false)
+	case JSONB_LITERAL:
+		r.renderLiteral(data)
+	case JSONB_INT16:
+		if r.isDataShort(data, 2) {
+			return
+		}
+		r.buf.WriteString(strconv.FormatInt(int64(mysql.ParseBinaryInt16(data[:2])), 10))
+	case JSONB_UINT16:
+		if r.isDataShort(data, 2) {
+			return
+		}
+		r.buf.WriteString(strconv.FormatUint(uint64(mysql.ParseBinaryUint16(data[:2])), 10))
+	case JSONB_INT32:
+		if r.isDataShort(data, 4) {
+			return
+		}
+		r.buf.WriteString(strconv.FormatInt(int64(mysql.ParseBinaryInt32(data[:4])), 10))
+	case JSONB_UINT32:
+		if r.isDataShort(data, 4) {
+			return
+		}
+		r.buf.WriteString(strconv.FormatUint(uint64(mysql.ParseBinaryUint32(data[:4])), 10))
+	case JSONB_INT64:
+		if r.isDataShort(data, 8) {
+			return
+		}
+		r.buf.WriteString(strconv.FormatInt(mysql.ParseBinaryInt64(data[:8]), 10))
+	case JSONB_UINT64:
+		if r.isDataShort(data, 8) {
+			return
+		}
+		r.buf.WriteString(strconv.FormatUint(mysql.ParseBinaryUint64(data[:8]), 10))
+	case JSONB_DOUBLE:
+		if r.isDataShort(data, 8) {
+			return
+		}
+		r.buf.WriteString(formatMySQLDouble(mysql.ParseBinaryFloat64(data[:8])))
+	case JSONB_STRING:
+		r.renderString(data)
+	case JSONB_OPAQUE:
+		r.renderOpaque(data)
+	default:
+		r.setErr(errors.Errorf("invalid json type %d", tp))
+	}
+}
+
+func (r *jsonMySQLTextRenderer) renderLiteral(data []byte) {
+	if r.isDataShort(data, 1) {
+		return
+	}
+	switch data[0] {
+	case JSONB_NULL_LITERAL:
+		r.buf.WriteString("null")
+	case JSONB_TRUE_LITERAL:
+		r.buf.WriteString("true")
+	case JSONB_FALSE_LITERAL:
+		r.buf.WriteString("false")
+	default:
+		r.setErr(errors.Errorf("invalid literal %c", data[0]))
+	}
+}
+
+func (r *jsonMySQLTextRenderer) renderObjectOrArray(data []byte, isSmall, isObject bool) {
+	offsetSize := jsonbGetOffsetSize(isSmall)
+	if r.isDataShort(data, 2*offsetSize) {
+		return
+	}
+	count := decodeJSONCount(data, isSmall)
+	size := decodeJSONCount(data[offsetSize:], isSmall)
+	if r.isDataShort(data, size) {
+		return
+	}
+
+	keyEntrySize := jsonbGetKeyEntrySize(isSmall)
+	valueEntrySize := jsonbGetValueEntrySize(isSmall)
+	headerSize := 2*offsetSize + count*valueEntrySize
+	if isObject {
+		headerSize += count * keyEntrySize
+	}
+	if headerSize > size {
+		r.setErr(errors.Errorf("header size %d > size %d", headerSize, size))
+		return
+	}
+
+	// Decode keys up front (only when iterating an object) so they can be
+	// emitted in order alongside the values.
+	var keys [][]byte
+	if isObject {
+		keys = make([][]byte, count)
+		for i := 0; i < count; i++ {
+			entryOffset := 2*offsetSize + keyEntrySize*i
+			keyOffset := decodeJSONCount(data[entryOffset:], isSmall)
+			keyLength := int(mysql.ParseBinaryUint16(data[entryOffset+offsetSize : entryOffset+offsetSize+2]))
+			if keyOffset < headerSize {
+				r.setErr(errors.Errorf("invalid key offset %d, must >= %d", keyOffset, headerSize))
+				return
+			}
+			if r.isDataShort(data, keyOffset+keyLength) {
+				return
+			}
+			keys[i] = data[keyOffset : keyOffset+keyLength]
+		}
+	}
+
+	if isObject {
+		r.buf.WriteByte('{')
+	} else {
+		r.buf.WriteByte('[')
+	}
+	for i := 0; i < count; i++ {
+		if i > 0 {
+			r.buf.WriteString(", ")
+		}
+		if isObject {
+			r.buf.WriteByte('"')
+			writeJSONString(&r.buf, keys[i])
+			r.buf.WriteString(`": `)
+		}
+
+		entryOffset := 2*offsetSize + valueEntrySize*i
+		if isObject {
+			entryOffset += keyEntrySize * count
+		}
+		tp := data[entryOffset]
+		if isInlineValue(tp, isSmall) {
+			r.renderValue(tp, data[entryOffset+1:entryOffset+valueEntrySize])
+			if r.err != nil {
+				return
+			}
+			continue
+		}
+		valueOffset := decodeJSONCount(data[entryOffset+1:], isSmall)
+		if r.isDataShort(data, valueOffset) {
+			return
+		}
+		r.renderValue(tp, data[valueOffset:])
+		if r.err != nil {
+			return
+		}
+	}
+	if isObject {
+		r.buf.WriteByte('}')
+	} else {
+		r.buf.WriteByte(']')
+	}
+}
+
+func (r *jsonMySQLTextRenderer) renderString(data []byte) {
+	l, n, err := decodeJSONVarLen(data)
+	if err != nil {
+		r.setErr(err)
+		return
+	}
+	if r.isDataShort(data, l+n) {
+		return
+	}
+	r.buf.WriteByte('"')
+	writeJSONString(&r.buf, data[n:n+l])
+	r.buf.WriteByte('"')
+}
+
+func (r *jsonMySQLTextRenderer) renderOpaque(data []byte) {
+	if r.isDataShort(data, 1) {
+		return
+	}
+	opaqueTp := data[0]
+	data = data[1:]
+	l, n, err := decodeJSONVarLen(data)
+	if err != nil {
+		r.setErr(err)
+		return
+	}
+	if r.isDataShort(data, l+n) {
+		return
+	}
+	payload := data[n : n+l]
+	switch opaqueTp {
+	case mysql.MYSQL_TYPE_NEWDECIMAL:
+		if len(payload) < 2 {
+			r.setErr(errors.Errorf("decimal payload too short: %d", len(payload)))
+			return
+		}
+		precision := int(payload[0])
+		scale := int(payload[1])
+		v, _, derr := decodeDecimal(payload[2:], precision, scale, false /*useDecimal*/)
+		if derr != nil {
+			r.setErr(derr)
+			return
+		}
+		// decodeDecimal returns the canonical text form when useDecimal=false.
+		// MySQL formats JSON DECIMAL values as plain numbers (no quotes), so
+		// write the value directly.
+		s, ok := v.(string)
+		if !ok {
+			r.setErr(errors.Errorf("decimal decode produced %T, expected string", v))
+			return
+		}
+		r.buf.WriteString(s)
+	case mysql.MYSQL_TYPE_TIME:
+		r.buf.WriteByte('"')
+		r.buf.WriteString(formatJSONTime(payload))
+		r.buf.WriteByte('"')
+	case mysql.MYSQL_TYPE_DATE, mysql.MYSQL_TYPE_DATETIME, mysql.MYSQL_TYPE_TIMESTAMP:
+		r.buf.WriteByte('"')
+		r.buf.WriteString(formatJSONDateTime(opaqueTp, payload))
+		r.buf.WriteByte('"')
+	default:
+		// MySQL serialises unknown opaque types as base64("opaque-binary").
+		// "SELECT json_col" yields "base64:typeNN:..."; emit the hex form
+		// surrounded by quotes so the consumer at least sees a stable string.
+		r.buf.WriteByte('"')
+		r.buf.WriteString("opaque:type=")
+		r.buf.WriteString(strconv.Itoa(int(opaqueTp)))
+		r.buf.WriteByte(':')
+		r.buf.WriteString(hex.EncodeToString(payload))
+		r.buf.WriteByte('"')
+	}
+}
+
+// formatMySQLDouble formats a float64 the way MySQL does in JSON text:
+// whole-number doubles keep a trailing ".0", and other values use the
+// shortest round-trippable decimal/scientific form that strconv produces.
+// This mirrors FloatWithTrailingZero.MarshalJSON.
+func formatMySQLDouble(f float64) string {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		// MySQL refuses to store NaN/Inf in JSON; we should never see one,
+		// but emit a safe fallback rather than corrupt the surrounding doc.
+		return "null"
+	}
+	if f == math.Trunc(f) && !math.IsInf(f, 0) {
+		// Use FormatFloat 'f' with 1 digit after the decimal so 1.0 stays
+		// "1.0". Matches FloatWithTrailingZero.MarshalJSON.
+		return strconv.FormatFloat(f, 'f', 1, 64)
+	}
+	return strconv.FormatFloat(f, 'g', -1, 64)
+}
+
+func formatJSONTime(payload []byte) string {
+	if len(payload) < 8 {
+		return "00:00:00"
+	}
+	v := mysql.ParseBinaryInt64(payload[:8])
+	if v == 0 {
+		return "00:00:00"
+	}
+	sign := ""
+	if v < 0 {
+		sign = "-"
+		v = -v
+	}
+	intPart := v >> 24
+	hour := (intPart >> 12) % (1 << 10)
+	minute := (intPart >> 6) % (1 << 6)
+	sec := intPart % (1 << 6)
+	frac := v % (1 << 24)
+	return fmt.Sprintf("%s%02d:%02d:%02d.%06d", sign, hour, minute, sec, frac)
+}
+
+func formatJSONDateTime(opaqueTp byte, payload []byte) string {
+	if len(payload) < 8 {
+		return "0000-00-00 00:00:00"
+	}
+	v := mysql.ParseBinaryInt64(payload[:8])
+	if v == 0 {
+		if opaqueTp == mysql.MYSQL_TYPE_DATE {
+			return "0000-00-00"
+		}
+		return "0000-00-00 00:00:00"
+	}
+	if v < 0 {
+		v = -v
+	}
+	intPart := v >> 24
+	ymd := intPart >> 17
+	ym := ymd >> 5
+	hms := intPart % (1 << 17)
+	year := ym / 13
+	month := ym % 13
+	day := ymd % (1 << 5)
+	hour := hms >> 12
+	minute := (hms >> 6) % (1 << 6)
+	second := hms % (1 << 6)
+	frac := v % (1 << 24)
+	if opaqueTp == mysql.MYSQL_TYPE_DATE {
+		return fmt.Sprintf("%04d-%02d-%02d", year, month, day)
+	}
+	return fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d.%06d", year, month, day, hour, minute, second, frac)
+}
+
+func decodeJSONCount(data []byte, isSmall bool) int {
+	if isSmall {
+		return int(mysql.ParseBinaryUint16(data[:2]))
+	}
+	return int(mysql.ParseBinaryUint32(data[:4]))
+}
+
+// decodeJSONVarLen decodes the variable-length integer used by JSONB. It
+// mirrors jsonBinaryDecoder.decodeVariableLength but is reusable without
+// holding an instance.
+func decodeJSONVarLen(data []byte) (length, consumed int, err error) {
+	maxCount := len(data)
+	if maxCount > 5 {
+		maxCount = 5
+	}
+	var l uint64
+	for pos := 0; pos < maxCount; pos++ {
+		v := data[pos]
+		l |= uint64(v&0x7F) << uint(7*pos)
+		if v&0x80 == 0 {
+			if l > math.MaxUint32 {
+				return 0, 0, errors.Errorf("variable length %d exceeds %d", l, int64(math.MaxUint32))
+			}
+			return int(l), pos + 1, nil
+		}
+	}
+	return 0, 0, errors.New("decode variable length failed")
+}
+
+// writeJSONString writes the contents of s as a JSON-escaped string
+// (without surrounding quotes). The escape set matches what
+// goccy/go-json produces for plain Go strings: control chars, quote,
+// backslash, plus invalid UTF-8 bytes as U+FFFD. The U+FFFD substitution
+// is lossy and diverges from MySQL, which preserves raw bytes — callers
+// that need exact round-tripping must ensure inputs are valid UTF-8.
+func writeJSONString(buf *bytes.Buffer, s []byte) {
+	const hexdigits = "0123456789abcdef"
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		if c < 0x20 || c == '"' || c == '\\' {
+			switch c {
+			case '"':
+				buf.WriteString(`\"`)
+			case '\\':
+				buf.WriteString(`\\`)
+			case '\b':
+				buf.WriteString(`\b`)
+			case '\f':
+				buf.WriteString(`\f`)
+			case '\n':
+				buf.WriteString(`\n`)
+			case '\r':
+				buf.WriteString(`\r`)
+			case '\t':
+				buf.WriteString(`\t`)
+			default:
+				buf.WriteString(`\u00`)
+				buf.WriteByte(hexdigits[c>>4])
+				buf.WriteByte(hexdigits[c&0xF])
+			}
+			i++
+			continue
+		}
+		if c < utf8.RuneSelf {
+			buf.WriteByte(c)
+			i++
+			continue
+		}
+		// Multi-byte UTF-8: pass through if valid, replace if not.
+		_, size := utf8.DecodeRune(s[i:])
+		if size == 1 {
+			buf.WriteString(`�`)
+		} else {
+			buf.Write(s[i : i+size])
+		}
+		i += size
+	}
+}

--- a/replication/json_mysql_text.go
+++ b/replication/json_mysql_text.go
@@ -145,13 +145,3 @@ func writeJSONString(buf *bytes.Buffer, s []byte) {
 		buf.WriteByte(c)
 	}
 }
-
-// renderJSONAsMySQLText is a thin entry point used by tests. Production
-// code reaches this path through RowsEvent.decodeJSONBinary.
-func renderJSONAsMySQLText(data []byte, ignoreDecodeErr bool) ([]byte, error) {
-	e := &RowsEvent{
-		renderJSONAsMySQLText: true,
-		ignoreJSONDecodeErr:   ignoreDecodeErr,
-	}
-	return e.decodeJSONBinary(data)
-}

--- a/replication/json_mysql_text_test.go
+++ b/replication/json_mysql_text_test.go
@@ -4,11 +4,23 @@ import (
 	"bytes"
 	"encoding/binary"
 	"math"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/stretchr/testify/require"
 )
+
+// renderJSONAsMySQLText is a thin entry point used by tests. Production
+// code reaches this path through RowsEvent.decodeJSONBinary.
+func renderJSONAsMySQLText(data []byte, ignoreDecodeErr bool) ([]byte, error) {
+	e := &RowsEvent{
+		renderJSONAsMySQLText: true,
+		ignoreJSONDecodeErr:   ignoreDecodeErr,
+	}
+	return e.decodeJSONBinary(data)
+}
 
 func TestFormatMySQLDouble(t *testing.T) {
 	cases := []struct {
@@ -450,4 +462,113 @@ func TestBinlogParser_SetRenderJSONAsMySQLText(t *testing.T) {
 	require.True(t, parser.renderJSONAsMySQLText)
 	parser.SetRenderJSONAsMySQLText(false)
 	require.False(t, parser.renderJSONAsMySQLText)
+}
+
+// TestRenderJSONAsMySQLText_StringEscaping checks that a JSONB_STRING
+// payload containing characters that JSON requires to be escaped
+// (notably ", \, and control bytes) is emitted with the correct
+// backslash escapes. The per-character escape logic lives in
+// writeJSONString and is unit-tested directly by TestWriteJSONString;
+// this case exercises it through jsonString.MarshalJSON to make sure
+// the quote-and-escape sequencing in MarshalJSON is correct.
+func TestRenderJSONAsMySQLText_StringEscaping(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"double_quote", `a"b`, `"a\"b"`},
+		{"backslash", `a\b`, `"a\\b"`},
+		{"both", `a"\b`, `"a\"\\b"`},
+		{"newline", "a\nb", `"a\nb"`},
+		{"control_byte", "a\x01b", `"a\u0001b"`},
+		{"plain", "hello", `"hello"`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			data := append([]byte{JSONB_STRING, byte(len(c.in))}, []byte(c.in)...)
+			out, err := renderJSONAsMySQLText(data, false)
+			require.NoError(t, err)
+			require.Equal(t, c.want, string(out))
+		})
+	}
+}
+
+// TestRenderJSONAsMySQLText_OpaqueDispatch locks in which inner MySQL
+// type bytes take a typed decode path inside JSONB_OPAQUE and which
+// fall through to the "base64:typeN:..." envelope. The explicit set is
+// small (NEWDECIMAL, TIME, DATE, DATETIME, TIMESTAMP); everything else
+// must base64-encode. If a future change adds a new explicit branch in
+// decodeOpaque, this table must be updated too -- otherwise the new
+// branch is the silent kind of change that breaks downstream
+// round-tripping.
+func TestRenderJSONAsMySQLText_OpaqueDispatch(t *testing.T) {
+	// Explicit cases: the output must NOT carry the base64 envelope.
+	// Value formatting is covered by the dedicated Opaque{Decimal,
+	// Date, DateTime, Time} tests above; here we only assert the
+	// dispatch decision.
+	explicit := []struct {
+		name      string
+		innerType byte
+		payload   []byte
+	}{
+		{"NEWDECIMAL", mysql.MYSQL_TYPE_NEWDECIMAL, []byte{0x02, 0x01, 0x81, 0x00}},
+		{"TIME", mysql.MYSQL_TYPE_TIME, encodeJSONTimePayload(t, 0, 0, 0, 0)},
+		{"DATE", mysql.MYSQL_TYPE_DATE, encodeJSONDateTimePayload(t, 2024, 1, 15, 0, 0, 0, 0)},
+		{"DATETIME", mysql.MYSQL_TYPE_DATETIME, encodeJSONDateTimePayload(t, 2024, 1, 15, 10, 30, 45, 0)},
+		{"TIMESTAMP", mysql.MYSQL_TYPE_TIMESTAMP, encodeJSONDateTimePayload(t, 2024, 1, 15, 10, 30, 45, 0)},
+	}
+	for _, c := range explicit {
+		t.Run("explicit/"+c.name, func(t *testing.T) {
+			data := append([]byte{JSONB_OPAQUE, c.innerType, byte(len(c.payload))}, c.payload...)
+			out, err := renderJSONAsMySQLText(data, false)
+			require.NoError(t, err)
+			require.False(t, strings.Contains(string(out), "base64:"),
+				"type %s must not use base64 fallback, got %q", c.name, string(out))
+		})
+	}
+
+	// Fallback cases: every other byte the decoder might see must be
+	// emitted via the base64 envelope, matching mysqld's serialisation.
+	// We assert the full output (not just the prefix) so a regression
+	// that drops or mangles the trailing bytes is caught.
+	fallback := []struct {
+		name      string
+		innerType byte
+	}{
+		{"DECIMAL", mysql.MYSQL_TYPE_DECIMAL},
+		{"TINY", mysql.MYSQL_TYPE_TINY},
+		{"SHORT", mysql.MYSQL_TYPE_SHORT},
+		{"LONG", mysql.MYSQL_TYPE_LONG},
+		{"FLOAT", mysql.MYSQL_TYPE_FLOAT},
+		{"DOUBLE", mysql.MYSQL_TYPE_DOUBLE},
+		{"NULL", mysql.MYSQL_TYPE_NULL},
+		{"LONGLONG", mysql.MYSQL_TYPE_LONGLONG},
+		{"INT24", mysql.MYSQL_TYPE_INT24},
+		{"YEAR", mysql.MYSQL_TYPE_YEAR},
+		{"NEWDATE", mysql.MYSQL_TYPE_NEWDATE},
+		{"VARCHAR", mysql.MYSQL_TYPE_VARCHAR},
+		{"BIT", mysql.MYSQL_TYPE_BIT},
+		{"JSON", mysql.MYSQL_TYPE_JSON},
+		{"ENUM", mysql.MYSQL_TYPE_ENUM},
+		{"SET", mysql.MYSQL_TYPE_SET},
+		{"TINY_BLOB", mysql.MYSQL_TYPE_TINY_BLOB},
+		{"MEDIUM_BLOB", mysql.MYSQL_TYPE_MEDIUM_BLOB},
+		{"LONG_BLOB", mysql.MYSQL_TYPE_LONG_BLOB},
+		{"BLOB", mysql.MYSQL_TYPE_BLOB},
+		{"VAR_STRING", mysql.MYSQL_TYPE_VAR_STRING},
+		{"STRING", mysql.MYSQL_TYPE_STRING},
+		{"GEOMETRY", mysql.MYSQL_TYPE_GEOMETRY},
+	}
+	payload := []byte{0xDE, 0xAD}
+	const wantB64 = "3q0=" // base64.StdEncoding.EncodeToString([]byte{0xDE, 0xAD})
+	for _, c := range fallback {
+		t.Run("fallback/"+c.name, func(t *testing.T) {
+			data := append([]byte{JSONB_OPAQUE, c.innerType, byte(len(payload))}, payload...)
+			out, err := renderJSONAsMySQLText(data, false)
+			require.NoError(t, err)
+			want := `"base64:type` + strconv.Itoa(int(c.innerType)) + `:` + wantB64 + `"`
+			require.Equal(t, want, string(out))
+		})
+	}
 }

--- a/replication/json_mysql_text_test.go
+++ b/replication/json_mysql_text_test.go
@@ -1,0 +1,291 @@
+package replication
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatMySQLDouble(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want string
+	}{
+		// Whole-number doubles must keep the trailing zero so MySQL re-stores
+		// them as JSON DOUBLE, not JSON INTEGER. This is the bug
+		// UseFloatWithTrailingZero already addresses for the non-MySQL-text
+		// path; the renderer must match that behaviour.
+		{1.0, "1.0"},
+		{0.0, "0.0"},
+		{-3.0, "-3.0"},
+		{1e10, "10000000000.0"},
+		// Non-integer values: shortest round-trippable form.
+		{3.14, "3.14"},
+		{-2.5, "-2.5"},
+		{0.1, "0.1"},
+		{1.5e-5, "1.5e-05"},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, formatMySQLDouble(c.in), "in=%v", c.in)
+	}
+	// NaN/Inf should not corrupt the surrounding document.
+	require.Equal(t, "null", formatMySQLDouble(math.NaN()))
+	require.Equal(t, "null", formatMySQLDouble(math.Inf(1)))
+	require.Equal(t, "null", formatMySQLDouble(math.Inf(-1)))
+}
+
+func TestWriteJSONString(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{`hello`, `hello`},
+		{`a"b`, `a\"b`},
+		{`a\b`, `a\\b`},
+		{"line1\nline2", `line1\nline2`},
+		{"tab\there", `tab\there`},
+		{"ctrl\x01char", `ctrl\u0001char`},
+		{"unicode: é 漢", "unicode: é 漢"},
+	}
+	for _, c := range cases {
+		var buf bytes.Buffer
+		writeJSONString(&buf, []byte(c.in))
+		require.Equal(t, c.want, buf.String(), "in=%q", c.in)
+	}
+}
+
+// TestRenderJSONAsMySQLText_Double exercises the renderer directly on a
+// hand-constructed JSONB_DOUBLE byte stream (the simplest JSONB layout:
+// a single scalar). It confirms the renderer emits MySQL-style "1.0" for
+// a whole-number double instead of "1" (which the legacy decoder would
+// produce because float64(1.0) marshals to "1" via json.Marshal).
+//
+// JSONB_OBJECT / JSONB_ARRAY / JSONB_OPAQUE layouts (offset tables,
+// inline-vs-pointer values, NEWDECIMAL/DATETIME payloads) are covered by
+// the fixture tests below. Full end-to-end coverage against a live MySQL
+// binlog stream lives in github.com/block/spirit's pkg/repl tests.
+func TestRenderJSONAsMySQLText_Double(t *testing.T) {
+	// JSONB top-level value: a single type byte followed by 8 bytes of
+	// little-endian IEEE 754 representing 1.0.
+	data := make([]byte, 1+8)
+	data[0] = JSONB_DOUBLE
+	binary.LittleEndian.PutUint64(data[1:], math.Float64bits(1.0))
+
+	out, err := renderJSONAsMySQLText(data, false)
+	require.NoError(t, err)
+	require.Equal(t, "1.0", string(out))
+}
+
+// TestRenderJSONAsMySQLText_Int verifies that JSONB integers stay
+// integers (no spurious ".0" decoration).
+func TestRenderJSONAsMySQLText_Int(t *testing.T) {
+	data := make([]byte, 1+2)
+	data[0] = JSONB_INT16
+	binary.LittleEndian.PutUint16(data[1:], uint16(int16(42)))
+
+	out, err := renderJSONAsMySQLText(data, false)
+	require.NoError(t, err)
+	require.Equal(t, "42", string(out))
+}
+
+// TestRenderJSONAsMySQLText_Literal exercises the LITERAL path.
+func TestRenderJSONAsMySQLText_Literal(t *testing.T) {
+	cases := []struct {
+		lit  byte
+		want string
+	}{
+		{JSONB_NULL_LITERAL, "null"},
+		{JSONB_TRUE_LITERAL, "true"},
+		{JSONB_FALSE_LITERAL, "false"},
+	}
+	for _, c := range cases {
+		data := []byte{JSONB_LITERAL, c.lit}
+		out, err := renderJSONAsMySQLText(data, false)
+		require.NoError(t, err)
+		require.Equal(t, c.want, string(out))
+	}
+}
+
+// TestRenderJSONAsMySQLText_EmptyObject and _EmptyArray check the
+// degenerate header-only cases.
+func TestRenderJSONAsMySQLText_EmptyObject(t *testing.T) {
+	// SMALL_OBJECT body: count=0 (LE u16), size=4 (LE u16) -- just the header.
+	data := []byte{JSONB_SMALL_OBJECT, 0x00, 0x00, 0x04, 0x00}
+	out, err := renderJSONAsMySQLText(data, false)
+	require.NoError(t, err)
+	require.Equal(t, "{}", string(out))
+}
+
+func TestRenderJSONAsMySQLText_EmptyArray(t *testing.T) {
+	data := []byte{JSONB_SMALL_ARRAY, 0x00, 0x00, 0x04, 0x00}
+	out, err := renderJSONAsMySQLText(data, false)
+	require.NoError(t, err)
+	require.Equal(t, "[]", string(out))
+}
+
+// TestRenderJSONAsMySQLText_Object exercises the SMALL_OBJECT offset table
+// with one inline value (INT16) and one pointer value (STRING). This is
+// the main path that risks getting offset arithmetic wrong.
+func TestRenderJSONAsMySQLText_Object(t *testing.T) {
+	// Layout for {"a": 1, "b": "x"} as JSONB SMALL_OBJECT body:
+	//   0-1   count = 2                       (LE u16)
+	//   2-3   total body size = 22            (LE u16)
+	//   4-7   key entry 0: offset=18, len=1   ("a")
+	//   8-11  key entry 1: offset=19, len=1   ("b")
+	//   12-14 value entry 0: INT16 inline, 1
+	//   15-17 value entry 1: STRING, offset=20
+	//   18    'a'
+	//   19    'b'
+	//   20    varlen prefix = 1
+	//   21    'x'
+	body := []byte{
+		0x02, 0x00, // count = 2
+		0x16, 0x00, // size = 22
+		0x12, 0x00, 0x01, 0x00, // key entry 0
+		0x13, 0x00, 0x01, 0x00, // key entry 1
+		JSONB_INT16, 0x01, 0x00, // value 0: INT16 inline = 1
+		JSONB_STRING, 0x14, 0x00, // value 1: STRING at offset 20
+		'a',
+		'b',
+		0x01, 'x',
+	}
+	data := append([]byte{JSONB_SMALL_OBJECT}, body...)
+	out, err := renderJSONAsMySQLText(data, false)
+	require.NoError(t, err)
+	require.Equal(t, `{"a": 1, "b": "x"}`, string(out))
+}
+
+// TestRenderJSONAsMySQLText_Array exercises SMALL_ARRAY with a mix of
+// inline scalars (INT16, LITERAL) and a pointer value (STRING).
+func TestRenderJSONAsMySQLText_Array(t *testing.T) {
+	// Layout for [1, "x", true]:
+	//   0-1  count = 3
+	//   2-3  size = 15
+	//   4-6  value 0: INT16 inline = 1
+	//   7-9  value 1: STRING at offset 13
+	//   10-12 value 2: LITERAL inline = true
+	//   13   varlen = 1
+	//   14   'x'
+	body := []byte{
+		0x03, 0x00, // count = 3
+		0x0F, 0x00, // size = 15
+		JSONB_INT16, 0x01, 0x00, // value 0: INT16 inline = 1
+		JSONB_STRING, 0x0D, 0x00, // value 1: STRING at offset 13
+		JSONB_LITERAL, JSONB_TRUE_LITERAL, 0x00, // value 2: LITERAL inline true
+		0x01, 'x',
+	}
+	data := append([]byte{JSONB_SMALL_ARRAY}, body...)
+	out, err := renderJSONAsMySQLText(data, false)
+	require.NoError(t, err)
+	require.Equal(t, `[1, "x", true]`, string(out))
+}
+
+// TestRenderJSONAsMySQLText_OpaqueDecimal exercises the NEWDECIMAL path
+// inside JSONB_OPAQUE. This is the value class where the legacy decoder
+// loses the JSON DECIMAL type (it becomes a quoted JSON STRING) and the
+// renderer must keep the value unquoted.
+func TestRenderJSONAsMySQLText_OpaqueDecimal(t *testing.T) {
+	// For precision=2, scale=1 the MySQL DECIMAL binary form needs 1 byte
+	// for the integer digit and 1 byte for the fractional digit. The sign
+	// is encoded in the high bit of the first byte (set => positive).
+	//   0x81 = positive '1'
+	//   0x00 = '0' fractional
+	data := []byte{
+		JSONB_OPAQUE,
+		mysql.MYSQL_TYPE_NEWDECIMAL,
+		0x04,       // payload varlen = 4 bytes
+		0x02, 0x01, // precision=2, scale=1
+		0x81, 0x00, // decimal bytes: 1.0
+	}
+	out, err := renderJSONAsMySQLText(data, false)
+	require.NoError(t, err)
+	// MySQL renders JSON DECIMAL values unquoted -- this is the whole
+	// point of the renderer for round-tripping back into JSON.
+	require.Equal(t, "1.0", string(out))
+}
+
+func encodeJSONDateTimePayload(t *testing.T, year, month, day, hour, minute, second, frac int64) []byte {
+	t.Helper()
+	ym := year*13 + month
+	ymd := (ym << 5) | day
+	hms := (hour << 12) | (minute << 6) | second
+	intPart := (ymd << 17) | hms
+	v := (intPart << 24) | frac
+	payload := make([]byte, 8)
+	binary.LittleEndian.PutUint64(payload, uint64(v))
+	return payload
+}
+
+func encodeJSONTimePayload(t *testing.T, hour, minute, second, frac int64) []byte {
+	t.Helper()
+	intPart := (hour << 12) | (minute << 6) | second
+	v := (intPart << 24) | frac
+	payload := make([]byte, 8)
+	binary.LittleEndian.PutUint64(payload, uint64(v))
+	return payload
+}
+
+// TestRenderJSONAsMySQLText_OpaqueDateTime exercises the DATETIME path.
+// MySQL emits these quoted with microsecond resolution.
+func TestRenderJSONAsMySQLText_OpaqueDateTime(t *testing.T) {
+	payload := encodeJSONDateTimePayload(t, 2024, 1, 15, 10, 30, 45, 123456)
+	data := append([]byte{JSONB_OPAQUE, mysql.MYSQL_TYPE_DATETIME, 0x08}, payload...)
+	out, err := renderJSONAsMySQLText(data, false)
+	require.NoError(t, err)
+	require.Equal(t, `"2024-01-15 10:30:45.123456"`, string(out))
+}
+
+// TestRenderJSONAsMySQLText_OpaqueDate exercises the DATE path. The
+// renderer is more correct here than the legacy decoder, which always
+// formats DATE values with a trailing " 00:00:00.000000".
+func TestRenderJSONAsMySQLText_OpaqueDate(t *testing.T) {
+	payload := encodeJSONDateTimePayload(t, 2024, 1, 15, 0, 0, 0, 0)
+	data := append([]byte{JSONB_OPAQUE, mysql.MYSQL_TYPE_DATE, 0x08}, payload...)
+	out, err := renderJSONAsMySQLText(data, false)
+	require.NoError(t, err)
+	require.Equal(t, `"2024-01-15"`, string(out))
+}
+
+// TestRenderJSONAsMySQLText_OpaqueTime exercises the TIME path.
+func TestRenderJSONAsMySQLText_OpaqueTime(t *testing.T) {
+	payload := encodeJSONTimePayload(t, 10, 30, 45, 123456)
+	data := append([]byte{JSONB_OPAQUE, mysql.MYSQL_TYPE_TIME, 0x08}, payload...)
+	out, err := renderJSONAsMySQLText(data, false)
+	require.NoError(t, err)
+	require.Equal(t, `"10:30:45.123456"`, string(out))
+}
+
+// TestRenderJSONAsMySQLText_IgnoreDecodeError verifies that with
+// ignoreDecodeErr=true the renderer returns a *valid* JSON document
+// ("null") rather than the half-written buffer it accumulated before
+// hitting the error. This matches the legacy decoder, which returns
+// Go nil -> json.Marshal -> "null" in the same scenario.
+func TestRenderJSONAsMySQLText_IgnoreDecodeError(t *testing.T) {
+	// SMALL_OBJECT body that claims size=10 but only supplies 4 bytes.
+	data := []byte{JSONB_SMALL_OBJECT, 0x00, 0x00, 0x0A, 0x00}
+
+	_, err := renderJSONAsMySQLText(data, false)
+	require.Error(t, err)
+
+	out, err := renderJSONAsMySQLText(data, true)
+	require.NoError(t, err)
+	require.Equal(t, "null", string(out))
+
+	// Empty data is also a valid JSON "null" when errors are ignored.
+	out, err = renderJSONAsMySQLText(nil, true)
+	require.NoError(t, err)
+	require.Equal(t, "null", string(out))
+}
+
+func TestBinlogParser_SetRenderJSONAsMySQLText(t *testing.T) {
+	parser := NewBinlogParser()
+	require.False(t, parser.renderJSONAsMySQLText)
+	parser.SetRenderJSONAsMySQLText(true)
+	require.True(t, parser.renderJSONAsMySQLText)
+	parser.SetRenderJSONAsMySQLText(false)
+	require.False(t, parser.renderJSONAsMySQLText)
+}

--- a/replication/json_mysql_text_test.go
+++ b/replication/json_mysql_text_test.go
@@ -79,10 +79,10 @@ func TestWriteJSONString(t *testing.T) {
 	}
 }
 
-// TestRenderJSONAsMySQLText_OpaqueUnknown covers the fallback branch for
+// TestRenderJSONAsMySQLTextOpaqueUnknown covers the fallback branch for
 // JSONB_OPAQUE values whose inner type is not one of the recognised MySQL
 // temporal/decimal types. MySQL serialises these as "base64:typeNN:<b64>".
-func TestRenderJSONAsMySQLText_OpaqueUnknown(t *testing.T) {
+func TestRenderJSONAsMySQLTextOpaqueUnknown(t *testing.T) {
 	payload := []byte{0xDE, 0xAD, 0xBE, 0xEF}
 	// MYSQL_TYPE_BLOB (0xfc) is not handled specially by the decoder.
 	data := append([]byte{JSONB_OPAQUE, mysql.MYSQL_TYPE_BLOB, byte(len(payload))}, payload...)
@@ -91,7 +91,7 @@ func TestRenderJSONAsMySQLText_OpaqueUnknown(t *testing.T) {
 	require.Equal(t, `"base64:type252:3q2+7w=="`, string(out))
 }
 
-// TestRenderJSONAsMySQLText_Double exercises the renderer directly on a
+// TestRenderJSONAsMySQLTextDouble exercises the renderer directly on a
 // hand-constructed JSONB_DOUBLE byte stream (the simplest JSONB layout:
 // a single scalar). It confirms the renderer emits MySQL-style "1.0" for
 // a whole-number double instead of "1" (which the legacy decoder would
@@ -101,7 +101,7 @@ func TestRenderJSONAsMySQLText_OpaqueUnknown(t *testing.T) {
 // inline-vs-pointer values, NEWDECIMAL/DATETIME payloads) are covered by
 // the fixture tests below. Full end-to-end coverage against a live MySQL
 // binlog stream lives in github.com/block/spirit's pkg/repl tests.
-func TestRenderJSONAsMySQLText_Double(t *testing.T) {
+func TestRenderJSONAsMySQLTextDouble(t *testing.T) {
 	// JSONB top-level value: a single type byte followed by 8 bytes of
 	// little-endian IEEE 754 representing 1.0.
 	data := make([]byte, 1+8)
@@ -113,9 +113,9 @@ func TestRenderJSONAsMySQLText_Double(t *testing.T) {
 	require.Equal(t, "1.0", string(out))
 }
 
-// TestRenderJSONAsMySQLText_Int verifies that JSONB integers stay
+// TestRenderJSONAsMySQLTextInt verifies that JSONB integers stay
 // integers (no spurious ".0" decoration).
-func TestRenderJSONAsMySQLText_Int(t *testing.T) {
+func TestRenderJSONAsMySQLTextInt(t *testing.T) {
 	data := make([]byte, 1+2)
 	data[0] = JSONB_INT16
 	binary.LittleEndian.PutUint16(data[1:], uint16(int16(42)))
@@ -125,8 +125,8 @@ func TestRenderJSONAsMySQLText_Int(t *testing.T) {
 	require.Equal(t, "42", string(out))
 }
 
-// TestRenderJSONAsMySQLText_Literal exercises the LITERAL path.
-func TestRenderJSONAsMySQLText_Literal(t *testing.T) {
+// TestRenderJSONAsMySQLTextLiteral exercises the LITERAL path.
+func TestRenderJSONAsMySQLTextLiteral(t *testing.T) {
 	cases := []struct {
 		lit  byte
 		want string
@@ -143,9 +143,9 @@ func TestRenderJSONAsMySQLText_Literal(t *testing.T) {
 	}
 }
 
-// TestRenderJSONAsMySQLText_EmptyObject and _EmptyArray check the
-// degenerate header-only cases.
-func TestRenderJSONAsMySQLText_EmptyObject(t *testing.T) {
+// TestRenderJSONAsMySQLTextEmptyObject and TestRenderJSONAsMySQLTextEmptyArray
+// check the degenerate header-only cases.
+func TestRenderJSONAsMySQLTextEmptyObject(t *testing.T) {
 	// SMALL_OBJECT body: count=0 (LE u16), size=4 (LE u16) -- just the header.
 	data := []byte{JSONB_SMALL_OBJECT, 0x00, 0x00, 0x04, 0x00}
 	out, err := renderJSONAsMySQLText(data, false)
@@ -153,17 +153,17 @@ func TestRenderJSONAsMySQLText_EmptyObject(t *testing.T) {
 	require.Equal(t, "{}", string(out))
 }
 
-func TestRenderJSONAsMySQLText_EmptyArray(t *testing.T) {
+func TestRenderJSONAsMySQLTextEmptyArray(t *testing.T) {
 	data := []byte{JSONB_SMALL_ARRAY, 0x00, 0x00, 0x04, 0x00}
 	out, err := renderJSONAsMySQLText(data, false)
 	require.NoError(t, err)
 	require.Equal(t, "[]", string(out))
 }
 
-// TestRenderJSONAsMySQLText_Object exercises the SMALL_OBJECT offset table
+// TestRenderJSONAsMySQLTextObject exercises the SMALL_OBJECT offset table
 // with one inline value (INT16) and one pointer value (STRING). This is
 // the main path that risks getting offset arithmetic wrong.
-func TestRenderJSONAsMySQLText_Object(t *testing.T) {
+func TestRenderJSONAsMySQLTextObject(t *testing.T) {
 	// Layout for {"a": 1, "b": "x"} as JSONB SMALL_OBJECT body:
 	//   0-1   count = 2                       (LE u16)
 	//   2-3   total body size = 22            (LE u16)
@@ -192,9 +192,9 @@ func TestRenderJSONAsMySQLText_Object(t *testing.T) {
 	require.Equal(t, `{"a":1,"b":"x"}`, string(out))
 }
 
-// TestRenderJSONAsMySQLText_Array exercises SMALL_ARRAY with a mix of
+// TestRenderJSONAsMySQLTextArray exercises SMALL_ARRAY with a mix of
 // inline scalars (INT16, LITERAL) and a pointer value (STRING).
-func TestRenderJSONAsMySQLText_Array(t *testing.T) {
+func TestRenderJSONAsMySQLTextArray(t *testing.T) {
 	// Layout for [1, "x", true]:
 	//   0-1  count = 3
 	//   2-3  size = 15
@@ -217,11 +217,11 @@ func TestRenderJSONAsMySQLText_Array(t *testing.T) {
 	require.Equal(t, `[1,"x",true]`, string(out))
 }
 
-// TestRenderJSONAsMySQLText_LargeObject exercises the LARGE_OBJECT
+// TestRenderJSONAsMySQLTextLargeObject exercises the LARGE_OBJECT
 // offset table (4-byte offsets/counts) which the SMALL_OBJECT test
 // does not cover. INT32 also becomes an inline value in large mode,
 // where it was a pointer value in small mode.
-func TestRenderJSONAsMySQLText_LargeObject(t *testing.T) {
+func TestRenderJSONAsMySQLTextLargeObject(t *testing.T) {
 	// Layout for {"a": 1, "b": "x"} as JSONB LARGE_OBJECT body:
 	//   header (u32 count, u32 size)        = 8 bytes
 	//   2 key entries (u32 offset, u16 len) = 12 bytes
@@ -252,10 +252,10 @@ func TestRenderJSONAsMySQLText_LargeObject(t *testing.T) {
 	require.Equal(t, `{"a":1,"b":"x"}`, string(out))
 }
 
-// TestRenderJSONAsMySQLText_LargeArray exercises the LARGE_ARRAY path
+// TestRenderJSONAsMySQLTextLargeArray exercises the LARGE_ARRAY path
 // with a mix of inline scalars (INT16, LITERAL) and a pointer value
 // (STRING).
-func TestRenderJSONAsMySQLText_LargeArray(t *testing.T) {
+func TestRenderJSONAsMySQLTextLargeArray(t *testing.T) {
 	// Layout for [1, "x", true] as JSONB LARGE_ARRAY body:
 	//   header (u32 count, u32 size)      = 8 bytes
 	//   3 value entries (u8 tp, u32 slot) = 15 bytes
@@ -278,11 +278,11 @@ func TestRenderJSONAsMySQLText_LargeArray(t *testing.T) {
 	require.Equal(t, `[1,"x",true]`, string(out))
 }
 
-// TestRenderJSONAsMySQLText_NestedObject exercises a jsonObject value
+// TestRenderJSONAsMySQLTextNestedObject exercises a jsonObject value
 // nested inside another jsonObject. This is the path that would break
 // if jsonObject.MarshalJSON ever stopped recursing through json.Marshal
 // (e.g. if a future change started writing leaf bytes directly).
-func TestRenderJSONAsMySQLText_NestedObject(t *testing.T) {
+func TestRenderJSONAsMySQLTextNestedObject(t *testing.T) {
 	// Inner SMALL_OBJECT body for {"inner": 1}:
 	//   header (u16,u16) = 4
 	//   1 key entry      = 4
@@ -317,11 +317,11 @@ func TestRenderJSONAsMySQLText_NestedObject(t *testing.T) {
 	require.Equal(t, `{"outer":{"inner":1}}`, string(out))
 }
 
-// TestRenderJSONAsMySQLText_KeyEscaping verifies that object keys go
+// TestRenderJSONAsMySQLTextKeyEscaping verifies that object keys go
 // through the same escaping path as string values: characters needing
 // JSON escapes are escaped, and multi-byte UTF-8 passes through
 // verbatim.
-func TestRenderJSONAsMySQLText_KeyEscaping(t *testing.T) {
+func TestRenderJSONAsMySQLTextKeyEscaping(t *testing.T) {
 	// SMALL_OBJECT body for {"a\"b": 1, "héllo": 2}.
 	// "a\"b" is 3 bytes; "héllo" is 6 bytes (é = 0xC3 0xA9 in UTF-8).
 	//   header        = 4
@@ -347,10 +347,10 @@ func TestRenderJSONAsMySQLText_KeyEscaping(t *testing.T) {
 	require.Equal(t, "{\"a\\\"b\":1,\"héllo\":2}", string(out))
 }
 
-// TestRenderJSONAsMySQLText_OpaqueDecimalShort exercises the bounds
+// TestRenderJSONAsMySQLTextOpaqueDecimalShort exercises the bounds
 // check on the NEWDECIMAL header. Previously a payload shorter than 2
 // bytes would index past the slice; now it surfaces a decode error.
-func TestRenderJSONAsMySQLText_OpaqueDecimalShort(t *testing.T) {
+func TestRenderJSONAsMySQLTextOpaqueDecimalShort(t *testing.T) {
 	data := []byte{
 		JSONB_OPAQUE,
 		mysql.MYSQL_TYPE_NEWDECIMAL,
@@ -361,11 +361,11 @@ func TestRenderJSONAsMySQLText_OpaqueDecimalShort(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestRenderJSONAsMySQLText_OpaqueDecimal exercises the NEWDECIMAL path
+// TestRenderJSONAsMySQLTextOpaqueDecimal exercises the NEWDECIMAL path
 // inside JSONB_OPAQUE. This is the value class where the legacy decoder
 // loses the JSON DECIMAL type (it becomes a quoted JSON STRING) and the
 // renderer must keep the value unquoted.
-func TestRenderJSONAsMySQLText_OpaqueDecimal(t *testing.T) {
+func TestRenderJSONAsMySQLTextOpaqueDecimal(t *testing.T) {
 	// For precision=2, scale=1 the MySQL DECIMAL binary form needs 1 byte
 	// for the integer digit and 1 byte for the fractional digit. The sign
 	// is encoded in the high bit of the first byte (set => positive).
@@ -406,9 +406,9 @@ func encodeJSONTimePayload(t *testing.T, hour, minute, second, frac int64) []byt
 	return payload
 }
 
-// TestRenderJSONAsMySQLText_OpaqueDateTime exercises the DATETIME path.
+// TestRenderJSONAsMySQLTextOpaqueDateTime exercises the DATETIME path.
 // MySQL emits these quoted with microsecond resolution.
-func TestRenderJSONAsMySQLText_OpaqueDateTime(t *testing.T) {
+func TestRenderJSONAsMySQLTextOpaqueDateTime(t *testing.T) {
 	payload := encodeJSONDateTimePayload(t, 2024, 1, 15, 10, 30, 45, 123456)
 	data := append([]byte{JSONB_OPAQUE, mysql.MYSQL_TYPE_DATETIME, 0x08}, payload...)
 	out, err := renderJSONAsMySQLText(data, false)
@@ -416,10 +416,10 @@ func TestRenderJSONAsMySQLText_OpaqueDateTime(t *testing.T) {
 	require.Equal(t, `"2024-01-15 10:30:45.123456"`, string(out))
 }
 
-// TestRenderJSONAsMySQLText_OpaqueDate exercises the DATE path. The
+// TestRenderJSONAsMySQLTextOpaqueDate exercises the DATE path. The
 // renderer is more correct here than the legacy decoder, which always
 // formats DATE values with a trailing " 00:00:00.000000".
-func TestRenderJSONAsMySQLText_OpaqueDate(t *testing.T) {
+func TestRenderJSONAsMySQLTextOpaqueDate(t *testing.T) {
 	payload := encodeJSONDateTimePayload(t, 2024, 1, 15, 0, 0, 0, 0)
 	data := append([]byte{JSONB_OPAQUE, mysql.MYSQL_TYPE_DATE, 0x08}, payload...)
 	out, err := renderJSONAsMySQLText(data, false)
@@ -427,8 +427,8 @@ func TestRenderJSONAsMySQLText_OpaqueDate(t *testing.T) {
 	require.Equal(t, `"2024-01-15"`, string(out))
 }
 
-// TestRenderJSONAsMySQLText_OpaqueTime exercises the TIME path.
-func TestRenderJSONAsMySQLText_OpaqueTime(t *testing.T) {
+// TestRenderJSONAsMySQLTextOpaqueTime exercises the TIME path.
+func TestRenderJSONAsMySQLTextOpaqueTime(t *testing.T) {
 	payload := encodeJSONTimePayload(t, 10, 30, 45, 123456)
 	data := append([]byte{JSONB_OPAQUE, mysql.MYSQL_TYPE_TIME, 0x08}, payload...)
 	out, err := renderJSONAsMySQLText(data, false)
@@ -436,12 +436,12 @@ func TestRenderJSONAsMySQLText_OpaqueTime(t *testing.T) {
 	require.Equal(t, `"10:30:45.123456"`, string(out))
 }
 
-// TestRenderJSONAsMySQLText_IgnoreDecodeError verifies that with
+// TestRenderJSONAsMySQLTextIgnoreDecodeError verifies that with
 // ignoreDecodeErr=true the renderer returns a *valid* JSON document
 // ("null") rather than the half-written buffer it accumulated before
 // hitting the error. This matches the legacy decoder, which returns
 // Go nil -> json.Marshal -> "null" in the same scenario.
-func TestRenderJSONAsMySQLText_IgnoreDecodeError(t *testing.T) {
+func TestRenderJSONAsMySQLTextIgnoreDecodeError(t *testing.T) {
 	// SMALL_OBJECT body that claims size=10 but only supplies 4 bytes.
 	data := []byte{JSONB_SMALL_OBJECT, 0x00, 0x00, 0x0A, 0x00}
 
@@ -458,7 +458,7 @@ func TestRenderJSONAsMySQLText_IgnoreDecodeError(t *testing.T) {
 	require.Equal(t, "null", string(out))
 }
 
-func TestBinlogParser_SetRenderJSONAsMySQLText(t *testing.T) {
+func TestBinlogParserSetRenderJSONAsMySQLText(t *testing.T) {
 	parser := NewBinlogParser()
 	require.False(t, parser.renderJSONAsMySQLText)
 	parser.SetRenderJSONAsMySQLText(true)
@@ -467,14 +467,14 @@ func TestBinlogParser_SetRenderJSONAsMySQLText(t *testing.T) {
 	require.False(t, parser.renderJSONAsMySQLText)
 }
 
-// TestRenderJSONAsMySQLText_StringEscaping checks that a JSONB_STRING
+// TestRenderJSONAsMySQLTextStringEscaping checks that a JSONB_STRING
 // payload containing characters that JSON requires to be escaped
 // (notably ", \, and control bytes) is emitted with the correct
 // backslash escapes. The per-character escape logic lives in
 // writeJSONString and is unit-tested directly by TestWriteJSONString;
 // this case exercises it through jsonString.MarshalJSON to make sure
 // the quote-and-escape sequencing in MarshalJSON is correct.
-func TestRenderJSONAsMySQLText_StringEscaping(t *testing.T) {
+func TestRenderJSONAsMySQLTextStringEscaping(t *testing.T) {
 	cases := []struct {
 		name string
 		in   string
@@ -497,7 +497,7 @@ func TestRenderJSONAsMySQLText_StringEscaping(t *testing.T) {
 	}
 }
 
-// TestRenderJSONAsMySQLText_OpaqueDispatch locks in which inner MySQL
+// TestRenderJSONAsMySQLTextOpaqueDispatch locks in which inner MySQL
 // type bytes take a typed decode path inside JSONB_OPAQUE and which
 // fall through to the "base64:typeN:..." envelope. The explicit set is
 // small (NEWDECIMAL, TIME, DATE, DATETIME, TIMESTAMP); everything else
@@ -505,7 +505,7 @@ func TestRenderJSONAsMySQLText_StringEscaping(t *testing.T) {
 // decodeOpaque, this table must be updated too -- otherwise the new
 // branch is the silent kind of change that breaks downstream
 // round-tripping.
-func TestRenderJSONAsMySQLText_OpaqueDispatch(t *testing.T) {
+func TestRenderJSONAsMySQLTextOpaqueDispatch(t *testing.T) {
 	// Explicit cases: the output must NOT carry the base64 envelope.
 	// Value formatting is covered by the dedicated Opaque{Decimal,
 	// Date, DateTime, Time} tests above; here we only assert the

--- a/replication/json_mysql_text_test.go
+++ b/replication/json_mysql_text_test.go
@@ -23,7 +23,10 @@ func TestFormatMySQLDouble(t *testing.T) {
 		{0.0, "0.0"},
 		{-3.0, "-3.0"},
 		{1e10, "10000000000.0"},
-		// Non-integer values: shortest round-trippable form.
+		// Non-integer values: shortest round-trippable form. Note that
+		// Go's 'g' emits "1.5e-05" where MySQL's my_gcvt emits "1.5e-5";
+		// the float64 value (and therefore the re-stored JSONB) is
+		// identical, only the visible text differs.
 		{3.14, "3.14"},
 		{-2.5, "-2.5"},
 		{0.1, "0.1"},
@@ -50,12 +53,27 @@ func TestWriteJSONString(t *testing.T) {
 		{"tab\there", `tab\there`},
 		{"ctrl\x01char", `ctrl\u0001char`},
 		{"unicode: é 漢", "unicode: é 漢"},
+		// MySQL JSON is byte-transparent; invalid UTF-8 bytes are passed
+		// through verbatim rather than replaced with U+FFFD.
+		{"\xff\xfe", "\xff\xfe"},
 	}
 	for _, c := range cases {
 		var buf bytes.Buffer
 		writeJSONString(&buf, []byte(c.in))
 		require.Equal(t, c.want, buf.String(), "in=%q", c.in)
 	}
+}
+
+// TestRenderJSONAsMySQLText_OpaqueUnknown covers the fallback branch for
+// JSONB_OPAQUE values whose inner type is not one of the recognised MySQL
+// temporal/decimal types. MySQL serialises these as "base64:typeNN:<b64>".
+func TestRenderJSONAsMySQLText_OpaqueUnknown(t *testing.T) {
+	payload := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	// MYSQL_TYPE_BLOB (0xfc) is not handled specially by the decoder.
+	data := append([]byte{JSONB_OPAQUE, mysql.MYSQL_TYPE_BLOB, byte(len(payload))}, payload...)
+	out, err := renderJSONAsMySQLText(data, false)
+	require.NoError(t, err)
+	require.Equal(t, `"base64:type252:3q2+7w=="`, string(out))
 }
 
 // TestRenderJSONAsMySQLText_Double exercises the renderer directly on a
@@ -156,7 +174,7 @@ func TestRenderJSONAsMySQLText_Object(t *testing.T) {
 	data := append([]byte{JSONB_SMALL_OBJECT}, body...)
 	out, err := renderJSONAsMySQLText(data, false)
 	require.NoError(t, err)
-	require.Equal(t, `{"a": 1, "b": "x"}`, string(out))
+	require.Equal(t, `{"a":1,"b":"x"}`, string(out))
 }
 
 // TestRenderJSONAsMySQLText_Array exercises SMALL_ARRAY with a mix of
@@ -181,7 +199,151 @@ func TestRenderJSONAsMySQLText_Array(t *testing.T) {
 	data := append([]byte{JSONB_SMALL_ARRAY}, body...)
 	out, err := renderJSONAsMySQLText(data, false)
 	require.NoError(t, err)
-	require.Equal(t, `[1, "x", true]`, string(out))
+	require.Equal(t, `[1,"x",true]`, string(out))
+}
+
+// TestRenderJSONAsMySQLText_LargeObject exercises the LARGE_OBJECT
+// offset table (4-byte offsets/counts) which the SMALL_OBJECT test
+// does not cover. INT32 also becomes an inline value in large mode,
+// where it was a pointer value in small mode.
+func TestRenderJSONAsMySQLText_LargeObject(t *testing.T) {
+	// Layout for {"a": 1, "b": "x"} as JSONB LARGE_OBJECT body:
+	//   header (u32 count, u32 size)        = 8 bytes
+	//   2 key entries (u32 offset, u16 len) = 12 bytes
+	//   2 value entries (u8 tp, u32 slot)   = 10 bytes
+	//   "a", "b"                            = 2 bytes
+	//   varlen=1, 'x'                       = 2 bytes
+	//   total body                          = 34 bytes
+	//
+	// Value 0 (INT16) is inline in large mode too, but the inline slot
+	// is 4 bytes wide -- we use the first 2 and zero-pad the rest.
+	body := []byte{
+		0x02, 0x00, 0x00, 0x00, // count = 2
+		0x22, 0x00, 0x00, 0x00, // size = 34
+		// key entry 0: offset=30, len=1
+		0x1E, 0x00, 0x00, 0x00, 0x01, 0x00,
+		// key entry 1: offset=31, len=1
+		0x1F, 0x00, 0x00, 0x00, 0x01, 0x00,
+		// value entry 0: INT16 inline = 1 (zero-padded to 4 bytes)
+		JSONB_INT16, 0x01, 0x00, 0x00, 0x00,
+		// value entry 1: STRING at offset 32
+		JSONB_STRING, 0x20, 0x00, 0x00, 0x00,
+		'a', 'b',
+		0x01, 'x',
+	}
+	data := append([]byte{JSONB_LARGE_OBJECT}, body...)
+	out, err := renderJSONAsMySQLText(data, false)
+	require.NoError(t, err)
+	require.Equal(t, `{"a":1,"b":"x"}`, string(out))
+}
+
+// TestRenderJSONAsMySQLText_LargeArray exercises the LARGE_ARRAY path
+// with a mix of inline scalars (INT16, LITERAL) and a pointer value
+// (STRING).
+func TestRenderJSONAsMySQLText_LargeArray(t *testing.T) {
+	// Layout for [1, "x", true] as JSONB LARGE_ARRAY body:
+	//   header (u32 count, u32 size)      = 8 bytes
+	//   3 value entries (u8 tp, u32 slot) = 15 bytes
+	//   varlen=1, 'x'                     = 2 bytes
+	//   total body                        = 25 bytes
+	body := []byte{
+		0x03, 0x00, 0x00, 0x00, // count = 3
+		0x19, 0x00, 0x00, 0x00, // size = 25
+		// value entry 0: INT16 inline = 1
+		JSONB_INT16, 0x01, 0x00, 0x00, 0x00,
+		// value entry 1: STRING at offset 23
+		JSONB_STRING, 0x17, 0x00, 0x00, 0x00,
+		// value entry 2: LITERAL inline true
+		JSONB_LITERAL, JSONB_TRUE_LITERAL, 0x00, 0x00, 0x00,
+		0x01, 'x',
+	}
+	data := append([]byte{JSONB_LARGE_ARRAY}, body...)
+	out, err := renderJSONAsMySQLText(data, false)
+	require.NoError(t, err)
+	require.Equal(t, `[1,"x",true]`, string(out))
+}
+
+// TestRenderJSONAsMySQLText_NestedObject exercises a jsonObject value
+// nested inside another jsonObject. This is the path that would break
+// if jsonObject.MarshalJSON ever stopped recursing through json.Marshal
+// (e.g. if a future change started writing leaf bytes directly).
+func TestRenderJSONAsMySQLText_NestedObject(t *testing.T) {
+	// Inner SMALL_OBJECT body for {"inner": 1}:
+	//   header (u16,u16) = 4
+	//   1 key entry      = 4
+	//   1 value entry    = 3
+	//   "inner"          = 5
+	//   total            = 16 bytes
+	inner := []byte{
+		0x01, 0x00, // count = 1
+		0x10, 0x00, // size = 16
+		0x0B, 0x00, 0x05, 0x00, // key entry: offset=11, len=5
+		JSONB_INT16, 0x01, 0x00, // INT16 inline = 1
+		'i', 'n', 'n', 'e', 'r',
+	}
+	// Outer SMALL_OBJECT body for {"outer": <inner>}:
+	//   header        = 4
+	//   1 key entry   = 4
+	//   1 value entry = 3
+	//   "outer"       = 5
+	//   inner body    = 16
+	//   total         = 32 bytes
+	outer := []byte{
+		0x01, 0x00, // count = 1
+		0x20, 0x00, // size = 32
+		0x0B, 0x00, 0x05, 0x00, // key entry: offset=11, len=5
+		JSONB_SMALL_OBJECT, 0x10, 0x00, // value: SMALL_OBJECT at offset 16
+		'o', 'u', 't', 'e', 'r',
+	}
+	outer = append(outer, inner...)
+	data := append([]byte{JSONB_SMALL_OBJECT}, outer...)
+	out, err := renderJSONAsMySQLText(data, false)
+	require.NoError(t, err)
+	require.Equal(t, `{"outer":{"inner":1}}`, string(out))
+}
+
+// TestRenderJSONAsMySQLText_KeyEscaping verifies that object keys go
+// through the same escaping path as string values: characters needing
+// JSON escapes are escaped, and multi-byte UTF-8 passes through
+// verbatim.
+func TestRenderJSONAsMySQLText_KeyEscaping(t *testing.T) {
+	// SMALL_OBJECT body for {"a\"b": 1, "héllo": 2}.
+	// "a\"b" is 3 bytes; "héllo" is 6 bytes (é = 0xC3 0xA9 in UTF-8).
+	//   header        = 4
+	//   2 key entries = 8
+	//   2 value entries = 6
+	//   header end    = 18
+	//   "a\"b" at 18, len 3
+	//   "héllo" at 21, len 6
+	//   total         = 27 bytes
+	body := []byte{
+		0x02, 0x00, // count = 2
+		0x1B, 0x00, // size = 27
+		0x12, 0x00, 0x03, 0x00, // key entry 0: offset=18, len=3
+		0x15, 0x00, 0x06, 0x00, // key entry 1: offset=21, len=6
+		JSONB_INT16, 0x01, 0x00, // INT16 inline = 1
+		JSONB_INT16, 0x02, 0x00, // INT16 inline = 2
+		'a', '"', 'b',
+		'h', 0xC3, 0xA9, 'l', 'l', 'o',
+	}
+	data := append([]byte{JSONB_SMALL_OBJECT}, body...)
+	out, err := renderJSONAsMySQLText(data, false)
+	require.NoError(t, err)
+	require.Equal(t, "{\"a\\\"b\":1,\"héllo\":2}", string(out))
+}
+
+// TestRenderJSONAsMySQLText_OpaqueDecimalShort exercises the bounds
+// check on the NEWDECIMAL header. Previously a payload shorter than 2
+// bytes would index past the slice; now it surfaces a decode error.
+func TestRenderJSONAsMySQLText_OpaqueDecimalShort(t *testing.T) {
+	data := []byte{
+		JSONB_OPAQUE,
+		mysql.MYSQL_TYPE_NEWDECIMAL,
+		0x01, // payload varlen = 1, but NEWDECIMAL needs >= 2
+		0x02,
+	}
+	_, err := renderJSONAsMySQLText(data, false)
+	require.Error(t, err)
 }
 
 // TestRenderJSONAsMySQLText_OpaqueDecimal exercises the NEWDECIMAL path

--- a/replication/json_mysql_text_test.go
+++ b/replication/json_mysql_text_test.go
@@ -12,8 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// renderJSONAsMySQLText is a thin entry point used by tests. Production
-// code reaches this path through RowsEvent.decodeJSONBinary.
+// renderJSONAsMySQLText is a test-only helper that synthesises a minimal
+// RowsEvent so unit tests can drive jsonBinaryDecoder directly with the
+// mysql-text mode enabled. Production code does not call this; it
+// constructs RowsEvents via BinlogParser.newRowsEvent and reaches the
+// same decoder through RowsEvent.decodeJSONBinary.
 func renderJSONAsMySQLText(data []byte, ignoreDecodeErr bool) ([]byte, error) {
 	e := &RowsEvent{
 		renderJSONAsMySQLText: true,

--- a/replication/parser.go
+++ b/replication/parser.go
@@ -37,6 +37,7 @@ type BinlogParser struct {
 
 	useDecimal               bool
 	useFloatWithTrailingZero bool
+	renderJSONAsMySQLText    bool
 	ignoreJSONDecodeErr      bool
 	verifyChecksum           bool
 
@@ -203,6 +204,12 @@ func (p *BinlogParser) SetUseDecimal(useDecimal bool) {
 
 func (p *BinlogParser) SetUseFloatWithTrailingZero(useFloatWithTrailingZero bool) {
 	p.useFloatWithTrailingZero = useFloatWithTrailingZero
+}
+
+// SetRenderJSONAsMySQLText toggles MySQL-text JSON rendering for RowsEvents.
+// See BinlogSyncerConfig.RenderJSONAsMySQLText for the full rationale.
+func (p *BinlogParser) SetRenderJSONAsMySQLText(renderJSONAsMySQLText bool) {
+	p.renderJSONAsMySQLText = renderJSONAsMySQLText
 }
 
 func (p *BinlogParser) SetIgnoreJSONDecodeError(ignoreJSONDecodeErr bool) {
@@ -432,6 +439,7 @@ func (p *BinlogParser) newRowsEvent(h *EventHeader) *RowsEvent {
 	e.timestampStringLocation = p.timestampStringLocation
 	e.useDecimal = p.useDecimal
 	e.useFloatWithTrailingZero = p.useFloatWithTrailingZero
+	e.renderJSONAsMySQLText = p.renderJSONAsMySQLText
 	e.ignoreJSONDecodeErr = p.ignoreJSONDecodeErr
 
 	switch h.EventType {

--- a/replication/parser.go
+++ b/replication/parser.go
@@ -236,6 +236,30 @@ func (p *BinlogParser) SetTableMapOptionalMetaDecodeFunc(tableMapOptionalMetaDec
 	p.tableMapOptionalMetaDecodeFunc = tableMapOptionalMetaDecondeFunc
 }
 
+// cloneForPayloadDecode returns a new BinlogParser that inherits the
+// caller's user-settable decode options (UseDecimal, RenderJSONAsMySQLText,
+// ParseTime, etc.) but with checksum verification disabled and a fresh
+// tables map. It is used to parse the events nested inside a
+// TRANSACTION_PAYLOAD_EVENT, so that those rows decode with the same
+// options as uncompressed rows.
+func (p *BinlogParser) cloneForPayloadDecode() *BinlogParser {
+	inner := NewBinlogParser()
+	inner.flavor = p.flavor
+	inner.rawMode = p.rawMode
+	inner.parseTime = p.parseTime
+	inner.timestampStringLocation = p.timestampStringLocation
+	inner.useDecimal = p.useDecimal
+	inner.useFloatWithTrailingZero = p.useFloatWithTrailingZero
+	inner.renderJSONAsMySQLText = p.renderJSONAsMySQLText
+	inner.ignoreJSONDecodeErr = p.ignoreJSONDecodeErr
+	// verifyChecksum is intentionally left at the zero value: nested
+	// events do not carry their own checksum trailers.
+	inner.payloadDecoderConcurrency = p.payloadDecoderConcurrency
+	inner.rowsEventDecodeFunc = p.rowsEventDecodeFunc
+	inner.tableMapOptionalMetaDecodeFunc = p.tableMapOptionalMetaDecodeFunc
+	return inner
+}
+
 func (p *BinlogParser) parseHeader(data []byte) (*EventHeader, error) {
 	h := new(EventHeader)
 	err := h.Decode(data)
@@ -485,6 +509,7 @@ func (p *BinlogParser) newTransactionPayloadEvent() *TransactionPayloadEvent {
 	e := &TransactionPayloadEvent{}
 	e.format = *p.format
 	e.concurrency = p.payloadDecoderConcurrency
+	e.parent = p
 
 	return e
 }

--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -953,6 +953,7 @@ type RowsEvent struct {
 	timestampStringLocation  *time.Location
 	useDecimal               bool
 	useFloatWithTrailingZero bool
+	renderJSONAsMySQLText    bool
 	ignoreJSONDecodeErr      bool
 }
 

--- a/replication/transaction_payload_event.go
+++ b/replication/transaction_payload_event.go
@@ -29,8 +29,15 @@ const (
 )
 
 type TransactionPayloadEvent struct {
-	format           FormatDescriptionEvent
-	concurrency      int
+	format      FormatDescriptionEvent
+	concurrency int
+	// parent is the BinlogParser that produced this event. The inner
+	// parser used to decode the decompressed payload inherits its
+	// user-settable options (UseDecimal, RenderJSONAsMySQLText, ...) so
+	// that compressed and uncompressed rows decode identically. nil when
+	// the event is constructed outside of BinlogParser, in which case
+	// decodePayload falls back to default parser options.
+	parent           *BinlogParser
 	Size             uint64
 	UncompressedSize uint64
 	CompressionType  uint64
@@ -117,10 +124,18 @@ func (e *TransactionPayloadEvent) decodePayload() error {
 	}
 
 	// The uncompressed data needs to be split up into individual events for Parse()
-	// to work on them. We can't use e.parser directly as we need to disable checksums
-	// but we still need the initialization from the FormatDescriptionEvent. We can't
-	// modify e.parser as it is used elsewhere.
-	parser := NewBinlogParser()
+	// to work on them. We can't use the parent parser directly as we need to disable
+	// checksums but we still need the initialization from the FormatDescriptionEvent.
+	// We can't modify the parent parser as it is used elsewhere. We do however want
+	// to inherit user-settable decode options (UseDecimal, RenderJSONAsMySQLText,
+	// IgnoreJSONDecodeError, ...) so that rows inside a compressed payload decode
+	// with the same semantics as uncompressed rows.
+	var parser *BinlogParser
+	if e.parent != nil {
+		parser = e.parent.cloneForPayloadDecode()
+	} else {
+		parser = NewBinlogParser()
+	}
 	parser.format = &FormatDescriptionEvent{
 		Version:                e.format.Version,
 		ServerVersion:          e.format.ServerVersion,

--- a/replication/transaction_payload_event_test.go
+++ b/replication/transaction_payload_event_test.go
@@ -2,9 +2,63 @@ package replication
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+// TestBinlogParser_cloneForPayloadDecode verifies that the inner parser
+// used for decompressed transaction payloads inherits user-settable
+// decode options from its parent. Without this, JSON columns in
+// compressed transactions would silently fall back to legacy rendering
+// even when RenderJSONAsMySQLText (and friends) are configured on the
+// outer parser.
+func TestBinlogParser_cloneForPayloadDecode(t *testing.T) {
+	loc, err := time.LoadLocation("UTC")
+	require.NoError(t, err)
+
+	outer := NewBinlogParser()
+	outer.SetFlavor("mariadb")
+	outer.SetRawMode(true)
+	outer.SetParseTime(true)
+	outer.SetTimestampStringLocation(loc)
+	outer.SetUseDecimal(true)
+	outer.SetUseFloatWithTrailingZero(true)
+	outer.SetRenderJSONAsMySQLText(true)
+	outer.SetIgnoreJSONDecodeError(true)
+	outer.SetVerifyChecksum(true) // intentionally not propagated
+	outer.SetPayloadDecoderConcurrency(7)
+
+	inner := outer.cloneForPayloadDecode()
+
+	require.Equal(t, "mariadb", inner.flavor)
+	require.True(t, inner.rawMode)
+	require.True(t, inner.parseTime)
+	require.Same(t, loc, inner.timestampStringLocation)
+	require.True(t, inner.useDecimal)
+	require.True(t, inner.useFloatWithTrailingZero)
+	require.True(t, inner.renderJSONAsMySQLText)
+	require.True(t, inner.ignoreJSONDecodeErr)
+	require.Equal(t, 7, inner.payloadDecoderConcurrency)
+	// Checksum verification must be off: nested events do not carry
+	// their own checksum trailers.
+	require.False(t, inner.verifyChecksum)
+	// tables must be a fresh map, not shared with the outer parser.
+	require.NotNil(t, inner.tables)
+	require.NotSame(t, &outer.tables, &inner.tables)
+}
+
+// TestNewTransactionPayloadEvent_InheritsParent verifies that events
+// created via the parser path carry a reference to it, so that
+// decodePayload picks up the parser options.
+func TestNewTransactionPayloadEvent_InheritsParent(t *testing.T) {
+	p := NewBinlogParser()
+	p.format = &FormatDescriptionEvent{} // newTransactionPayloadEvent dereferences this
+	p.SetRenderJSONAsMySQLText(true)
+
+	e := p.newTransactionPayloadEvent()
+	require.Same(t, p, e.parent)
+}
 
 func TestTransactionPayloadEventDecode(t *testing.T) {
 	e := &TransactionPayloadEvent{

--- a/replication/transaction_payload_event_test.go
+++ b/replication/transaction_payload_event_test.go
@@ -48,10 +48,10 @@ func TestBinlogParser_cloneForPayloadDecode(t *testing.T) {
 	require.NotSame(t, &outer.tables, &inner.tables)
 }
 
-// TestNewTransactionPayloadEvent_InheritsParent verifies that events
+// TestNewTransactionPayloadEventInheritsParent verifies that events
 // created via the parser path carry a reference to it, so that
 // decodePayload picks up the parser options.
-func TestNewTransactionPayloadEvent_InheritsParent(t *testing.T) {
+func TestNewTransactionPayloadEventInheritsParent(t *testing.T) {
 	p := NewBinlogParser()
 	p.format = &FormatDescriptionEvent{} // newTransactionPayloadEvent dereferences this
 	p.SetRenderJSONAsMySQLText(true)

--- a/replication/transaction_payload_event_test.go
+++ b/replication/transaction_payload_event_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestBinlogParser_cloneForPayloadDecode verifies that the inner parser
+// TestBinlogParserCloneForPayloadDecode verifies that the inner parser
 // used for decompressed transaction payloads inherits user-settable
 // decode options from its parent. Without this, JSON columns in
 // compressed transactions would silently fall back to legacy rendering
 // even when RenderJSONAsMySQLText (and friends) are configured on the
 // outer parser.
-func TestBinlogParser_cloneForPayloadDecode(t *testing.T) {
+func TestBinlogParserCloneForPayloadDecode(t *testing.T) {
 	loc, err := time.LoadLocation("UTC")
 	require.NoError(t, err)
 


### PR DESCRIPTION
Fixes https://github.com/go-mysql-org/go-mysql/issues/1142

The implementation is different from the draft I proposed when creating the initial issue, and it re-uses the existing json_binary decoder.