### PR TITLE
compress: return Reset error from pooled zlib reader

### DIFF
--- a/compress/zlib.go
+++ b/compress/zlib.go
@@ -57,7 +57,7 @@ func GetPooledZlibReader(src io.Reader) (io.ReadCloser, error) {
 
 	if r := zlibReaderPool.Get(); r != nil {
 		rc = r.(io.ReadCloser)
-		if rc.(zlib.Resetter).Reset(src, nil) != nil {
+		if err = rc.(zlib.Resetter).Reset(src, nil); err != nil {
 			return nil, err
 		}
 	} else {

--- a/compress/zlib_test.go
+++ b/compress/zlib_test.go
@@ -1,0 +1,49 @@
+package compress
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestGetPooledZlibReaderResetError verifies that when a zlib reader is taken
+// from the pool and Reset fails (e.g. the source does not start with a valid
+// zlib header), GetPooledZlibReader returns that error instead of swallowing it
+// and returning a nil reader with a nil error.
+func TestGetPooledZlibReaderResetError(t *testing.T) {
+	// Produce a valid zlib stream so we can create, then pool, a reader.
+	var compressed bytes.Buffer
+	w, err := GetPooledZlibWriter(&compressed)
+	if err != nil {
+		t.Fatalf("GetPooledZlibWriter: %v", err)
+	}
+	if _, err := w.Write([]byte("hello world")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	// Borrow and return a reader so the pool is primed in this goroutine; the
+	// next Get is then expected to hand back the pooled (Resetter) reader.
+	r, err := GetPooledZlibReader(bytes.NewReader(compressed.Bytes()))
+	if err != nil {
+		t.Fatalf("GetPooledZlibReader (valid): %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close reader: %v", err)
+	}
+
+	// Now request a reader over a source whose bytes are not a valid zlib
+	// header. Reset must fail; the error must be propagated to the caller.
+	bad, err := GetPooledZlibReader(strings.NewReader("not a zlib stream"))
+	if err == nil {
+		if bad != nil {
+			_ = bad.Close()
+		}
+		t.Fatal("expected error from GetPooledZlibReader on invalid zlib header, got nil")
+	}
+	if bad != nil {
+		t.Fatalf("expected nil reader on error, got %v", bad)
+	}
+}


### PR DESCRIPTION
## Problem

`GetPooledZlibReader` swallows the error from the pooled reader's `Reset` call and returns `(nil, nil)`:

```go
if rc.(zlib.Resetter).Reset(src, nil) != nil {
    return nil, err // err is always nil at this point
}
```

`err` is still `nil` here (it is only assigned in the `else` branch that calls `zlib.NewReader`). So when `Reset` fails — e.g. the source does not begin with a valid zlib header — the caller receives a **nil `io.ReadCloser` together with a nil error**.

That return value is not benign downstream. In `packet.Conn.newCompressedPacketReader` the result is stored directly as the active compressed reader:

```go
c.compressedReader, err = c.newCompressedPacketReader()
```

A `nil` reader with a `nil` error means `c.compressedReader == nil`, and `currentPacketReader()` then falls back to reading the **raw, still-compressed** connection stream as if it were uncompressed:

```go
func (c *Conn) currentPacketReader() io.Reader {
    if c.Compression == MYSQL_COMPRESS_NONE || c.compressedReader == nil {
        return c.reader
    }
    return c.compressedReader
}
```

So a recoverable `Reset` failure is converted into silent, cascading stream corruption that never surfaces to the caller as an error (and `Reset` has already consumed bytes from the underlying stream before failing).

## Fix

Capture and return the actual `Reset` error instead of the always-nil `err`.

## Test

Adds `TestGetPooledZlibReaderResetError`, which primes the pool and then requests a reader over a source with an invalid zlib header, asserting the error is propagated and the returned reader is nil. Verified that it **passes with this fix and fails against the current code** (`got nil`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)