### PR TITLE
packet: bound uncompressed compressed-protocol frames to the frame length

### DIFF
--- a/packet/conn.go
+++ b/packet/conn.go
@@ -50,8 +50,6 @@ type Conn struct {
 	compressedHeader [7]byte
 
 	compressedReader io.Reader
-
-	compressedReaderActive bool
 }
 
 func NewConn(conn net.Conn) *Conn {
@@ -107,19 +105,10 @@ func (c *Conn) ReadPacketReuseMem(dst []byte) ([]byte, error) {
 	}()
 
 	if c.Compression != mysql.MYSQL_COMPRESS_NONE {
-		// it's possible that we're using compression but the server response with a compressed
-		// packet with uncompressed length of 0. In this case we leave compressedReader nil. The
-		// compressedReaderActive flag is important to track the state of the reader, allowing
-		// for the compressedReader to be reset after a packet write. Without this flag, when a
-		// compressed packet with uncompressed length of 0 is read, the compressedReader would
-		// be nil, and we'd incorrectly attempt to read the next packet as compressed.
-		if !c.compressedReaderActive {
-			var err error
-			c.compressedReader, err = c.newCompressedPacketReader()
-			if err != nil {
-				return nil, err
-			}
-			c.compressedReaderActive = true
+		var err error
+		c.compressedReader, err = c.newCompressedPacketReader()
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -336,7 +325,6 @@ func (c *Conn) WritePacket(data []byte) error {
 			return errors.Wrapf(mysql.ErrBadConn, "Write failed. only %v bytes written, while %v expected", n, len(data))
 		}
 
-		c.compressedReaderActive = false
 		if c.compressedReader != nil {
 			if _, ok := c.compressedReader.(io.ReadCloser); ok {
 				_ = c.compressedReader.(io.ReadCloser).Close()

--- a/packet/conn.go
+++ b/packet/conn.go
@@ -168,8 +168,12 @@ func (c *Conn) newCompressedPacketReader() (io.Reader, error) {
 
 	compressedLength := int(uint32(c.compressedHeader[0]) | uint32(c.compressedHeader[1])<<8 | uint32(c.compressedHeader[2])<<16)
 	uncompressedLength := int(uint32(c.compressedHeader[4]) | uint32(c.compressedHeader[5])<<8 | uint32(c.compressedHeader[6])<<16)
+
+	// Always bound reads to this frame's payload (compressedLength bytes on the wire).
+	// copyN relies on hitting EOF at the frame boundary to advance CompressedSequence
+	// and move on to the next compressed packet.
+	limitedReader := io.LimitReader(c.reader, int64(compressedLength))
 	if uncompressedLength > 0 {
-		limitedReader := io.LimitReader(c.reader, int64(compressedLength))
 		switch c.Compression {
 		case mysql.MYSQL_COMPRESS_ZLIB:
 			return compress.GetPooledZlibReader(limitedReader)
@@ -178,7 +182,12 @@ func (c *Conn) newCompressedPacketReader() (io.Reader, error) {
 		}
 	}
 
-	return nil, nil
+	// uncompressedLength == 0 means the payload was sent verbatim (compression wasn't
+	// worthwhile for this chunk). It must still be bounded to the frame: returning the
+	// raw, unbounded connection here lets a packet that spans into the following frame
+	// read straight through that frame's header, desyncing the compressed stream and
+	// surfacing later as "invalid compressed sequence" / "zlib: invalid header".
+	return limitedReader, nil
 }
 
 func (c *Conn) currentPacketReader() io.Reader {

--- a/packet/conn.go
+++ b/packet/conn.go
@@ -104,7 +104,12 @@ func (c *Conn) ReadPacketReuseMem(dst []byte) ([]byte, error) {
 		utils.BytesBufferPut(buf)
 	}()
 
-	if c.Compression != mysql.MYSQL_COMPRESS_NONE {
+	// compressedReader is reset to nil after each WritePacket, so a nil reader here means
+	// we're at the start of a new compressed frame and need to read its header. While a
+	// frame still has buffered packets to hand out, we reuse the existing reader rather
+	// than consuming another frame header. (newCompressedPacketReader never returns a nil
+	// reader, so its nilness fully tracks whether a frame read is in progress.)
+	if c.Compression != mysql.MYSQL_COMPRESS_NONE && c.compressedReader == nil {
 		var err error
 		c.compressedReader, err = c.newCompressedPacketReader()
 		if err != nil {

--- a/packet/conn_test.go
+++ b/packet/conn_test.go
@@ -1,0 +1,134 @@
+package packet
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/go-mysql-org/go-mysql/compress"
+	"github.com/go-mysql-org/go-mysql/mysql"
+)
+
+// newReadTestConn builds a Conn whose read side is fed from the given raw bytes,
+// simulating frames as they would arrive from a MySQL server. No net.Conn is
+// needed because readTimeout is 0, so SetReadDeadline is never called.
+func newReadTestConn(stream []byte, compression uint8) *Conn {
+	c := new(Conn)
+	c.reader = bytes.NewReader(stream)
+	c.copyNBuf = make([]byte, DefaultBufferSize)
+	c.Compression = compression
+	return c
+}
+
+// mysqlPacket builds a single MySQL protocol packet (4-byte header + payload).
+func mysqlPacket(seq byte, payload []byte) []byte {
+	n := len(payload)
+	b := make([]byte, 4+n)
+	b[0] = byte(n)
+	b[1] = byte(n >> 8)
+	b[2] = byte(n >> 16)
+	b[3] = seq
+	copy(b[4:], payload)
+	return b
+}
+
+// uncompressedFrame builds a compressed-protocol frame whose payload is stored
+// verbatim (length-before-compression == 0), as a server does for small or
+// incompressible chunks.
+func uncompressedFrame(seq byte, body []byte) []byte {
+	cl := len(body)
+	f := make([]byte, 7+cl)
+	f[0] = byte(cl)
+	f[1] = byte(cl >> 8)
+	f[2] = byte(cl >> 16)
+	f[3] = seq
+	// bytes 4..6 (uncompressed length) stay 0
+	copy(f[7:], body)
+	return f
+}
+
+// zlibFrame builds a compressed-protocol frame whose payload is zlib-compressed.
+func zlibFrame(t *testing.T, seq byte, payload []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w, err := compress.GetPooledZlibWriter(&buf)
+	if err != nil {
+		t.Fatalf("GetPooledZlibWriter: %v", err)
+	}
+	if _, err := w.Write(payload); err != nil {
+		t.Fatalf("zlib write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("zlib close: %v", err)
+	}
+	body := buf.Bytes()
+	cl := len(body)
+	ul := len(payload)
+	f := make([]byte, 7+cl)
+	f[0] = byte(cl)
+	f[1] = byte(cl >> 8)
+	f[2] = byte(cl >> 16)
+	f[3] = seq
+	f[4] = byte(ul)
+	f[5] = byte(ul >> 8)
+	f[6] = byte(ul >> 16)
+	copy(f[7:], body)
+	return f
+}
+
+// TestReadPacketPacketSpanningUncompressedFrames reproduces the desync where a
+// single MySQL packet spans out of an uncompressed (length-before-compression 0)
+// frame into the following frame. Before the fix the uncompressed frame was read
+// from the raw, unbounded connection, so copyN read straight through the next
+// frame's 7-byte header and corrupted the payload.
+func TestReadPacketPacketSpanningUncompressedFrames(t *testing.T) {
+	payload := bytes.Repeat([]byte("0123456789abcdef"), 16) // 256 bytes
+	pkt := mysqlPacket(0, payload)
+
+	// Split the packet's bytes mid-payload across two uncompressed frames.
+	split := 100
+	stream := append(uncompressedFrame(0, pkt[:split]), uncompressedFrame(1, pkt[split:])...)
+
+	c := newReadTestConn(stream, mysql.MYSQL_COMPRESS_ZLIB)
+	got, err := c.ReadPacket()
+	if err != nil {
+		t.Fatalf("ReadPacket: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("payload mismatch:\n got  %q\n want %q", got, payload)
+	}
+}
+
+// TestReadPacketPacketSpanningZlibFrames guards the already-working compressed
+// path: a packet split across two zlib frames must still reassemble correctly.
+func TestReadPacketPacketSpanningZlibFrames(t *testing.T) {
+	payload := bytes.Repeat([]byte("the quick brown fox "), 32) // 640 bytes
+	pkt := mysqlPacket(0, payload)
+
+	split := 200
+	stream := append(zlibFrame(t, 0, pkt[:split]), zlibFrame(t, 1, pkt[split:])...)
+
+	c := newReadTestConn(stream, mysql.MYSQL_COMPRESS_ZLIB)
+	got, err := c.ReadPacket()
+	if err != nil {
+		t.Fatalf("ReadPacket: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("payload mismatch:\n got  %q\n want %q", got, payload)
+	}
+}
+
+// TestReadPacketSingleUncompressedFrame guards the common small-response case:
+// a whole packet inside one uncompressed frame.
+func TestReadPacketSingleUncompressedFrame(t *testing.T) {
+	payload := []byte("small uncompressed response")
+	stream := uncompressedFrame(0, mysqlPacket(0, payload))
+
+	c := newReadTestConn(stream, mysql.MYSQL_COMPRESS_ZLIB)
+	got, err := c.ReadPacket()
+	if err != nil {
+		t.Fatalf("ReadPacket: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("payload mismatch:\n got  %q\n want %q", got, payload)
+	}
+}

--- a/packet/conn_test.go
+++ b/packet/conn_test.go
@@ -117,6 +117,39 @@ func TestReadPacketPacketSpanningZlibFrames(t *testing.T) {
 	}
 }
 
+// TestReadPacketMultiplePacketsInOneZlibFrame guards reader reuse across reads: a
+// server may pack several MySQL packets into a single compressed frame, and each is
+// retrieved by a separate ReadPacket call. The first read consumes the frame header
+// and decompresses; subsequent reads must continue from the same compressedReader
+// rather than consuming another frame header. Recreating the reader on every read
+// (e.g. dropping the nil guard) reads garbage as the next frame's header and desyncs.
+func TestReadPacketMultiplePacketsInOneZlibFrame(t *testing.T) {
+	payloadA := bytes.Repeat([]byte("alpha "), 8)
+	payloadB := bytes.Repeat([]byte("bravo "), 8)
+
+	// Two complete MySQL packets (sequence 0 and 1) inside one zlib frame.
+	combined := append(mysqlPacket(0, payloadA), mysqlPacket(1, payloadB)...)
+	stream := zlibFrame(t, 0, combined)
+
+	c := newReadTestConn(stream, mysql.MYSQL_COMPRESS_ZLIB)
+
+	got, err := c.ReadPacket()
+	if err != nil {
+		t.Fatalf("ReadPacket #1: %v", err)
+	}
+	if !bytes.Equal(got, payloadA) {
+		t.Fatalf("packet #1 mismatch:\n got  %q\n want %q", got, payloadA)
+	}
+
+	got, err = c.ReadPacket()
+	if err != nil {
+		t.Fatalf("ReadPacket #2: %v", err)
+	}
+	if !bytes.Equal(got, payloadB) {
+		t.Fatalf("packet #2 mismatch:\n got  %q\n want %q", got, payloadB)
+	}
+}
+
 // TestReadPacketSingleUncompressedFrame guards the common small-response case:
 // a whole packet inside one uncompressed frame.
 func TestReadPacketSingleUncompressedFrame(t *testing.T) {


### PR DESCRIPTION
## Problem

In the compressed protocol, when a frame stores its payload **verbatim** (length-before-compression `== 0`, which the server uses for small or incompressible chunks), `newCompressedPacketReader` returns a `nil` reader:

```go
if uncompressedLength > 0 {
    limitedReader := io.LimitReader(c.reader, int64(compressedLength))
    switch c.Compression { ... }
}
return nil, nil   // <- uncompressedLength == 0
```

With `compressedReader == nil`, `currentPacketReader()` falls back to the **raw, unbounded** `c.reader`. So `copyN` no longer stops at the frame boundary.

If a MySQL packet spans *out of* such an uncompressed frame, `copyN` reads straight through the **following frame's 7-byte header** as if it were payload, desyncing the compressed stream. And because the reads come from the raw connection (which never returns EOF at the boundary), the `EOF → advance frame` path that increments `CompressedSequence` never runs.

The corruption typically surfaces later, on an unrelated subsequent read, as:

- `invalid compressed sequence X != Y`, or
- `zlib: invalid header`

This is hard to reproduce in the wild because it only triggers when a packet happens to straddle the boundary of a stored-uncompressed frame that is followed by more frames — but under heavy traffic it does happen.

## Fix

Bound the uncompressed payload to the frame with an `io.LimitReader`, mirroring the compressed path, so `copyN` hits EOF at the frame boundary and advances to the next compressed packet.

## Tests

The compressed read path had no unit coverage, so this adds `packet/conn_test.go`:

- `TestReadPacketPacketSpanningUncompressedFrames` — regression test for this bug. It **fails without the fix** (the reassembled payload contains the next frame's header bytes verbatim) and passes with it.
- `TestReadPacketPacketSpanningZlibFrames` — guards the already-working compressed multi-frame path.
- `TestReadPacketSingleUncompressedFrame` — guards the common single-frame small-response case.