### PR TITLE
fix: make compressed transaction payloads checkpointable

### DIFF
--- a/canal/sync.go
+++ b/canal/sync.go
@@ -145,10 +145,13 @@ func (c *Canal) handleEvent(ev *replication.BinlogEvent) error {
 			c.cfg.Logger.Error("error parsing query, will skip this event", slog.String("query", string(e.Query)), slog.Any("error", err))
 			return nil
 		}
-		if len(stmts) > 0 {
-			savePos = true
-		}
 		for _, stmt := range stmts {
+			switch stmt.(type) {
+			case *ast.BeginStmt, *ast.SavepointStmt:
+				// transaction not yet complete; checkpointing here would skip it on GTID resume
+				continue
+			}
+			savePos = true
 			nodes := parseStmt(stmt)
 			for _, node := range nodes {
 				if node.db == "" {

--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -1007,6 +1007,21 @@ func (b *BinlogSyncer) handleEventAndACK(s *BinlogStreamer, e *BinlogEvent, need
 		if !b.cfg.DiscardGTIDSet {
 			event.GSet = b.getCurrentGtidSet()
 		}
+
+	case *TransactionPayloadEvent:
+		// XID/Query decoded from compressed payload need GTID set attached,
+		// same as their uncompressed counterparts above; GTID event precedes
+		// payload uncompressed, so currGset already covers this transaction
+		if !b.cfg.DiscardGTIDSet {
+			for _, inner := range event.Events {
+				switch innerEvent := inner.Event.(type) {
+				case *XIDEvent:
+					innerEvent.GSet = b.getCurrentGtidSet()
+				case *QueryEvent:
+					innerEvent.GSet = b.getCurrentGtidSet()
+				}
+			}
+		}
 	}
 
 	// Use SynchronousEventHandler if it's set

--- a/replication/binlogsyncer_test.go
+++ b/replication/binlogsyncer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-mysql-org/go-mysql/client"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/packet"
 )
 
@@ -121,4 +122,28 @@ func TestCloseUnblocksWhenSetReadDeadlineFails(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("Close hung when SetReadDeadline refused a deadline")
 	}
+}
+
+// TestHandleEventAndACKPayloadInnerGSet verifies XID/Query events decoded from
+// a compressed transaction payload get the current GTID set attached, same as
+// their uncompressed counterparts, so consumers (eg canal) can checkpoint GTID
+// progress
+func TestHandleEventAndACKPayloadInnerGSet(t *testing.T) {
+	b := NewBinlogSyncer(BinlogSyncerConfig{ServerID: 1})
+	defer b.Close()
+
+	gset, err := mysql.ParseGTIDSet(mysql.MySQLFlavor, "de278ad0-2106-11e4-9f8e-6edd0ca20947:1-2")
+	require.NoError(t, err)
+	b.currGset = gset
+
+	innerQuery := &BinlogEvent{Header: &EventHeader{EventType: QUERY_EVENT}, Event: &QueryEvent{}}
+	innerXID := &BinlogEvent{Header: &EventHeader{EventType: XID_EVENT}, Event: &XIDEvent{}}
+	ev := &BinlogEvent{
+		Header: &EventHeader{EventType: TRANSACTION_PAYLOAD_EVENT, LogPos: 5000, EventSize: 1200},
+		Event:  &TransactionPayloadEvent{Events: []*BinlogEvent{innerQuery, innerXID}},
+	}
+
+	require.NoError(t, b.handleEventAndACK(NewBinlogStreamer(), ev, false))
+	require.Equal(t, gset.String(), innerQuery.Event.(*QueryEvent).GSet.String())
+	require.Equal(t, gset.String(), innerXID.Event.(*XIDEvent).GSet.String())
 }

--- a/replication/parser.go
+++ b/replication/parser.go
@@ -387,6 +387,10 @@ func (p *BinlogParser) parseEvent(h *EventHeader, data []byte, rawData []byte) (
 		p.tables[te.TableID] = te
 	}
 
+	if tpe, ok := e.(*TransactionPayloadEvent); ok {
+		tpe.stampInnerEventPositions(h)
+	}
+
 	if re, ok := e.(*RowsEvent); ok {
 		if (re.Flags & RowsEventStmtEndFlag) > 0 {
 			// Refer https://github.com/alibaba/canal/blob/38cc81b7dab29b51371096fb6763ca3a8432ffee/dbsync/src/main/java/com/taobao/tddl/dbsync/binlog/event/RowsLogEvent.java#L176

--- a/replication/transaction_payload_event.go
+++ b/replication/transaction_payload_event.go
@@ -106,6 +106,23 @@ func (e *TransactionPayloadEvent) decodeFields(data []byte) error {
 	return nil
 }
 
+// stampInnerEventPositions fixes LogPos of decoded inner events. MySQL copies
+// them from transaction cache before position fixup, so they arrive with
+// LogPos=0. Stamp checkpoint-equivalent positions: payload start for
+// mid-transaction events (resume there replays whole transaction, matching
+// uncompressed semantics), payload end for final event (XID/COMMIT, resume
+// there skips transaction)
+func (e *TransactionPayloadEvent) stampInnerEventPositions(h *EventHeader) {
+	if len(e.Events) == 0 || h.LogPos < h.EventSize {
+		return
+	}
+	start := h.LogPos - h.EventSize
+	for _, inner := range e.Events {
+		inner.Header.LogPos = start
+	}
+	e.Events[len(e.Events)-1].Header.LogPos = h.LogPos
+}
+
 func (e *TransactionPayloadEvent) decodePayload() error {
 	if e.CompressionType != ZSTD {
 		return fmt.Errorf("TransactionPayloadEvent has compression type %d (%s)",

--- a/replication/transaction_payload_event_test.go
+++ b/replication/transaction_payload_event_test.go
@@ -147,4 +147,41 @@ func TestTransactionPayloadEventDecode(t *testing.T) {
 	devent, ok := e.Events[6].Event.(*RowsEvent)
 	require.True(t, ok)
 	require.Equal(t, devent.Type(), EnumRowsEventTypeDelete)
+
+	// MySQL writes inner events with LogPos=0 (copied from transaction cache
+	// before position fixup); parser must stamp usable positions, see
+	// stampInnerEventPositions
+	for _, inner := range e.Events {
+		require.Equal(t, uint32(0), inner.Header.LogPos)
+	}
+}
+
+func TestTransactionPayloadEventStampInnerEventPositions(t *testing.T) {
+	mk := func(types ...EventType) *TransactionPayloadEvent {
+		e := &TransactionPayloadEvent{}
+		for _, typ := range types {
+			e.Events = append(e.Events, &BinlogEvent{Header: &EventHeader{EventType: typ}})
+		}
+		return e
+	}
+
+	e := mk(QUERY_EVENT, TABLE_MAP_EVENT, WRITE_ROWS_EVENTv2, XID_EVENT)
+	e.stampInnerEventPositions(&EventHeader{LogPos: 5000, EventSize: 1200})
+	// mid-transaction events point at payload start so resume replays
+	// whole transaction
+	for _, inner := range e.Events[:3] {
+		require.Equal(t, uint32(3800), inner.Header.LogPos)
+	}
+	// final event (XID) points past payload so resume skips transaction
+	require.Equal(t, uint32(5000), e.Events[3].Header.LogPos)
+
+	// outer LogPos=0 (eg artificial event), leave inner events untouched
+	e = mk(QUERY_EVENT, XID_EVENT)
+	e.stampInnerEventPositions(&EventHeader{LogPos: 0, EventSize: 1200})
+	for _, inner := range e.Events {
+		require.Equal(t, uint32(0), inner.Header.LogPos)
+	}
+
+	// no events, must not panic
+	mk().stampInnerEventPositions(&EventHeader{LogPos: 5000, EventSize: 1200})
 }


### PR DESCRIPTION
binlog_transaction_compression=ON wraps each transaction's Query/TableMap/Rows/XID events in TRANSACTION_PAYLOAD_EVENT. Inner events are copied from transaction cache before position fixup, arriving with LogPos=0, & GTID set attachment only happened on outer XID/Query events. Consequence: canal persisted Pos=0 after every compressed transaction & never called UpdateGTIDSet during streaming since inner XIDEvent.GSet was always nil

- parser: stamp inner event positions after payload decode, payload start for mid-transaction events (resume replays whole transaction, matching uncompressed semantics), payload end for final XID/COMMIT (resume skips transaction)
- binlogsyncer: attach current GTID set to XID/Query events decoded from payload, same as uncompressed counterparts; safe since GTID event precedes payload uncompressed