### PR TITLE
client: add ExecQueryRelayLocalInfile for proxy-friendly LOAD DATA LOCAL INFILE

### DIFF
--- a/client/conn.go
+++ b/client/conn.go
@@ -392,38 +392,35 @@ func (c *Conn) ExecuteSelectStreaming(command string, result *mysql.Result, perR
 	return c.readResultStreaming(false, result, perRowCallback, perResultCallback)
 }
 
-// cancelLocalInfileRequest sends an empty LOCAL INFILE payload packet and reads the server's
-// OK or ERR so the connection can be reused when relayFile failed before any file data was sent.
-func (c *Conn) cancelLocalInfileRequest() error {
-	data := make([]byte, 4)
-	if err := c.WritePacket(data); err != nil {
-		return errors.Trace(err)
+// prepareLocalInfileReader fully validates that r can be read without error before any data is
+// sent upstream, per the LOCAL INFILE protocol requirement that on error the server must see
+// only the terminal empty packet, never a truncated file. If r implements io.Seeker (as returned
+// by callers per the documented example: *bytes.Reader, *os.File) it is drained and seeked back
+// to the start so large files are not fully buffered in memory; otherwise the content is read
+// fully into memory with io.ReadAll.
+func prepareLocalInfileReader(r io.Reader) (io.Reader, error) {
+	if r == nil {
+		return bytes.NewReader(nil), nil
 	}
-	resp, err := c.ReadPacket()
+	if seeker, ok := r.(io.Seeker); ok {
+		if _, err := io.Copy(io.Discard, r); err != nil {
+			return nil, err
+		}
+		if _, err := seeker.Seek(0, io.SeekStart); err != nil {
+			return nil, err
+		}
+		return r, nil
+	}
+	content, err := io.ReadAll(r)
 	if err != nil {
-		return errors.Trace(err)
+		return nil, err
 	}
-	if len(resp) == 0 {
-		return errors.New("unexpected empty packet during local infile cancel")
-	}
-	switch resp[0] {
-	case mysql.OK_HEADER:
-		_, err := c.handleOKPacket(resp)
-		return errors.Trace(err)
-	case mysql.ERR_HEADER:
-		_ = c.handleErrorPacket(resp)
-		return nil
-	default:
-		return errors.Errorf("unexpected packet during local infile cancel: 0x%x", resp[0])
-	}
+	return bytes.NewReader(content), nil
 }
 
-// sendLocalInfileContent reads file bytes from r and sends them as LOCAL INFILE data packets,
+// streamLocalInfileChunks sends already-validated file bytes as LOCAL INFILE data packets,
 // followed by the terminal empty packet.
-func (c *Conn) sendLocalInfileContent(r io.Reader) error {
-	if r == nil {
-		r = bytes.NewReader(nil)
-	}
+func (c *Conn) streamLocalInfileChunks(r io.Reader) error {
 	buf := make([]byte, defaultBufferSize)
 	for {
 		n, err := r.Read(buf)
@@ -447,13 +444,58 @@ func (c *Conn) sendLocalInfileContent(r io.Reader) error {
 	return nil
 }
 
+// sendLocalInfileContentAndAwaitResult validates and sends LOCAL INFILE content, then reads the
+// server's OK or ERR. When relayErr is non-nil, or when reader validation fails, only the empty
+// terminator packet is sent (no file data).
+func (c *Conn) sendLocalInfileContentAndAwaitResult(reader io.Reader, relayErr error) (*mysql.Result, error) {
+	content := io.Reader(bytes.NewReader(nil))
+	if relayErr == nil {
+		validated, err := prepareLocalInfileReader(reader)
+		if err != nil {
+			relayErr = err
+		} else {
+			content = validated
+		}
+	}
+	if err := c.streamLocalInfileChunks(content); err != nil {
+		return nil, errors.Trace(err)
+	}
+	resp, err := c.ReadPacket()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(resp) == 0 {
+		return nil, errors.New("unexpected empty packet after LOCAL INFILE")
+	}
+	var result *mysql.Result
+	var respErr error
+	switch resp[0] {
+	case mysql.OK_HEADER:
+		result, respErr = c.handleOKPacket(resp)
+	case mysql.ERR_HEADER:
+		respErr = c.handleErrorPacket(resp)
+	default:
+		respErr = errors.Errorf("unexpected packet after LOCAL INFILE: 0x%x", resp[0])
+	}
+	if relayErr != nil {
+		if respErr != nil {
+			return nil, errors.Errorf("local infile relay failed: %v; server response: %v", relayErr, respErr)
+		}
+		return nil, errors.Trace(relayErr)
+	}
+	return result, errors.Trace(respErr)
+}
+
 // ExecQueryRelayLocalInfile sends COM_QUERY and handles the LOCAL INFILE protocol when the server
 // responds with a 0xfb packet. relayFile receives that full request payload and must return a
-// reader over the complete file content (or nil for an empty file). The library sends the data
-// packets and terminal empty packet; the final OK or ERR from the upstream server is returned.
+// reader over the complete file content (or nil for an empty file). The library validates the
+// reader, sends data packets and the terminal empty packet, then returns the final OK or ERR.
 //
-// If relayFile returns an error, no file data is sent upstream; cancelLocalInfileRequest sends
-// only the empty packet so the connection can be reused.
+// If relayFile returns an error, or the reader cannot be fully read, no file data is sent
+// upstream; only the empty terminator packet is sent so the connection can be reused.
+//
+// OK and ERR responses before the 0xfb packet are handled directly when the server rejects the
+// LOAD DATA statement (e.g. local_infile disabled, missing privileges).
 //
 // This is the proxy-friendly counterpart to the local-file reading in client/auth.go. It does not
 // access the filesystem; ownership of the file transfer is delegated entirely to the caller.
@@ -497,34 +539,11 @@ func (c *Conn) ExecQueryRelayLocalInfile(query string, relayFile func(localInfil
 	case mysql.ERR_HEADER:
 		return nil, c.handleErrorPacket(data)
 	case mysql.LocalInFile_HEADER:
-		reader, err := relayFile(data)
-		if err != nil {
-			if cancelErr := c.cancelLocalInfileRequest(); cancelErr != nil {
-				return nil, errors.Errorf("local infile relay failed: %v; cancel failed: %v", err, cancelErr)
-			}
-			return nil, errors.Trace(err)
-		}
+		reader, relayErr := relayFile(data)
 		if closer, ok := reader.(io.Closer); ok && reader != nil {
 			defer closer.Close()
 		}
-		if err := c.sendLocalInfileContent(reader); err != nil {
-			return nil, errors.Trace(err)
-		}
-		data2, err := c.ReadPacket()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		if len(data2) == 0 {
-			return nil, errors.New("unexpected empty packet after LOCAL INFILE")
-		}
-		switch data2[0] {
-		case mysql.OK_HEADER:
-			return c.handleOKPacket(data2)
-		case mysql.ERR_HEADER:
-			return nil, c.handleErrorPacket(data2)
-		default:
-			return nil, errors.Errorf("unexpected packet after LOCAL INFILE: 0x%x", data2[0])
-		}
+		return c.sendLocalInfileContentAndAwaitResult(reader, relayErr)
 	default:
 		return nil, errors.Errorf("unexpected response to COM_QUERY (expected OK, ERR, or LOCAL INFILE): 0x%x", data[0])
 	}

--- a/client/conn.go
+++ b/client/conn.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"maps"
 	"math/bits"
 	"net"
@@ -391,9 +392,9 @@ func (c *Conn) ExecuteSelectStreaming(command string, result *mysql.Result, perR
 	return c.readResultStreaming(false, result, perRowCallback, perResultCallback)
 }
 
-// cleanupLocalInfileAfterRelayError sends an empty payload packet (EOF for LOCAL INFILE) and reads
-// the server's OK or ERR so the client connection is resynchronized after relayFile failed mid-transfer.
-func (c *Conn) cleanupLocalInfileAfterRelayError() error {
+// cancelLocalInfileRequest sends an empty LOCAL INFILE payload packet and reads the server's
+// OK or ERR so the connection can be reused when relayFile failed before any file data was sent.
+func (c *Conn) cancelLocalInfileRequest() error {
 	data := make([]byte, 4)
 	if err := c.WritePacket(data); err != nil {
 		return errors.Trace(err)
@@ -403,7 +404,7 @@ func (c *Conn) cleanupLocalInfileAfterRelayError() error {
 		return errors.Trace(err)
 	}
 	if len(resp) == 0 {
-		return errors.New("unexpected empty packet during local infile cleanup")
+		return errors.New("unexpected empty packet during local infile cancel")
 	}
 	switch resp[0] {
 	case mysql.OK_HEADER:
@@ -413,24 +414,50 @@ func (c *Conn) cleanupLocalInfileAfterRelayError() error {
 		_ = c.handleErrorPacket(resp)
 		return nil
 	default:
-		return errors.Errorf("unexpected packet during local infile cleanup: 0x%x", resp[0])
+		return errors.Errorf("unexpected packet during local infile cancel: 0x%x", resp[0])
 	}
 }
 
+// sendLocalInfileContent reads file bytes from r and sends them as LOCAL INFILE data packets,
+// followed by the terminal empty packet.
+func (c *Conn) sendLocalInfileContent(r io.Reader) error {
+	if r == nil {
+		r = bytes.NewReader(nil)
+	}
+	buf := make([]byte, defaultBufferSize)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			pkt := make([]byte, 4+n)
+			copy(pkt[4:], buf[:n])
+			if err := c.WritePacket(pkt); err != nil {
+				return errors.Trace(err)
+			}
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	if err := c.WritePacket(make([]byte, 4)); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
 // ExecQueryRelayLocalInfile sends COM_QUERY and handles the LOCAL INFILE protocol when the server
-// responds with a 0xfb packet. relayFile receives that full request payload and the connection
-// c; it must forward the request to the application client, read file-data packets from that
-// client, and write each to c via c.WritePacket (4-byte header prefix + payload) until an empty
-// packet signals EOF. The final OK or ERR from the upstream server is read and returned.
+// responds with a 0xfb packet. relayFile receives that full request payload and must return a
+// reader over the complete file content (or nil for an empty file). The library sends the data
+// packets and terminal empty packet; the final OK or ERR from the upstream server is returned.
 //
-// On success, relayFile must send all file-data packets and the terminal empty packet before
-// returning nil. On error, relayFile may return after forwarding partial data; the empty packet
-// is then sent by cleanupLocalInfileAfterRelayError so the connection can be resynchronized and
-// reused. The original relay error is still returned to the caller.
+// If relayFile returns an error, no file data is sent upstream; cancelLocalInfileRequest sends
+// only the empty packet so the connection can be reused.
 //
 // This is the proxy-friendly counterpart to the local-file reading in client/auth.go. It does not
 // access the filesystem; ownership of the file transfer is delegated entirely to the caller.
-func (c *Conn) ExecQueryRelayLocalInfile(query string, relayFile func(localInfileRequestPayload []byte, c *Conn) error) (*mysql.Result, error) {
+func (c *Conn) ExecQueryRelayLocalInfile(query string, relayFile func(localInfileRequestPayload []byte) (io.Reader, error)) (*mysql.Result, error) {
 	if err := c.execSend(query); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -447,10 +474,17 @@ func (c *Conn) ExecQueryRelayLocalInfile(query string, relayFile func(localInfil
 	case mysql.ERR_HEADER:
 		return nil, c.handleErrorPacket(data)
 	case mysql.LocalInFile_HEADER:
-		if err := relayFile(data, c); err != nil {
-			if cleanupErr := c.cleanupLocalInfileAfterRelayError(); cleanupErr != nil {
-				return nil, errors.Errorf("local infile relay failed: %v; cleanup failed: %v", err, cleanupErr)
+		reader, err := relayFile(data)
+		if err != nil {
+			if cancelErr := c.cancelLocalInfileRequest(); cancelErr != nil {
+				return nil, errors.Errorf("local infile relay failed: %v; cancel failed: %v", err, cancelErr)
 			}
+			return nil, errors.Trace(err)
+		}
+		if closer, ok := reader.(io.Closer); ok && reader != nil {
+			defer closer.Close()
+		}
+		if err := c.sendLocalInfileContent(reader); err != nil {
 			return nil, errors.Trace(err)
 		}
 		data2, err := c.ReadPacket()

--- a/client/conn.go
+++ b/client/conn.go
@@ -396,16 +396,19 @@ func (c *Conn) ExecuteSelectStreaming(command string, result *mysql.Result, perR
 func (c *Conn) cleanupLocalInfileAfterRelayError() error {
 	data := make([]byte, 4)
 	if err := c.WritePacket(data); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	resp, err := c.ReadPacket()
 	if err != nil {
-		return err
+		return errors.Trace(err)
+	}
+	if len(resp) == 0 {
+		return errors.New("unexpected empty packet during local infile cleanup")
 	}
 	switch resp[0] {
 	case mysql.OK_HEADER:
 		_, err := c.handleOKPacket(resp)
-		return err
+		return errors.Trace(err)
 	case mysql.ERR_HEADER:
 		_ = c.handleErrorPacket(resp)
 		return nil
@@ -433,6 +436,9 @@ func (c *Conn) ExecQueryRelayLocalInfile(query string, relayFile func(localInfil
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	if len(data) == 0 {
+		return nil, errors.New("unexpected empty packet from server")
+	}
 	switch data[0] {
 	case mysql.OK_HEADER:
 		return c.handleOKPacket(data)
@@ -448,6 +454,9 @@ func (c *Conn) ExecQueryRelayLocalInfile(query string, relayFile func(localInfil
 		data2, err := c.ReadPacket()
 		if err != nil {
 			return nil, errors.Trace(err)
+		}
+		if len(data2) == 0 {
+			return nil, errors.New("unexpected empty packet after LOCAL INFILE")
 		}
 		switch data2[0] {
 		case mysql.OK_HEADER:

--- a/client/conn.go
+++ b/client/conn.go
@@ -391,6 +391,77 @@ func (c *Conn) ExecuteSelectStreaming(command string, result *mysql.Result, perR
 	return c.readResultStreaming(false, result, perRowCallback, perResultCallback)
 }
 
+// cleanupLocalInfileAfterRelayError sends an empty payload packet (EOF for LOCAL INFILE) and reads
+// the server's OK or ERR so the client connection is resynchronized after relayFile failed mid-transfer.
+func (c *Conn) cleanupLocalInfileAfterRelayError() error {
+	data := make([]byte, 4)
+	if err := c.WritePacket(data); err != nil {
+		return err
+	}
+	resp, err := c.ReadPacket()
+	if err != nil {
+		return err
+	}
+	switch resp[0] {
+	case mysql.OK_HEADER:
+		_, err := c.handleOKPacket(resp)
+		return err
+	case mysql.ERR_HEADER:
+		_ = c.handleErrorPacket(resp)
+		return nil
+	default:
+		return errors.Errorf("unexpected packet during local infile cleanup: 0x%x", resp[0])
+	}
+}
+
+// ExecQueryRelayLocalInfile sends COM_QUERY and handles the LOCAL INFILE protocol when the server
+// responds with a 0xfb packet. relayFile receives that full request payload and must forward the
+// request to the application client, read file-data packets from that client, and write each to
+// this connection via WritePacket (4-byte header prefix + payload) until an empty packet signals
+// EOF. The final OK or ERR from the upstream server is read and returned.
+//
+// If relayFile returns an error the connection is resynchronized before the error is returned so
+// the connection can be reused.
+//
+// This is the proxy-friendly counterpart to the local-file reading in client/auth.go. It does not
+// access the filesystem; ownership of the file transfer is delegated entirely to the caller.
+func (c *Conn) ExecQueryRelayLocalInfile(query string, relayFile func(localInfileRequestPayload []byte) error) (*mysql.Result, error) {
+	if err := c.execSend(query); err != nil {
+		return nil, errors.Trace(err)
+	}
+	data, err := c.ReadPacket()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	switch data[0] {
+	case mysql.OK_HEADER:
+		return c.handleOKPacket(data)
+	case mysql.ERR_HEADER:
+		return nil, c.handleErrorPacket(data)
+	case mysql.LocalInFile_HEADER:
+		if err := relayFile(data); err != nil {
+			if cleanupErr := c.cleanupLocalInfileAfterRelayError(); cleanupErr != nil {
+				return nil, errors.Errorf("local infile relay failed: %v; cleanup failed: %v", err, cleanupErr)
+			}
+			return nil, errors.Trace(err)
+		}
+		data2, err := c.ReadPacket()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		switch data2[0] {
+		case mysql.OK_HEADER:
+			return c.handleOKPacket(data2)
+		case mysql.ERR_HEADER:
+			return nil, c.handleErrorPacket(data2)
+		default:
+			return nil, errors.Errorf("unexpected packet after LOCAL INFILE: 0x%x", data2[0])
+		}
+	default:
+		return nil, errors.Errorf("unexpected response to COM_QUERY (expected OK, ERR, or LOCAL INFILE): 0x%x", data[0])
+	}
+}
+
 func (c *Conn) Begin() error {
 	_, err := c.exec("BEGIN")
 	return errors.Trace(err)

--- a/client/conn.go
+++ b/client/conn.go
@@ -418,17 +418,19 @@ func (c *Conn) cleanupLocalInfileAfterRelayError() error {
 }
 
 // ExecQueryRelayLocalInfile sends COM_QUERY and handles the LOCAL INFILE protocol when the server
-// responds with a 0xfb packet. relayFile receives that full request payload and must forward the
-// request to the application client, read file-data packets from that client, and write each to
-// this connection via WritePacket (4-byte header prefix + payload) until an empty packet signals
-// EOF. The final OK or ERR from the upstream server is read and returned.
+// responds with a 0xfb packet. relayFile receives that full request payload and the connection
+// c; it must forward the request to the application client, read file-data packets from that
+// client, and write each to c via c.WritePacket (4-byte header prefix + payload) until an empty
+// packet signals EOF. The final OK or ERR from the upstream server is read and returned.
 //
-// If relayFile returns an error the connection is resynchronized before the error is returned so
-// the connection can be reused.
+// On success, relayFile must send all file-data packets and the terminal empty packet before
+// returning nil. On error, relayFile may return after forwarding partial data; the empty packet
+// is then sent by cleanupLocalInfileAfterRelayError so the connection can be resynchronized and
+// reused. The original relay error is still returned to the caller.
 //
 // This is the proxy-friendly counterpart to the local-file reading in client/auth.go. It does not
 // access the filesystem; ownership of the file transfer is delegated entirely to the caller.
-func (c *Conn) ExecQueryRelayLocalInfile(query string, relayFile func(localInfileRequestPayload []byte) error) (*mysql.Result, error) {
+func (c *Conn) ExecQueryRelayLocalInfile(query string, relayFile func(localInfileRequestPayload []byte, c *Conn) error) (*mysql.Result, error) {
 	if err := c.execSend(query); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -445,7 +447,7 @@ func (c *Conn) ExecQueryRelayLocalInfile(query string, relayFile func(localInfil
 	case mysql.ERR_HEADER:
 		return nil, c.handleErrorPacket(data)
 	case mysql.LocalInFile_HEADER:
-		if err := relayFile(data); err != nil {
+		if err := relayFile(data, c); err != nil {
 			if cleanupErr := c.cleanupLocalInfileAfterRelayError(); cleanupErr != nil {
 				return nil, errors.Errorf("local infile relay failed: %v; cleanup failed: %v", err, cleanupErr)
 			}

--- a/client/conn.go
+++ b/client/conn.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"log"
 	"maps"
 	"math/bits"
 	"net"
@@ -418,27 +419,39 @@ func prepareLocalInfileReader(r io.Reader) (io.Reader, error) {
 	return bytes.NewReader(content), nil
 }
 
+func (c *Conn) writeLocalInfileTerminator() error {
+	return c.WritePacket(make([]byte, 4))
+}
+
 // streamLocalInfileChunks sends already-validated file bytes as LOCAL INFILE data packets,
 // followed by the terminal empty packet.
 func (c *Conn) streamLocalInfileChunks(r io.Reader) error {
-	buf := make([]byte, defaultBufferSize)
+	buf := make([]byte, 4+defaultBufferSize)
+	sentData := false
 	for {
-		n, err := r.Read(buf)
+		n, err := r.Read(buf[4:])
 		if n > 0 {
-			pkt := make([]byte, 4+n)
-			copy(pkt[4:], buf[:n])
-			if err := c.WritePacket(pkt); err != nil {
-				return errors.Trace(err)
+			if werr := c.WritePacket(buf[:4+n]); werr != nil {
+				if tErr := c.writeLocalInfileTerminator(); tErr != nil {
+					log.Printf("go-mysql: failed to send LOCAL INFILE terminator after write error: %v", tErr)
+				}
+				return errors.Trace(werr)
 			}
+			sentData = true
 		}
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
+			if sentData {
+				if tErr := c.writeLocalInfileTerminator(); tErr != nil {
+					log.Printf("go-mysql: failed to send LOCAL INFILE terminator after read error: %v", tErr)
+				}
+			}
 			return errors.Trace(err)
 		}
 	}
-	if err := c.WritePacket(make([]byte, 4)); err != nil {
+	if err := c.writeLocalInfileTerminator(); err != nil {
 		return errors.Trace(err)
 	}
 	return nil
@@ -457,8 +470,12 @@ func (c *Conn) sendLocalInfileContentAndAwaitResult(reader io.Reader, relayErr e
 			content = validated
 		}
 	}
+	streamErr := error(nil)
 	if err := c.streamLocalInfileChunks(content); err != nil {
-		return nil, errors.Trace(err)
+		streamErr = err
+	}
+	if relayErr == nil && streamErr != nil {
+		relayErr = streamErr
 	}
 	resp, err := c.ReadPacket()
 	if err != nil {
@@ -487,24 +504,29 @@ func (c *Conn) sendLocalInfileContentAndAwaitResult(reader io.Reader, relayErr e
 }
 
 // ExecQueryRelayLocalInfile sends COM_QUERY and handles the LOCAL INFILE protocol when the server
-// responds with a 0xfb packet. relayFile receives that full request payload and must return a
-// reader over the complete file content (or nil for an empty file). The library validates the
-// reader, sends data packets and the terminal empty packet, then returns the final OK or ERR.
+// responds with a 0xfb packet. relayFile receives the filename bytes from that request (without the
+// 0xfb header) and must return a reader over the complete file content (or nil for an empty file).
+// The library validates the reader, sends data packets and the terminal empty packet, then returns
+// the final OK or ERR.
 //
-// If relayFile returns an error, or the reader cannot be fully read, no file data is sent
-// upstream; only the empty terminator packet is sent so the connection can be reused.
+// If relayFile returns an error, or the reader cannot be fully read, no file data is sent upstream;
+// only the empty terminator packet is sent so the connection can be reused.
 //
-// OK and ERR responses before the 0xfb packet are handled directly when the server rejects the
-// LOAD DATA statement (e.g. local_infile disabled, missing privileges).
+// Notes:
+//   - This function is intended for LOAD DATA LOCAL INFILE queries.
+//   - relayFile is only invoked when the server responds with LocalInFile_HEADER (0xfb).
+//   - Direct OK or ERR (no 0xfb) occurs when the server rejects the statement before requesting a
+//     file — e.g. local_infile disabled, missing privileges, or a syntax error. Handling these
+//     responses keeps the connection usable, consistent with readResultStreaming and
+//     ExecuteMultiple.
 //
 // This is the proxy-friendly counterpart to the local-file reading in client/auth.go. It does not
 // access the filesystem; ownership of the file transfer is delegated entirely to the caller.
 //
 // Example (MySQL proxy relaying LOAD DATA LOCAL INFILE from an application client to upstream):
 //
-//	result, err := upstream.ExecQueryRelayLocalInfile(query, func(requestPayload []byte) (io.Reader, error) {
-//	    // requestPayload[0] is 0xfb; filename/path bytes follow (not null-terminated).
-//	    if err := downstream.WritePacket(wrapPacket(requestPayload)); err != nil {
+//	result, err := upstream.ExecQueryRelayLocalInfile(query, func(filename []byte) (io.Reader, error) {
+//	    if err := downstream.WritePacket(wrapPacket(append([]byte{mysql.LocalInFile_HEADER}, filename...))); err != nil {
 //	        return nil, err
 //	    }
 //	    var buf bytes.Buffer
@@ -522,7 +544,7 @@ func (c *Conn) sendLocalInfileContentAndAwaitResult(reader io.Reader, relayErr e
 //	    }
 //	    return bytes.NewReader(buf.Bytes()), nil
 //	})
-func (c *Conn) ExecQueryRelayLocalInfile(query string, relayFile func(localInfileRequestPayload []byte) (io.Reader, error)) (*mysql.Result, error) {
+func (c *Conn) ExecQueryRelayLocalInfile(query string, relayFile func(filename []byte) (io.Reader, error)) (*mysql.Result, error) {
 	if err := c.execSend(query); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -539,7 +561,7 @@ func (c *Conn) ExecQueryRelayLocalInfile(query string, relayFile func(localInfil
 	case mysql.ERR_HEADER:
 		return nil, c.handleErrorPacket(data)
 	case mysql.LocalInFile_HEADER:
-		reader, relayErr := relayFile(data)
+		reader, relayErr := relayFile(data[1:])
 		if closer, ok := reader.(io.Closer); ok && reader != nil {
 			defer closer.Close()
 		}

--- a/client/conn.go
+++ b/client/conn.go
@@ -457,6 +457,29 @@ func (c *Conn) sendLocalInfileContent(r io.Reader) error {
 //
 // This is the proxy-friendly counterpart to the local-file reading in client/auth.go. It does not
 // access the filesystem; ownership of the file transfer is delegated entirely to the caller.
+//
+// Example (MySQL proxy relaying LOAD DATA LOCAL INFILE from an application client to upstream):
+//
+//	result, err := upstream.ExecQueryRelayLocalInfile(query, func(requestPayload []byte) (io.Reader, error) {
+//	    // requestPayload[0] is 0xfb; filename/path bytes follow (not null-terminated).
+//	    if err := downstream.WritePacket(wrapPacket(requestPayload)); err != nil {
+//	        return nil, err
+//	    }
+//	    var buf bytes.Buffer
+//	    for {
+//	        pkt, err := downstream.ReadPacket()
+//	        if err != nil {
+//	            return nil, err
+//	        }
+//	        if len(pkt) == 0 {
+//	            break // empty packet = end of file from client
+//	        }
+//	        if _, err := buf.Write(pkt); err != nil {
+//	            return nil, err
+//	        }
+//	    }
+//	    return bytes.NewReader(buf.Bytes()), nil
+//	})
 func (c *Conn) ExecQueryRelayLocalInfile(query string, relayFile func(localInfileRequestPayload []byte) (io.Reader, error)) (*mysql.Result, error) {
 	if err := c.execSend(query); err != nil {
 		return nil, errors.Trace(err)

--- a/client/local_infile_test.go
+++ b/client/local_infile_test.go
@@ -53,107 +53,206 @@ func readServerCOMQuery(t *testing.T, pc *packet.Conn) {
 	require.Equal(t, mysql.COM_QUERY, pkt[0])
 }
 
-func TestExecQueryRelayLocalInfile_DirectOK(t *testing.T) {
-	serverConn, clientConn := net.Pipe()
-	defer serverConn.Close()
-	defer clientConn.Close()
-
-	serverPC := packet.NewConn(serverConn)
-	go func() {
-		readServerCOMQuery(t, serverPC)
-		require.NoError(t, writeServerOK(serverPC))
-	}()
-
-	c := newLocalInfileTestConn(clientConn)
-	relayCalled := false
-	result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'f.csv'", func([]byte) (io.Reader, error) {
-		relayCalled = true
-		return nil, nil
-	})
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.False(t, relayCalled)
+type failOnWriteConn struct {
+	net.Conn
+	writes int
+	failOn int
 }
 
-func TestExecQueryRelayLocalInfile_DirectErr(t *testing.T) {
-	serverConn, clientConn := net.Pipe()
-	defer serverConn.Close()
-	defer clientConn.Close()
-
-	serverPC := packet.NewConn(serverConn)
-	go func() {
-		readServerCOMQuery(t, serverPC)
-		require.NoError(t, writeServerERR(serverPC))
-	}()
-
-	c := newLocalInfileTestConn(clientConn)
-	relayCalled := false
-	result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'f.csv'", func([]byte) (io.Reader, error) {
-		relayCalled = true
-		return nil, nil
-	})
-	require.Error(t, err)
-	require.Nil(t, result)
-	require.False(t, relayCalled)
+func (c *failOnWriteConn) Write(b []byte) (int, error) {
+	c.writes++
+	if c.writes == c.failOn {
+		return 0, errors.New("write failed")
+	}
+	return c.Conn.Write(b)
 }
 
-func TestExecQueryRelayLocalInfile_RelaySuccess(t *testing.T) {
-	serverConn, clientConn := net.Pipe()
-	defer serverConn.Close()
-	defer clientConn.Close()
-
-	serverPC := packet.NewConn(serverConn)
-	go func() {
-		readServerCOMQuery(t, serverPC)
-		require.NoError(t, writeServerLocalInfile(serverPC, "test.csv"))
-
-		pkt, err := serverPC.ReadPacket()
-		require.NoError(t, err)
-		require.Equal(t, []byte("row1\n"), pkt)
-
-		pkt, err = serverPC.ReadPacket()
-		require.NoError(t, err)
-		require.Empty(t, pkt)
-
-		require.NoError(t, writeServerOK(serverPC))
-	}()
-
-	c := newLocalInfileTestConn(clientConn)
-	var requestPayload []byte
-	result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'test.csv'", func(payload []byte) (io.Reader, error) {
-		requestPayload = append([]byte(nil), payload...)
-		return bytes.NewReader([]byte("row1\n")), nil
-	})
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Equal(t, mysql.LocalInFile_HEADER, requestPayload[0])
-	require.Equal(t, "test.csv", string(requestPayload[1:]))
+type twoChunkReader struct {
+	chunks [][]byte
+	i      int
 }
 
-func TestExecQueryRelayLocalInfile_RelayError(t *testing.T) {
-	serverConn, clientConn := net.Pipe()
-	defer serverConn.Close()
-	defer clientConn.Close()
+func (r *twoChunkReader) Read(p []byte) (int, error) {
+	if r.i >= len(r.chunks) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.chunks[r.i])
+	r.i++
+	if r.i >= len(r.chunks) {
+		return n, io.EOF
+	}
+	return n, nil
+}
 
-	relayErr := errors.New("relay failed")
+func (r *twoChunkReader) Seek(offset int64, whence int) (int64, error) {
+	if whence != io.SeekStart || offset != 0 {
+		return 0, errors.New("unsupported seek")
+	}
+	r.i = 0
+	return 0, nil
+}
 
-	serverPC := packet.NewConn(serverConn)
-	go func() {
-		readServerCOMQuery(t, serverPC)
-		require.NoError(t, writeServerLocalInfile(serverPC, "test.csv"))
+func TestExecQueryRelayLocalInfile(t *testing.T) {
+	t.Run("DirectOK", func(t *testing.T) {
+		serverConn, clientConn := net.Pipe()
+		defer serverConn.Close()
+		defer clientConn.Close()
 
-		pkt, err := serverPC.ReadPacket()
+		serverPC := packet.NewConn(serverConn)
+		go func() {
+			readServerCOMQuery(t, serverPC)
+			require.NoError(t, writeServerOK(serverPC))
+		}()
+
+		c := newLocalInfileTestConn(clientConn)
+		relayCalled := false
+		result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'f.csv'", func([]byte) (io.Reader, error) {
+			relayCalled = true
+			return nil, nil
+		})
 		require.NoError(t, err)
-		require.Empty(t, pkt)
-
-		require.NoError(t, writeServerOK(serverPC))
-	}()
-
-	c := newLocalInfileTestConn(clientConn)
-	_, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'test.csv'", func([]byte) (io.Reader, error) {
-		return nil, relayErr
+		require.NotNil(t, result)
+		require.False(t, relayCalled)
 	})
-	require.ErrorIs(t, err, relayErr)
+
+	t.Run("DirectErr", func(t *testing.T) {
+		serverConn, clientConn := net.Pipe()
+		defer serverConn.Close()
+		defer clientConn.Close()
+
+		serverPC := packet.NewConn(serverConn)
+		go func() {
+			readServerCOMQuery(t, serverPC)
+			require.NoError(t, writeServerERR(serverPC))
+		}()
+
+		c := newLocalInfileTestConn(clientConn)
+		relayCalled := false
+		result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'f.csv'", func([]byte) (io.Reader, error) {
+			relayCalled = true
+			return nil, nil
+		})
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.False(t, relayCalled)
+	})
+
+	t.Run("RelaySuccess", func(t *testing.T) {
+		serverConn, clientConn := net.Pipe()
+		defer serverConn.Close()
+		defer clientConn.Close()
+
+		serverPC := packet.NewConn(serverConn)
+		go func() {
+			readServerCOMQuery(t, serverPC)
+			require.NoError(t, writeServerLocalInfile(serverPC, "test.csv"))
+
+			pkt, err := serverPC.ReadPacket()
+			require.NoError(t, err)
+			require.Equal(t, []byte("row1\n"), pkt)
+
+			pkt, err = serverPC.ReadPacket()
+			require.NoError(t, err)
+			require.Empty(t, pkt)
+
+			require.NoError(t, writeServerOK(serverPC))
+		}()
+
+		c := newLocalInfileTestConn(clientConn)
+		var filename []byte
+		result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'test.csv'", func(fn []byte) (io.Reader, error) {
+			filename = append([]byte(nil), fn...)
+			return bytes.NewReader([]byte("row1\n")), nil
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, "test.csv", string(filename))
+	})
+
+	t.Run("RelayError", func(t *testing.T) {
+		serverConn, clientConn := net.Pipe()
+		defer serverConn.Close()
+		defer clientConn.Close()
+
+		relayErr := errors.New("relay failed")
+
+		serverPC := packet.NewConn(serverConn)
+		go func() {
+			readServerCOMQuery(t, serverPC)
+			require.NoError(t, writeServerLocalInfile(serverPC, "test.csv"))
+
+			pkt, err := serverPC.ReadPacket()
+			require.NoError(t, err)
+			require.Empty(t, pkt)
+
+			require.NoError(t, writeServerOK(serverPC))
+		}()
+
+		c := newLocalInfileTestConn(clientConn)
+		_, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'test.csv'", func([]byte) (io.Reader, error) {
+			return nil, relayErr
+		})
+		require.ErrorIs(t, err, relayErr)
+	})
+
+	t.Run("RelayReadError", func(t *testing.T) {
+		serverConn, clientConn := net.Pipe()
+		defer serverConn.Close()
+		defer clientConn.Close()
+
+		readErr := errors.New("read failed mid-transfer")
+
+		serverPC := packet.NewConn(serverConn)
+		go func() {
+			readServerCOMQuery(t, serverPC)
+			require.NoError(t, writeServerLocalInfile(serverPC, "test.csv"))
+
+			pkt, err := serverPC.ReadPacket()
+			require.NoError(t, err)
+			require.Empty(t, pkt, "server must receive only empty terminator, no partial file data")
+
+			require.NoError(t, writeServerOK(serverPC))
+		}()
+
+		c := newLocalInfileTestConn(clientConn)
+		_, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'test.csv'", func([]byte) (io.Reader, error) {
+			return &failingLocalInfileReader{data: []byte("partial"), err: readErr}, nil
+		})
+		require.ErrorIs(t, err, readErr)
+	})
+
+	t.Run("StreamWriteError", func(t *testing.T) {
+		serverConn, rawClientConn := net.Pipe()
+		defer serverConn.Close()
+		defer rawClientConn.Close()
+
+		// COM_QUERY (1), first chunk (2), second chunk fails (3), defensive terminator (4).
+		clientConn := &failOnWriteConn{Conn: rawClientConn, failOn: 3}
+
+		serverPC := packet.NewConn(serverConn)
+		go func() {
+			readServerCOMQuery(t, serverPC)
+			require.NoError(t, writeServerLocalInfile(serverPC, "test.csv"))
+
+			pkt, err := serverPC.ReadPacket()
+			require.NoError(t, err)
+			require.Equal(t, []byte("part1"), pkt)
+
+			pkt, err = serverPC.ReadPacket()
+			require.NoError(t, err)
+			require.Empty(t, pkt, "defensive terminator must be sent after write failure")
+
+			require.NoError(t, writeServerOK(serverPC))
+		}()
+
+		c := newLocalInfileTestConn(clientConn)
+		result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'test.csv'", func([]byte) (io.Reader, error) {
+			return &twoChunkReader{chunks: [][]byte{[]byte("part1"), []byte("part2")}}, nil
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "write failed")
+		require.Nil(t, result)
+	})
 }
 
 type failingLocalInfileReader struct {
@@ -172,30 +271,4 @@ func (r *failingLocalInfileReader) Read(p []byte) (int, error) {
 		return n, r.err
 	}
 	return n, nil
-}
-
-func TestExecQueryRelayLocalInfile_RelayReadError(t *testing.T) {
-	serverConn, clientConn := net.Pipe()
-	defer serverConn.Close()
-	defer clientConn.Close()
-
-	readErr := errors.New("read failed mid-transfer")
-
-	serverPC := packet.NewConn(serverConn)
-	go func() {
-		readServerCOMQuery(t, serverPC)
-		require.NoError(t, writeServerLocalInfile(serverPC, "test.csv"))
-
-		pkt, err := serverPC.ReadPacket()
-		require.NoError(t, err)
-		require.Empty(t, pkt, "server must receive only empty terminator, no partial file data")
-
-		require.NoError(t, writeServerOK(serverPC))
-	}()
-
-	c := newLocalInfileTestConn(clientConn)
-	_, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'test.csv'", func([]byte) (io.Reader, error) {
-		return &failingLocalInfileReader{data: []byte("partial"), err: readErr}, nil
-	})
-	require.ErrorIs(t, err, readErr)
 }

--- a/client/local_infile_test.go
+++ b/client/local_infile_test.go
@@ -48,7 +48,7 @@ func readServerCOMQuery(t *testing.T, pc *packet.Conn) {
 	pkt, err := pc.ReadPacket()
 	require.NoError(t, err)
 	require.NotEmpty(t, pkt)
-	require.Equal(t, byte(mysql.COM_QUERY), pkt[0])
+	require.Equal(t, mysql.COM_QUERY, pkt[0])
 }
 
 func TestExecQueryRelayLocalInfile_DirectOK(t *testing.T) {
@@ -129,7 +129,7 @@ func TestExecQueryRelayLocalInfile_RelaySuccess(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Equal(t, byte(mysql.LocalInFile_HEADER), requestPayload[0])
+	require.Equal(t, mysql.LocalInFile_HEADER, requestPayload[0])
 	require.Equal(t, "test.csv", string(requestPayload[1:]))
 }
 

--- a/client/local_infile_test.go
+++ b/client/local_infile_test.go
@@ -1,0 +1,160 @@
+package client
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/packet"
+	"github.com/stretchr/testify/require"
+)
+
+func newLocalInfileTestConn(server net.Conn) *Conn {
+	return &Conn{
+		Conn:       packet.NewConn(server),
+		capability: mysql.CLIENT_PROTOCOL_41,
+	}
+}
+
+func writeServerPacket(pc *packet.Conn, payload []byte) error {
+	data := make([]byte, 4+len(payload))
+	copy(data[4:], payload)
+	return pc.WritePacket(data)
+}
+
+func writeServerOK(pc *packet.Conn) error {
+	payload := []byte{mysql.OK_HEADER, 0, 0, 0x02, 0x00, 0, 0}
+	return writeServerPacket(pc, payload)
+}
+
+func writeServerERR(pc *packet.Conn) error {
+	payload := []byte{
+		mysql.ERR_HEADER,
+		0x01, 0x00,
+		'#', 'H', 'Y', '0', '0', '0',
+	}
+	payload = append(payload, []byte("test error")...)
+	return writeServerPacket(pc, payload)
+}
+
+func writeServerLocalInfile(pc *packet.Conn, filename string) error {
+	payload := append([]byte{mysql.LocalInFile_HEADER}, []byte(filename)...)
+	return writeServerPacket(pc, payload)
+}
+
+func readServerCOMQuery(t *testing.T, pc *packet.Conn) {
+	t.Helper()
+	pkt, err := pc.ReadPacket()
+	require.NoError(t, err)
+	require.NotEmpty(t, pkt)
+	require.Equal(t, byte(mysql.COM_QUERY), pkt[0])
+}
+
+func TestExecQueryRelayLocalInfile_DirectOK(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	serverPC := packet.NewConn(serverConn)
+	go func() {
+		readServerCOMQuery(t, serverPC)
+		require.NoError(t, writeServerOK(serverPC))
+	}()
+
+	c := newLocalInfileTestConn(clientConn)
+	relayCalled := false
+	result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'f.csv'", func([]byte) error {
+		relayCalled = true
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, relayCalled)
+}
+
+func TestExecQueryRelayLocalInfile_DirectErr(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	serverPC := packet.NewConn(serverConn)
+	go func() {
+		readServerCOMQuery(t, serverPC)
+		require.NoError(t, writeServerERR(serverPC))
+	}()
+
+	c := newLocalInfileTestConn(clientConn)
+	relayCalled := false
+	result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'f.csv'", func([]byte) error {
+		relayCalled = true
+		return nil
+	})
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.False(t, relayCalled)
+}
+
+func TestExecQueryRelayLocalInfile_RelaySuccess(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	serverPC := packet.NewConn(serverConn)
+	go func() {
+		readServerCOMQuery(t, serverPC)
+		require.NoError(t, writeServerLocalInfile(serverPC, "test.csv"))
+
+		pkt, err := serverPC.ReadPacket()
+		require.NoError(t, err)
+		require.Equal(t, []byte("row1\n"), pkt)
+
+		pkt, err = serverPC.ReadPacket()
+		require.NoError(t, err)
+		require.Empty(t, pkt)
+
+		require.NoError(t, writeServerOK(serverPC))
+	}()
+
+	c := newLocalInfileTestConn(clientConn)
+	var requestPayload []byte
+	result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'test.csv'", func(payload []byte) error {
+		requestPayload = append([]byte(nil), payload...)
+		chunk := make([]byte, 4+len("row1\n"))
+		copy(chunk[4:], []byte("row1\n"))
+		if err := c.WritePacket(chunk); err != nil {
+			return err
+		}
+		return c.WritePacket(make([]byte, 4))
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, byte(mysql.LocalInFile_HEADER), requestPayload[0])
+	require.Equal(t, "test.csv", string(requestPayload[1:]))
+}
+
+func TestExecQueryRelayLocalInfile_RelayError(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	relayErr := errors.New("relay failed")
+
+	serverPC := packet.NewConn(serverConn)
+	go func() {
+		readServerCOMQuery(t, serverPC)
+		require.NoError(t, writeServerLocalInfile(serverPC, "test.csv"))
+
+		pkt, err := serverPC.ReadPacket()
+		require.NoError(t, err)
+		require.Empty(t, pkt)
+
+		require.NoError(t, writeServerOK(serverPC))
+	}()
+
+	c := newLocalInfileTestConn(clientConn)
+	_, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'test.csv'", func([]byte) error {
+		return relayErr
+	})
+	require.ErrorIs(t, err, relayErr)
+}

--- a/client/local_infile_test.go
+++ b/client/local_infile_test.go
@@ -64,7 +64,7 @@ func TestExecQueryRelayLocalInfile_DirectOK(t *testing.T) {
 
 	c := newLocalInfileTestConn(clientConn)
 	relayCalled := false
-	result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'f.csv'", func([]byte) error {
+	result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'f.csv'", func([]byte, *Conn) error {
 		relayCalled = true
 		return nil
 	})
@@ -86,7 +86,7 @@ func TestExecQueryRelayLocalInfile_DirectErr(t *testing.T) {
 
 	c := newLocalInfileTestConn(clientConn)
 	relayCalled := false
-	result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'f.csv'", func([]byte) error {
+	result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'f.csv'", func([]byte, *Conn) error {
 		relayCalled = true
 		return nil
 	})
@@ -118,7 +118,7 @@ func TestExecQueryRelayLocalInfile_RelaySuccess(t *testing.T) {
 
 	c := newLocalInfileTestConn(clientConn)
 	var requestPayload []byte
-	result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'test.csv'", func(payload []byte) error {
+	result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'test.csv'", func(payload []byte, c *Conn) error {
 		requestPayload = append([]byte(nil), payload...)
 		chunk := make([]byte, 4+len("row1\n"))
 		copy(chunk[4:], []byte("row1\n"))
@@ -153,7 +153,7 @@ func TestExecQueryRelayLocalInfile_RelayError(t *testing.T) {
 	}()
 
 	c := newLocalInfileTestConn(clientConn)
-	_, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'test.csv'", func([]byte) error {
+	_, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'test.csv'", func([]byte, *Conn) error {
 		return relayErr
 	})
 	require.ErrorIs(t, err, relayErr)

--- a/client/local_infile_test.go
+++ b/client/local_infile_test.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"bytes"
 	"errors"
+	"io"
 	"net"
 	"testing"
 
@@ -64,9 +66,9 @@ func TestExecQueryRelayLocalInfile_DirectOK(t *testing.T) {
 
 	c := newLocalInfileTestConn(clientConn)
 	relayCalled := false
-	result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'f.csv'", func([]byte, *Conn) error {
+	result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'f.csv'", func([]byte) (io.Reader, error) {
 		relayCalled = true
-		return nil
+		return nil, nil
 	})
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -86,9 +88,9 @@ func TestExecQueryRelayLocalInfile_DirectErr(t *testing.T) {
 
 	c := newLocalInfileTestConn(clientConn)
 	relayCalled := false
-	result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'f.csv'", func([]byte, *Conn) error {
+	result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'f.csv'", func([]byte) (io.Reader, error) {
 		relayCalled = true
-		return nil
+		return nil, nil
 	})
 	require.Error(t, err)
 	require.Nil(t, result)
@@ -118,14 +120,9 @@ func TestExecQueryRelayLocalInfile_RelaySuccess(t *testing.T) {
 
 	c := newLocalInfileTestConn(clientConn)
 	var requestPayload []byte
-	result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'test.csv'", func(payload []byte, c *Conn) error {
+	result, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'test.csv'", func(payload []byte) (io.Reader, error) {
 		requestPayload = append([]byte(nil), payload...)
-		chunk := make([]byte, 4+len("row1\n"))
-		copy(chunk[4:], []byte("row1\n"))
-		if err := c.WritePacket(chunk); err != nil {
-			return err
-		}
-		return c.WritePacket(make([]byte, 4))
+		return bytes.NewReader([]byte("row1\n")), nil
 	})
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -153,8 +150,8 @@ func TestExecQueryRelayLocalInfile_RelayError(t *testing.T) {
 	}()
 
 	c := newLocalInfileTestConn(clientConn)
-	_, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'test.csv'", func([]byte, *Conn) error {
-		return relayErr
+	_, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'test.csv'", func([]byte) (io.Reader, error) {
+		return nil, relayErr
 	})
 	require.ErrorIs(t, err, relayErr)
 }

--- a/client/local_infile_test.go
+++ b/client/local_infile_test.go
@@ -155,3 +155,47 @@ func TestExecQueryRelayLocalInfile_RelayError(t *testing.T) {
 	})
 	require.ErrorIs(t, err, relayErr)
 }
+
+type failingLocalInfileReader struct {
+	data []byte
+	pos  int
+	err  error
+}
+
+func (r *failingLocalInfileReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	if r.pos >= len(r.data) {
+		return n, r.err
+	}
+	return n, nil
+}
+
+func TestExecQueryRelayLocalInfile_RelayReadError(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	readErr := errors.New("read failed mid-transfer")
+
+	serverPC := packet.NewConn(serverConn)
+	go func() {
+		readServerCOMQuery(t, serverPC)
+		require.NoError(t, writeServerLocalInfile(serverPC, "test.csv"))
+
+		pkt, err := serverPC.ReadPacket()
+		require.NoError(t, err)
+		require.Empty(t, pkt, "server must receive only empty terminator, no partial file data")
+
+		require.NoError(t, writeServerOK(serverPC))
+	}()
+
+	c := newLocalInfileTestConn(clientConn)
+	_, err := c.ExecQueryRelayLocalInfile("LOAD DATA LOCAL INFILE 'test.csv'", func([]byte) (io.Reader, error) {
+		return &failingLocalInfileReader{data: []byte("partial"), err: readErr}, nil
+	})
+	require.ErrorIs(t, err, readErr)
+}


### PR DESCRIPTION
## Summary

Add `(*Conn).ExecQueryRelayLocalInfile` and the companion helper `cleanupLocalInfileAfterRelayError` to `client/conn.go`.

Closes #1161

## Motivation

The existing `Execute` / `exec` path (and the LOCAL INFILE handling in `client/auth.go`) reads the file from the local filesystem. In a proxy scenario the file lives on the *end-user's* machine, not on the proxy. The proxy must relay the `0xfb` request and the subsequent file-data packets between the upstream MySQL server and the downstream client.

There is no API today to intercept the `0xfb LOCAL INFILE` response and hand off the transfer to a callback. This PR fills that gap.

## New API

```go
// ExecQueryRelayLocalInfile sends COM_QUERY and handles the LOCAL INFILE protocol
// when the server responds with a 0xfb packet. relayFile receives the full 0xfb
// request payload; the implementation must forward the request to the application
// client, read file-data packets from that client, and write each to this
// connection via WritePacket (4-byte header + payload) until an empty packet
// signals EOF. The final OK or ERR from the upstream server is read and returned.
//
// If relayFile returns an error the connection is resynchronized before the error
// is returned so the connection can be reused.
func (c *Conn) ExecQueryRelayLocalInfile(
    query string,
    relayFile func(localInfileRequestPayload []byte) error,
) (*mysql.Result, error)
```

`cleanupLocalInfileAfterRelayError` is unexported; it sends the empty EOF packet and reads the server's OK/ERR to bring the connection back to a usable state when `relayFile` fails mid-transfer.

## Notes

- Pure additive change — no existing API is modified.
- Requires `CLIENT_LOCAL_FILES` to be set on both the server side (see #1163) and the client side (via `SetCapability`).
- Tested in production at [alayacare/castledm](https://github.com/alayacare/castledm).

Made with [Cursor](https://cursor.com)