### PR TITLE
server: fix OK session-track suffix and validate SetCapability

### DIFF
--- a/mysql/result.go
+++ b/mysql/result.go
@@ -28,8 +28,10 @@ type SessionTrackingInfo struct {
 	Characteristics  string
 }
 
-// AppendOKSessionTrackSuffix appends the OK-packet session tracking suffix:
-// [statusMessageLen][statusMessage][sessionTrackBlockLen][sessionTrackBlock].
+// AppendOKSessionTrackSuffix appends the OK-packet session tracking suffix when
+// CLIENT_SESSION_TRACK is negotiated: [statusMessageLen][statusMessage], and
+// when SERVER_SESSION_STATE_CHANGED is set in r.Status, also
+// [sessionTrackBlockLen][sessionTrackBlock].
 func AppendOKSessionTrackSuffix(data []byte, r *Result) []byte {
 	if r == nil {
 		return data
@@ -39,6 +41,10 @@ func AppendOKSessionTrackSuffix(data []byte, r *Result) []byte {
 	data = append(data, PutLengthEncodedInt(uint64(len(statusMessage)))...)
 	if len(statusMessage) > 0 {
 		data = append(data, statusMessage...)
+	}
+
+	if r.Status&SERVER_SESSION_STATE_CHANGED == 0 {
+		return data
 	}
 
 	block := encodeSessionTracking(r.SessionTracking)

--- a/mysql/result_test.go
+++ b/mysql/result_test.go
@@ -53,6 +53,7 @@ func TestEncodeSessionTrackingRoundTrip(t *testing.T) {
 
 func TestAppendOKSessionTrackSuffix(t *testing.T) {
 	result := &Result{
+		Status:        SERVER_SESSION_STATE_CHANGED,
 		StatusMessage: "Records: 3  Duplicates: 0  Warnings: 0",
 		SessionTracking: &SessionTrackingInfo{
 			GTID: "f4993c5e-d353-11f0-9b5f-eede6d5626c8:1-241:xmas:1-29",
@@ -64,4 +65,16 @@ func TestAppendOKSessionTrackSuffix(t *testing.T) {
 	require.Equal(t, result.StatusMessage, string(data[1:1+len(result.StatusMessage)]))
 	blockLenPos := 1 + len(result.StatusMessage)
 	require.Equal(t, byte(len(data)-blockLenPos-1), data[blockLenPos])
+}
+
+func TestAppendOKSessionTrackSuffixWithoutStateChange(t *testing.T) {
+	result := &Result{
+		StatusMessage: "hello",
+		SessionTracking: &SessionTrackingInfo{
+			Schema: "mysql",
+		},
+	}
+
+	data := AppendOKSessionTrackSuffix(nil, result)
+	require.Equal(t, []byte{0x05, 'h', 'e', 'l', 'l', 'o'}, data)
 }

--- a/server/resp.go
+++ b/server/resp.go
@@ -29,12 +29,7 @@ func (c *Conn) writeOK(r *mysql.Result) error {
 	}
 
 	if c.capability&mysql.CLIENT_SESSION_TRACK > 0 {
-		// Always emit the info string; only emit session-state block when flagged.
-		suffix := r
-		if r.Status&mysql.SERVER_SESSION_STATE_CHANGED == 0 {
-			suffix = &mysql.Result{StatusMessage: r.StatusMessage}
-		}
-		data = mysql.AppendOKSessionTrackSuffix(data, suffix)
+		data = mysql.AppendOKSessionTrackSuffix(data, r)
 	}
 
 	return c.WritePacket(data)

--- a/server/resp_test.go
+++ b/server/resp_test.go
@@ -92,7 +92,26 @@ func TestConnWriteOKStatusMessageWithoutStateChange(t *testing.T) {
 		byte(len(msg)), // info lenenc length
 	}
 	expectedPayload = append(expectedPayload, msg...)
-	expectedPayload = append(expectedPayload, 0x00) // empty session-state block length
+	expected := append([]byte{byte(len(expectedPayload)), 0, 0, 0}, expectedPayload...)
+	require.Equal(t, expected, clientConn.WriteBuffered)
+}
+
+func TestConnWriteOKSessionTrackWithoutStateChangeOrInfo(t *testing.T) {
+	clientConn := &mockconn.MockConn{}
+	conn := &Conn{Conn: packet.NewConn(clientConn)}
+	conn.SetCapability(mysql.CLIENT_PROTOCOL_41 | mysql.CLIENT_SESSION_TRACK)
+
+	result := mysql.NewResultReserveResultset(0)
+	err := conn.writeOK(result)
+	require.NoError(t, err)
+
+	// Auth-style OK: empty info string only; no session-state block.
+	expectedPayload := []byte{
+		mysql.OK_HEADER, 0, 0,
+		0x00, 0x00, // status
+		0x00, 0x00, // warnings
+		0x00, // empty info string
+	}
 	expected := append([]byte{byte(len(expectedPayload)), 0, 0, 0}, expectedPayload...)
 	require.Equal(t, expected, clientConn.WriteBuffered)
 }

--- a/server/server_conf.go
+++ b/server/server_conf.go
@@ -177,8 +177,8 @@ func validateUserConfigurableCapability(capability uint32) error {
 	if capability == 0 {
 		return fmt.Errorf("capability must not be zero")
 	}
-	if capability&^userConfigurableServerCapabilities != 0 {
-		return fmt.Errorf("server capability %#x is not user-configurable; only CLIENT_LOCAL_FILES, CLIENT_MULTI_RESULTS, and CLIENT_PS_MULTI_RESULTS are supported", capability)
+	if invalid := capability &^ userConfigurableServerCapabilities; invalid != 0 {
+		return fmt.Errorf("server capability %#x contains non-user-configurable flags %#x; only CLIENT_LOCAL_FILES, CLIENT_MULTI_RESULTS, and CLIENT_PS_MULTI_RESULTS are supported", capability, invalid)
 	}
 	return nil
 }

--- a/server/server_conf.go
+++ b/server/server_conf.go
@@ -10,6 +10,13 @@ import (
 	"github.com/go-mysql-org/go-mysql/mysql"
 )
 
+// userConfigurableServerCapabilities lists handshake flags that may be toggled
+// via SetCapability / UnsetCapability. Other flags (e.g. CLIENT_SSL) are derived
+// from server construction and must not be changed independently.
+const userConfigurableServerCapabilities = mysql.CLIENT_LOCAL_FILES |
+	mysql.CLIENT_MULTI_RESULTS |
+	mysql.CLIENT_PS_MULTI_RESULTS
+
 // Defines a basic MySQL server with configs.
 //
 // We do not aim at implementing the whole MySQL connection suite to have the best compatibilities for the clients.
@@ -135,21 +142,43 @@ func (s *Server) Capability() uint32 {
 }
 
 // SetCapability enables additional server capabilities advertised in the handshake.
-func (s *Server) SetCapability(capability uint32) {
+// Only CLIENT_LOCAL_FILES, CLIENT_MULTI_RESULTS, and CLIENT_PS_MULTI_RESULTS may
+// be set; other flags are managed by server construction (e.g. CLIENT_SSL requires TLS).
+func (s *Server) SetCapability(capability uint32) error {
+	if err := validateUserConfigurableCapability(capability); err != nil {
+		return err
+	}
 	for {
 		old := atomic.LoadUint32(&s.capability)
 		if atomic.CompareAndSwapUint32(&s.capability, old, old|capability) {
 			break
 		}
 	}
+	return nil
 }
 
 // UnsetCapability disables server capabilities advertised in the handshake.
-func (s *Server) UnsetCapability(capability uint32) {
+// Only CLIENT_LOCAL_FILES, CLIENT_MULTI_RESULTS, and CLIENT_PS_MULTI_RESULTS may
+// be cleared via this API.
+func (s *Server) UnsetCapability(capability uint32) error {
+	if err := validateUserConfigurableCapability(capability); err != nil {
+		return err
+	}
 	for {
 		old := atomic.LoadUint32(&s.capability)
 		if atomic.CompareAndSwapUint32(&s.capability, old, old&^capability) {
 			break
 		}
 	}
+	return nil
+}
+
+func validateUserConfigurableCapability(capability uint32) error {
+	if capability == 0 {
+		return fmt.Errorf("capability must not be zero")
+	}
+	if capability&^userConfigurableServerCapabilities != 0 {
+		return fmt.Errorf("server capability %#x is not user-configurable; only CLIENT_LOCAL_FILES, CLIENT_MULTI_RESULTS, and CLIENT_PS_MULTI_RESULTS are supported", capability)
+	}
+	return nil
 }

--- a/server/server_conf_test.go
+++ b/server/server_conf_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"net"
 	"testing"
 
@@ -196,8 +197,14 @@ func TestSetCapabilityRejectsUnsafeFlags(t *testing.T) {
 
 	err := svr.SetCapability(mysql.CLIENT_SSL)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "not user-configurable")
+	require.Contains(t, err.Error(), "non-user-configurable flags")
+	require.Contains(t, err.Error(), fmt.Sprintf("%#x", mysql.CLIENT_SSL))
 	require.False(t, svr.Capability()&mysql.CLIENT_SSL != 0)
+
+	err = svr.SetCapability(mysql.CLIENT_LOCAL_FILES | mysql.CLIENT_SSL)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("%#x", mysql.CLIENT_SSL))
+	require.False(t, svr.Capability()&mysql.CLIENT_LOCAL_FILES != 0)
 
 	err = svr.UnsetCapability(mysql.CLIENT_PROTOCOL_41)
 	require.Error(t, err)

--- a/server/server_conf_test.go
+++ b/server/server_conf_test.go
@@ -116,7 +116,7 @@ func TestLocalFilesCapabilityNegotiated(t *testing.T) {
 	defer l.Close()
 
 	svr := NewDefaultServer()
-	svr.SetCapability(mysql.CLIENT_LOCAL_FILES)
+	require.NoError(t, svr.SetCapability(mysql.CLIENT_LOCAL_FILES))
 	authHandler := NewInMemoryAuthenticationHandler()
 	require.NoError(t, authHandler.AddUser("root", ""))
 
@@ -189,4 +189,22 @@ func TestLocalFilesCapabilityCanBeDisabled(t *testing.T) {
 	negotiated := c.CapabilityString()
 	require.NotContains(t, negotiated, "CLIENT_LOCAL_FILES",
 		"CLIENT_LOCAL_FILES must not be negotiated when the server does not advertise it, got: %s", negotiated)
+}
+
+func TestSetCapabilityRejectsUnsafeFlags(t *testing.T) {
+	svr := NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_NATIVE_PASSWORD, nil, nil)
+
+	err := svr.SetCapability(mysql.CLIENT_SSL)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not user-configurable")
+	require.False(t, svr.Capability()&mysql.CLIENT_SSL != 0)
+
+	err = svr.UnsetCapability(mysql.CLIENT_PROTOCOL_41)
+	require.Error(t, err)
+	require.True(t, svr.Capability()&mysql.CLIENT_PROTOCOL_41 != 0)
+
+	require.NoError(t, svr.SetCapability(mysql.CLIENT_LOCAL_FILES))
+	require.True(t, svr.Capability()&mysql.CLIENT_LOCAL_FILES != 0)
+	require.NoError(t, svr.UnsetCapability(mysql.CLIENT_LOCAL_FILES))
+	require.False(t, svr.Capability()&mysql.CLIENT_LOCAL_FILES != 0)
 }


### PR DESCRIPTION
## Summary

- **P1 — OK packet session track:** When `CLIENT_SESSION_TRACK` is negotiated but `SERVER_SESSION_STATE_CHANGED` is not set, `writeOK` no longer appends a zero-length session-state block after the info string. The packet now ends after the length-encoded info string, matching the MySQL OK-packet format expected by strict clients (auth OK, normal OK).
- **P2 — SetCapability safety:** `Server.SetCapability` / `UnsetCapability` now return an error unless the flag is one of `CLIENT_LOCAL_FILES`, `CLIENT_MULTI_RESULTS`, or `CLIENT_PS_MULTI_RESULTS`. Flags such as `CLIENT_SSL` remain tied to server construction (`tlsConfig`) and cannot be enabled independently.

## Motivation

Follow-up to #1163: the new capability setter API and session-track OK encoding had two correctness issues reported in review.

## Changes

- `mysql/result.go` — `AppendOKSessionTrackSuffix` only appends the session-state block when `SERVER_SESSION_STATE_CHANGED` is set in `r.Status`.
- `server/resp.go` — simplified `writeOK` to delegate to `AppendOKSessionTrackSuffix`.
- `server/server_conf.go` — whitelist validation for `SetCapability` / `UnsetCapability`; methods now return `error`.

## Test plan

- [x] `TestAppendOKSessionTrackSuffixWithoutStateChange` — info string only, no session block
- [x] `TestConnWriteOKStatusMessageWithoutStateChange` — updated expected packet (no trailing `0x00` session block)
- [x] `TestConnWriteOKSessionTrackWithoutStateChangeOrInfo` — auth-style OK with empty info
- [x] `TestSetCapabilityRejectsUnsafeFlags` — `CLIENT_SSL` and `CLIENT_PROTOCOL_41` rejected; whitelisted flags work


Made with [Cursor](https://cursor.com)