### PR TITLE
Keep the connection open when a streamed resultset errors

### DIFF
--- a/server/resp.go
+++ b/server/resp.go
@@ -216,7 +216,7 @@ func (c *Conn) writeStreamTextRows(sr *mysql.StreamResult) error {
 	}
 
 	if err := sr.Err(); err != nil {
-		return err
+		return c.writeError(err)
 	}
 
 	return c.writeEOF()
@@ -266,7 +266,7 @@ func (c *Conn) writeStreamBinaryRows(sr *mysql.StreamResult) error {
 	}
 
 	if err := sr.Err(); err != nil {
-		return err
+		return c.writeError(err)
 	}
 
 	return c.writeEOF()

--- a/server/resp_test.go
+++ b/server/resp_test.go
@@ -465,10 +465,15 @@ func TestConnWriteStreamResultsetWithError(t *testing.T) {
 		sr.Close()
 	}()
 
-	// write stream resultset should return the error
+	// write stream resultset should write the error packet
+	// but leave the connection usable
 	err := conn.WriteValue(sr.AsResult())
-	require.Error(t, err)
-	require.Equal(t, testErr, err)
+	require.NoError(t, err)
+	require.Contains(t, clientConn.WriteBuffered, mysql.ERR_HEADER)
+	require.Contains(t, string(clientConn.WriteBuffered), testErr.Error())
+
+	require.NoError(t, conn.WriteValue(mysql.NewResultReserveResultset(0)))
+	require.False(t, clientConn.Closed)
 }
 
 func TestConnWriteStreamResultsetWithNullValue(t *testing.T) {


### PR DESCRIPTION
When a `StreamResult` has an error set via `SetError`, `writeStreamTextRows` and `writeStreamBinaryRows` currently return that error to `WriteValue`. But since `HandleCommand` treats any error from `WriteValue` as fatal, that closes the client connection, meaning that a single failed streamed query drops the entire session.

Per the MySQL protocol, when row generation fails after the column definitions have been sent, the resultset is terminated with an `ERR_Packet` in place of the final `EOF_Packet` ([docs](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_query_response_text_resultset.html)). This changes the streaming path to do the same. Because `HandleCommand` doesn't close the connection anymore, the client now sees the query fail while the connection stays open for subsequent queries.
