### PR TITLE
canal: Add row event flags to canal.RowEvent

### DIFF
--- a/canal/dump.go
+++ b/canal/dump.go
@@ -111,7 +111,7 @@ func (h *dumpParseHandler) Data(db string, table string, values []string) error 
 		}
 	}
 
-	events := newRowsEvent(tableInfo, InsertAction, [][]any{vs}, nil)
+	events := newRowsEvent(tableInfo, InsertAction, [][]any{vs}, nil, nil)
 	return h.c.eventHandler.OnRow(events)
 }
 

--- a/canal/rows.go
+++ b/canal/rows.go
@@ -26,15 +26,19 @@ type RowsEvent struct {
 	Rows [][]any
 	// Header can be used to inspect the event
 	Header *replication.EventHeader
+	Flags  uint16
 }
 
-func newRowsEvent(table *schema.Table, action string, rows [][]any, header *replication.EventHeader) *RowsEvent {
+func newRowsEvent(table *schema.Table, action string, rows [][]any, header *replication.EventHeader, ev *replication.RowsEvent) *RowsEvent {
 	e := new(RowsEvent)
 
 	e.Table = table
 	e.Action = action
 	e.Rows = rows
 	e.Header = header
+	if ev != nil {
+		e.Flags = ev.Flags
+	}
 
 	e.handleUnsigned()
 

--- a/canal/rows_test.go
+++ b/canal/rows_test.go
@@ -62,3 +62,15 @@ func TestRowsEvent_handleUnsigned(t *testing.T) {
 		})
 	}
 }
+
+// TestRowsEvent_flags checks if Flags from replication's RowsEvent propagate to canal's RowsEvent.
+func TestRowsEvent_flags(t *testing.T) {
+	replEvent := &replication.RowsEvent{
+		Flags: 0x15,
+	}
+
+	var table schema.Table
+	canalEvent := newRowsEvent(&table, "update", nil, nil, replEvent)
+
+	require.Equal(t, canalEvent.Flags, replEvent.Flags)
+}

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -291,7 +291,7 @@ func (c *Canal) handleRowsEvent(e *replication.BinlogEvent) error {
 	default:
 		return errors.Errorf("%s not supported now", e.Header.EventType)
 	}
-	events := newRowsEvent(t, action, ev.Rows, e.Header)
+	events := newRowsEvent(t, action, ev.Rows, e.Header, ev)
 	return c.eventHandler.OnRow(events)
 }
 


### PR DESCRIPTION
Give consumer access to useful rowevent flags.

