### PR TITLE
replication: Fix RenderJSONAsMySQLText floating point corruption

### DIFF
--- a/replication/json_mysql_text.go
+++ b/replication/json_mysql_text.go
@@ -16,10 +16,9 @@ import (
 // stays unquoted; etc.) and preserves the JSONB key order.
 //
 // Caveats:
-//   - The output is type-faithful, not byte-identical to MySQL's
-//     "SELECT json_col" form. Inter-token whitespace is compact (no
-//     space after ',' or ':') and floating-point text differs in some
-//     exponent/precision corner cases (see jsonMySQLDouble).
+//   - Inter-token whitespace is compact (no space after ',' or ':'),
+//     unlike MySQL's "SELECT json_col" form. DOUBLE scalars are
+//     byte-identical to MySQL's own text (see jsonMySQLDouble).
 //   - NEWDECIMAL is the one tag that cannot be preserved on text
 //     round-trip: MySQL's JSON text grammar has no decimal literal, so
 //     re-inserting the unquoted number yields a JSON DOUBLE, not the
@@ -51,20 +50,17 @@ func (n jsonRawNumber) MarshalJSON() ([]byte, error) {
 	return []byte(n), nil
 }
 
-// jsonMySQLDouble formats a float64 close to the way MySQL does in JSON
-// text: whole-number doubles keep a trailing ".0" so MySQL re-stores
-// them as JSON DOUBLE rather than JSON INTEGER, and non-integer values
-// use the shortest round-trippable form. We can't reuse
-// FloatWithTrailingZero here because it formats non-integers with 'f'
-// (always plain decimal); MySQL uses scientific notation for some
-// magnitudes, which 'g' matches more closely.
+// jsonMySQLDouble formats a float64 the way MySQL renders a JSON DOUBLE
+// in JSON text. Byte-identity matters because consumers re-insert this
+// text, and a spelling MySQL would not have produced can re-read as a
+// different value: expanding 6.02214076e23 to 24 fixed-point digits
+// re-reads as 6.0221407600000005e23.
 //
-// The output is NOT guaranteed to be byte-identical to MySQL's
-// my_gcvt-formatted text: Go's 'g' verb emits exponents as e.g.
-// "1.5e-05" where MySQL emits "1.5e-5", and the integer/scientific
-// crossover threshold differs. Binary round-trip through a MySQL JSON
-// column is unaffected (the same float64 produces the same JSONB
-// DOUBLE bytes); only the visible text form may differ.
+// This does not make the round-trip lossless. MySQL's JSON text parser
+// misrounds some 16-17 significant-digit doubles by 1 ulp whatever the
+// spelling (MySQL bugs #116160 and #112904), including values MySQL
+// itself renders that way. Matching the server is the contract here;
+// out-guessing its parser is not.
 type jsonMySQLDouble float64
 
 func (f jsonMySQLDouble) MarshalJSON() ([]byte, error) {
@@ -99,16 +95,70 @@ func (o jsonObject) MarshalJSON() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// formatMySQLDouble returns the bytes MySQL emits for a JSON DOUBLE.
+// The rule below was derived empirically and checked byte-for-byte
+// against MySQL 8.0, 8.4 and 9.x over a corpus spanning the format
+// boundaries.
+//
+// The significant digits are the shortest round-trip string, which Go's
+// strconv precision -1 already matches. Three things differ from Go's
+// defaults:
+//
+//   - Fixed-vs-scientific selection. With decpt the decimal point
+//     position (f = 0.digits * 10^decpt) and nd the digit count, MySQL
+//     uses fixed-point iff decpt >= -14 && (decpt <= 15 || nd > decpt).
+//     Since nd <= 17 for any float64, that is decpt in [-14, 15] plus
+//     the boundary case decpt == 16 && nd == 17, e.g.
+//     "1234567890123456.7".
+//   - Exponents carry no '+' and no zero padding: MySQL writes "1.5e-5"
+//     where Go writes "1.5e-05".
+//   - Integral fixed-point values get a ".0" so they re-parse as JSON
+//     DOUBLE rather than JSON INTEGER: 1e14 renders as
+//     "100000000000000.0", while 1e16 stays "1e16".
 func formatMySQLDouble(f float64) string {
 	if math.IsNaN(f) || math.IsInf(f, 0) {
 		// MySQL refuses to store NaN/Inf in JSON; emit a safe fallback
 		// rather than corrupt the surrounding document.
 		return "null"
 	}
-	if f == math.Trunc(f) {
-		return strconv.FormatFloat(f, 'f', 1, 64)
+	// The 'e' form carries both inputs to the selection: the shortest
+	// digit string and the decimal exponent.
+	sci := strconv.AppendFloat(make([]byte, 0, 32), f, 'e', -1, 64)
+	ePos := bytes.IndexByte(sci, 'e')
+	exp, err := strconv.Atoi(string(sci[ePos+1:]))
+	if err != nil {
+		// Unreachable: 'e'-formatted output always ends in "e±NN".
+		return strconv.FormatFloat(f, 'g', -1, 64)
 	}
-	return strconv.FormatFloat(f, 'g', -1, 64)
+	mant := sci[:ePos] // "d" or "d.ddd", optionally '-'-prefixed
+	neg := mant[0] == '-'
+	if neg {
+		mant = mant[1:]
+	}
+	nd := len(mant)
+	if nd > 1 {
+		nd-- // drop the '.' at mant[1]
+	}
+	decpt := exp + 1 // f = 0.digits * 10^decpt
+
+	if decpt >= -14 && (decpt <= 15 || nd > decpt) {
+		// Longest fixed-point form is 34 bytes: sign, "0.", 14 zeros, 17 digits.
+		out := strconv.AppendFloat(make([]byte, 0, 40), f, 'f', -1, 64)
+		if bytes.IndexByte(out, '.') < 0 {
+			out = append(out, '.', '0')
+		}
+		return string(out)
+	}
+
+	// Scientific notation: reuse Go's mantissa, respell the exponent.
+	out := make([]byte, 0, len(sci))
+	if neg {
+		out = append(out, '-')
+	}
+	out = append(out, mant...)
+	out = append(out, 'e')
+	out = strconv.AppendInt(out, int64(exp), 10)
+	return string(out)
 }
 
 // writeJSONString writes s as the contents of a JSON string (no

--- a/replication/json_mysql_text_test.go
+++ b/replication/json_mysql_text_test.go
@@ -38,14 +38,14 @@ func TestFormatMySQLDouble(t *testing.T) {
 		{0.0, "0.0"},
 		{-3.0, "-3.0"},
 		{1e10, "10000000000.0"},
-		// Non-integer values: shortest round-trippable form. Note that
-		// Go's 'g' emits "1.5e-05" where MySQL's my_gcvt emits "1.5e-5";
-		// the float64 value (and therefore the re-stored JSONB) is
-		// identical, only the visible text differs.
+		// Non-integer values use MySQL's spelling, not Go's: 1.5e-5 is
+		// fixed-point ("0.000015"), where Go emits "1.5e-05".
 		{3.14, "3.14"},
 		{-2.5, "-2.5"},
 		{0.1, "0.1"},
-		{1.5e-5, "1.5e-05"},
+		{1.5e-5, "0.000015"},
+		// Signed zero survives.
+		{math.Copysign(0, -1), "-0.0"},
 	}
 	for _, c := range cases {
 		require.Equal(t, c.want, formatMySQLDouble(c.in), "in=%v", c.in)
@@ -54,6 +54,128 @@ func TestFormatMySQLDouble(t *testing.T) {
 	require.Equal(t, "null", formatMySQLDouble(math.NaN()))
 	require.Equal(t, "null", formatMySQLDouble(math.Inf(1)))
 	require.Equal(t, "null", formatMySQLDouble(math.Inf(-1)))
+}
+
+// mysqlDoubleParityVectors holds output captured from MySQL 8.0.45 via
+//
+//	SELECT CAST(JSON_ARRAY(CAST('<strconv e-form>' AS DOUBLE)) AS CHAR)
+//
+// CAST of a string to DOUBLE is correctly rounded, so this renders
+// exactly the given float64 while bypassing MySQL's lossy JSON text
+// parser. The vectors bracket both sides of every format boundary, so
+// the contract stays enforced without a live server.
+var mysqlDoubleParityVectors = []struct {
+	in   float64
+	want string
+}{
+	// Anchors.
+	{1, "1.0"},
+	{0.1, "0.1"},
+	{169.09, "169.09"},
+	{1.08822770526e+11, "108822770526.0"},
+	{9.007199254740992e+15, "9.007199254740992e15"}, // 2^53: decpt 16, nd 16 -> sci
+	{1e+16, "1e16"},
+	{1e-05, "0.00001"},
+	{1.5e-05, "0.000015"},
+	{5e-324, "5e-324"}, // smallest subnormal
+	{0.6000000000000001, "0.6000000000000001"},
+	{3.14, "3.14"},
+	{-2.5, "-2.5"},
+	// Upper fixed/sci boundary ladder.
+	{9.99999999999998e+14, "999999999999998.0"},
+	{9.99999999999999e+14, "999999999999999.0"},
+	{9.999999999999999e+14, "999999999999999.9"}, // decpt 15, nd 16 -> fixed
+	{1e+15, "1e15"}, // decpt 16, nd 1 -> sci
+	{1.000000000002048e+15, "1.000000000002048e15"},
+	{1.125899906842624e+15, "1.125899906842624e15"}, // 2^50
+	{4.503599627370496e+15, "4.503599627370496e15"}, // 2^52
+	{9.99e+15, "9.99e15"},
+	{1.5e+16, "1.5e16"},
+	{1.2345678901234568e+15, "1234567890123456.8"}, // decpt 16, nd 17 -> the lone fixed cell
+	{1.0000000000000001e+15, "1000000000000000.1"}, // decpt 16, nd 17 -> fixed
+	{9.999999999999998e+15, "9.999999999999998e15"},
+	{1.2345678901234568e+16, "1.2345678901234568e16"}, // decpt 17, nd 17 -> sci
+	{1.2345678901234567e+14, "123456789012345.67"},
+	{9.876543210987654e+16, "9.876543210987654e16"},
+	{1e+17, "1e17"},
+	{1e+18, "1e18"},
+	{1e+21, "1e21"},
+	{1e+25, "1e25"}, // start of the rapidjson re-parse corruption class
+	{1.2676506002282294e+30, "1.2676506002282294e30"}, // 2^100
+	{3.402823669209385e+38, "3.402823669209385e38"},   // 2^128
+	{1e+308, "1e308"},
+	{1.7976931348623157e+308, "1.7976931348623157e308"}, // DBL_MAX
+	{1.7976931348623155e+308, "1.7976931348623155e308"},
+	// Lower fixed/sci boundary ladder.
+	{0.001, "0.001"},
+	{0.000123, "0.000123"},
+	{0.0001, "0.0001"},
+	{1e-06, "0.000001"},
+	{1.5e-06, "0.0000015"},
+	{1e-07, "0.0000001"},
+	{1e-09, "0.000000001"},
+	{1e-13, "0.0000000000001"},
+	{1e-14, "0.00000000000001"},
+	{1e-15, "0.000000000000001"}, // decpt -14 -> still fixed
+	{1.5e-15, "0.0000000000000015"},
+	{1.2345678901234567e-14, "0.000000000000012345678901234567"},
+	{1e-16, "1e-16"}, // decpt -15 -> sci
+	{1.5e-16, "1.5e-16"},
+	{9.876543210987654e-15, "0.000000000000009876543210987654"},
+	{2.2250738585072014e-308, "2.2250738585072014e-308"}, // smallest normal
+	{1e-300, "1e-300"},
+	// Mid-range probes.
+	{1.2345675e+06, "1234567.5"},
+	{1.0000005e+06, "1000000.5"},
+	{123456.789, "123456.789"},
+	{42, "42.0"},
+	{-42, "-42.0"},
+	{1e+10, "10000000000.0"},
+	{-1e+10, "-10000000000.0"},
+	{0.5, "0.5"},
+	{-0.5, "-0.5"},
+	{2.5, "2.5"},
+	{100, "100.0"},
+	{1e+14, "100000000000000.0"},
+	{9.9e+14, "990000000000000.0"},
+	{0.6, "0.6"},
+	{0.30000000000000004, "0.30000000000000004"},
+	{0.7071067811865476, "0.7071067811865476"},
+	{6.283185307179586, "6.283185307179586"},
+	{2.718281828459045, "2.718281828459045"},
+	{2.99792458e+08, "299792458.0"},
+	{9.80665, "9.80665"},
+	{6.62607015e-34, "6.62607015e-34"},
+	{6.02214076e+23, "6.02214076e23"},
+	// Negative mirrors across the boundaries (selection ignores sign).
+	{-9.007199254740992e+15, "-9.007199254740992e15"},
+	{-1.2345678901234568e+15, "-1234567890123456.8"},
+	{-1.2345678901234568e+16, "-1.2345678901234568e16"},
+	{-1e+15, "-1e15"},
+	{-1e+16, "-1e16"},
+	{-9.99999999999999e+14, "-999999999999999.0"},
+	{-1e-05, "-0.00001"},
+	{-1.5e-05, "-0.000015"},
+	{-1e-15, "-0.000000000000001"},
+	{-1e-16, "-1e-16"},
+	{-5e-324, "-5e-324"},
+	{-1e+308, "-1e308"},
+	{-1.7976931348623157e+308, "-1.7976931348623157e308"},
+	{-0.6000000000000001, "-0.6000000000000001"},
+	{-1e+25, "-1e25"},
+}
+
+// TestFormatMySQLDoublePinnedVectors checks byte identity with MySQL
+// without needing a live server.
+func TestFormatMySQLDoublePinnedVectors(t *testing.T) {
+	for _, c := range mysqlDoubleParityVectors {
+		require.Equal(t, c.want, formatMySQLDouble(c.in),
+			"in=%v bits=%016x", c.in, math.Float64bits(c.in))
+		// The rendering must still parse back to the identical bits.
+		back, err := strconv.ParseFloat(c.want, 64)
+		require.NoError(t, err)
+		require.Equal(t, math.Float64bits(c.in), math.Float64bits(back), "in=%v", c.in)
+	}
 }
 
 func TestWriteJSONString(t *testing.T) {


### PR DESCRIPTION
In https://github.com/go-mysql-org/go-mysql/pull/1147 an option was introduced (by me) to render JSON as text to avoid round-tripping through golang and corrupting JSON values.

That PR has a corruption bug itself: floating point values get rendered in a spelling MySQL would never produce, and MySQL re-reads some of those as a different value.

```sql
-- The same JSON document, stored two ways. These SHOULD be identical:
SELECT
  CRC32(CAST(CAST('{"v": 602214075999999987023872.0}' AS JSON) AS CHAR)) AS via_go_mysql_text, -- 4146900613
  CRC32(CAST(JSON_OBJECT('v', 6.02214076e23)          AS CHAR)) AS via_sql_double;             -- 1416476187

-- Why: go-mysql renders the double as a 24-digit expansion, which MySQL re-reads as a different value:
SELECT CAST(CAST('{"v": 602214075999999987023872.0}' AS JSON) AS CHAR);
--> {"v": 6.0221407600000005e23}    -- MySQL itself stores {"v": 6.02214076e23}
```

The fix is to render doubles exactly the way MySQL does. That's a somewhat complicated fix because it requires bug compatibility with MySQL itself.

The significant digits are the shortest round-trip form, which golang's `strconv` already produces identically. What differs is the fixed-vs-scientific choice and the exponent spelling (`1.5e-5` vs golang's `1.5e-05`). The rule is derived in the comment on `formatMySQLDouble`, and I've checked it byte-for-byte against 8.0, 8.4 and 9.x, so it isn't specific to one version.

Scope: this makes our rendering match the server, which is what stops us from introducing differences of our own. It does not make text-mediated round-trips lossless, because MySQL's JSON text parser misrounds some 16-17 significant-digit doubles by 1 ulp regardless of how they're spelled (bugs [#116160](https://bugs.mysql.com/bug.php?id=116160), [#112904](https://bugs.mysql.com/bug.php?id=112904)):

```sql
SELECT CAST(CAST('{"v": 1.0000013331624825e-276}' AS JSON) AS CHAR);
--> {"v": 1.0000013331624823e-276}   -- last digit changed, and this is MySQL's own rendering
```

I went with matching the server anyway — the alternative is emitting exact decimal expansions, which is worse across the board and which MySQL rejects outright at the top of the range ("Number too big to be stored in double" for `DBL_MAX`).

There is a second corruption bug in #1147 affecting temporal values, which I'll send separately as it touches code outside of the text rendering path.

How we detected this:

We use the go-mysql library to perform schema changes with Spirit. When making changes containing JSON documents we would sometimes see checksum mismatch errors. The checksum process can also isolate the specific rows that mismatch, leading to these discoveries.

After applying the fixes, we've been running without checksum mismatches again.
