### PR TITLE
replication: render zero JSON temporal opaques with 6-digit fractions

### DIFF
--- a/replication/json_binary.go
+++ b/replication/json_binary.go
@@ -535,10 +535,6 @@ func (d *jsonBinaryDecoder) decodeDecimal(data []byte) any {
 func (d *jsonBinaryDecoder) decodeTime(data []byte) any {
 	v := d.decodeInt64(data)
 
-	if v == 0 {
-		return "00:00:00"
-	}
-
 	sign := ""
 	if v < 0 {
 		sign = "-"
@@ -556,12 +552,6 @@ func (d *jsonBinaryDecoder) decodeTime(data []byte) any {
 
 func (d *jsonBinaryDecoder) decodeDateTime(data []byte, isDate bool) any {
 	v := d.decodeInt64(data)
-	if v == 0 {
-		if isDate {
-			return "0000-00-00"
-		}
-		return "0000-00-00 00:00:00"
-	}
 
 	// handle negative?
 	if v < 0 {

--- a/replication/json_mysql_text_test.go
+++ b/replication/json_mysql_text_test.go
@@ -2,13 +2,19 @@ package replication
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
+	"fmt"
 	"math"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/go-mysql-org/go-mysql/client"
 	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/test_util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -436,6 +442,31 @@ func TestRenderJSONAsMySQLTextOpaqueTime(t *testing.T) {
 	require.Equal(t, `"10:30:45.123456"`, string(out))
 }
 
+// TestRenderJSONAsMySQLTextOpaqueZeroTemporals covers the zero values.
+// MySQL renders zero TIME/DATETIME/TIMESTAMP with the same 6-digit
+// fractional field as every other value; zero DATE stays fraction-free.
+func TestRenderJSONAsMySQLTextOpaqueZeroTemporals(t *testing.T) {
+	zero := make([]byte, 8)
+	cases := []struct {
+		name      string
+		want      string
+		innerType byte
+	}{
+		{"TIME", `"00:00:00.000000"`, mysql.MYSQL_TYPE_TIME},
+		{"DATETIME", `"0000-00-00 00:00:00.000000"`, mysql.MYSQL_TYPE_DATETIME},
+		{"TIMESTAMP", `"0000-00-00 00:00:00.000000"`, mysql.MYSQL_TYPE_TIMESTAMP},
+		{"DATE", `"0000-00-00"`, mysql.MYSQL_TYPE_DATE},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			data := append([]byte{JSONB_OPAQUE, c.innerType, 0x08}, zero...)
+			out, err := renderJSONAsMySQLText(data, false)
+			require.NoError(t, err)
+			require.Equal(t, c.want, string(out))
+		})
+	}
+}
+
 // TestRenderJSONAsMySQLTextIgnoreDecodeError verifies that with
 // ignoreDecodeErr=true the renderer returns a *valid* JSON document
 // ("null") rather than the half-written buffer it accumulated before
@@ -574,4 +605,196 @@ func TestRenderJSONAsMySQLTextOpaqueDispatch(t *testing.T) {
 			require.Equal(t, want, string(out))
 		})
 	}
+}
+
+// temporalParityRows are inserted into a JSON column and then read back
+// two ways: through the binlog with RenderJSONAsMySQLText, and through
+// the server's own JSON-to-text conversion. The two must agree.
+//
+// Zero values are the interesting ones. MySQL gives them the same 6-digit
+// fractional field as every other value, so a decoder that special-cases
+// zero renders text the server would never emit, and a consumer writing
+// that text back stores a different value than the server had.
+var temporalParityRows = []string{
+	`CAST(CAST('00:00:00' AS TIME) AS JSON)`,
+	`CAST(CAST('01:02:03' AS TIME) AS JSON)`,
+	`CAST(CAST('0000-00-00 00:00:00' AS DATETIME) AS JSON)`,
+	`CAST(CAST('2015-01-15 23:24:25' AS DATETIME) AS JSON)`,
+	`CAST(CAST('0000-00-00' AS DATE) AS JSON)`,
+	`CAST(CAST('2015-01-15' AS DATE) AS JSON)`,
+	`JSON_OBJECT('t', CAST('00:00:00' AS TIME), 'd', CAST('0000-00-00' AS DATE))`,
+	`JSON_ARRAY(CAST('00:00:00' AS TIME), CAST('0000-00-00 00:00:00' AS DATETIME))`,
+}
+
+// TestJSONTemporalServerParity checks that the MySQL-text rendering of a
+// JSON column read from the binlog matches what the server itself returns
+// for the same row. Skips unless a row-based binlog is reachable.
+func TestJSONTemporalServerParity(t *testing.T) {
+	host, port := *test_util.MysqlHost, *test_util.MysqlPort
+	password := os.Getenv("MYSQL_PASSWORD")
+
+	c, err := client.Connect(fmt.Sprintf("%s:%s", host, port), "root", password, "")
+	if err != nil {
+		t.Skip(err.Error())
+	}
+	defer c.Close()
+
+	res, err := c.Execute("SELECT VERSION(), @@log_bin, @@binlog_format")
+	require.NoError(t, err)
+	version, err := res.GetString(0, 0)
+	require.NoError(t, err)
+	logBin, err := res.GetInt(0, 1)
+	require.NoError(t, err)
+	format, err := res.GetString(0, 2)
+	require.NoError(t, err)
+	if logBin != 1 || format != "ROW" {
+		t.Skipf("need a row-based binlog, got log_bin=%d binlog_format=%s", logBin, format)
+	}
+
+	for _, q := range []string{
+		"CREATE DATABASE IF NOT EXISTS test",
+		"USE test",
+		// Zero dates are only insertable with the strict modes off.
+		"SET SESSION sql_mode=''",
+		"DROP TABLE IF EXISTS test_json_temporal",
+		"CREATE TABLE test_json_temporal (id INT PRIMARY KEY, c JSON) ENGINE=InnoDB",
+	} {
+		_, err = c.Execute(q)
+		require.NoError(t, err, q)
+	}
+
+	// Record the position before the inserts so the syncer sees them all.
+	pos, err := binlogPosition(c)
+	require.NoError(t, err)
+
+	for i, expr := range temporalParityRows {
+		_, err = c.Execute(fmt.Sprintf(
+			"INSERT INTO test_json_temporal VALUES (%d, %s)", i, expr))
+		require.NoError(t, err, expr)
+	}
+
+	// What the server itself renders for each row.
+	want := make([]string, len(temporalParityRows))
+	res, err = c.Execute("SELECT id, CAST(c AS CHAR) FROM test_json_temporal ORDER BY id")
+	require.NoError(t, err)
+	require.Equal(t, len(temporalParityRows), res.RowNumber())
+	for i := range res.Values {
+		id, err := res.GetInt(i, 0)
+		require.NoError(t, err)
+		s, err := res.GetString(i, 1)
+		require.NoError(t, err)
+		want[id] = s
+	}
+
+	// What we render from the binlog's JSONB.
+	got := readJSONColumnFromBinlog(t, host, port, password, pos, len(temporalParityRows))
+
+	t.Logf("comparing %d JSON temporal rows against %s", len(temporalParityRows), version)
+	for i, expr := range temporalParityRows {
+		// MySQL puts a space after ',' and ':' in its own text form and the
+		// renderer is deliberately compact, so compare with those removed
+		// rather than reproducing MySQL's whitespace.
+		require.Equal(t, stripJSONSpacing(want[i]), stripJSONSpacing(got[i]),
+			"row %d: %s", i, expr)
+	}
+}
+
+// binlogPosition returns the server's current binlog file and offset.
+func binlogPosition(c *client.Conn) (mysql.Position, error) {
+	query := "SHOW BINARY LOG STATUS"
+	if eq, err := c.CompareServerVersion("8.4.0"); err == nil && eq < 0 {
+		query = "SHOW MASTER STATUS"
+	}
+	res, err := c.Execute(query)
+	if err != nil {
+		return mysql.Position{}, err
+	}
+	file, err := res.GetStringByName(0, "File")
+	if err != nil {
+		return mysql.Position{}, err
+	}
+	offset, err := res.GetIntByName(0, "Position")
+	if err != nil {
+		return mysql.Position{}, err
+	}
+	return mysql.Position{Name: file, Pos: uint32(offset)}, nil
+}
+
+// readJSONColumnFromBinlog streams from pos and returns the rendered JSON
+// column of the next wantRows inserts into test_json_temporal, indexed by
+// the row's id.
+func readJSONColumnFromBinlog(
+	t *testing.T, host, port, password string, pos mysql.Position, wantRows int,
+) []string {
+	t.Helper()
+
+	portNum, err := strconv.ParseUint(port, 10, 16)
+	require.NoError(t, err)
+
+	syncer := NewBinlogSyncer(BinlogSyncerConfig{
+		ServerID:              1001,
+		Flavor:                mysql.MySQLFlavor,
+		Host:                  host,
+		Port:                  uint16(portNum),
+		User:                  "root",
+		Password:              password,
+		RenderJSONAsMySQLText: true,
+	})
+	defer syncer.Close()
+
+	streamer, err := syncer.StartSync(pos)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	out := make([]string, wantRows)
+	for seen := 0; seen < wantRows; {
+		ev, err := streamer.GetEvent(ctx)
+		require.NoError(t, err, "only saw %d/%d rows", seen, wantRows)
+
+		switch ev.Header.EventType {
+		case WRITE_ROWS_EVENTv0, WRITE_ROWS_EVENTv1, WRITE_ROWS_EVENTv2:
+		default:
+			continue
+		}
+		re, ok := ev.Event.(*RowsEvent)
+		if !ok || string(re.Table.Table) != "test_json_temporal" {
+			continue
+		}
+		for _, row := range re.Rows {
+			require.Len(t, row, 2)
+			id, ok := row[0].(int32)
+			require.True(t, ok, "id column is %T", row[0])
+			require.Less(t, int(id), wantRows)
+			s, ok := row[1].(string)
+			require.True(t, ok, "JSON column is %T", row[1])
+			out[id] = s
+			seen++
+		}
+	}
+	return out
+}
+
+// stripJSONSpacing removes the inter-token spaces MySQL puts after ',' and
+// ':' so the compact renderer can be compared against it. It is not a JSON
+// parser: it only skips spaces outside string literals.
+func stripJSONSpacing(s string) string {
+	out := make([]byte, 0, len(s))
+	inStr := false
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		switch {
+		case inStr && ch == '\\' && i+1 < len(s):
+			out = append(out, ch, s[i+1])
+			i++
+			continue
+		case ch == '"':
+			inStr = !inStr
+		case !inStr && ch == ' ':
+			continue
+		}
+		out = append(out, ch)
+	}
+	return string(out)
 }


### PR DESCRIPTION
This is the second of the two corruption bugs in https://github.com/go-mysql-org/go-mysql/pull/1147 (an option I added to render JSON as text to avoid round-tripping through golang and corrupting JSON values). The floating point one is https://github.com/go-mysql-org/go-mysql/pull/1173; this one is temporal values, and it's a straight forward fix by removing code that was incorrect.

```sql
-- The same JSON document, stored two ways. These SHOULD be identical:
SELECT
  CRC32(CAST(CAST('{"t": "00:00:00"}' AS JSON) AS CHAR))      AS via_go_mysql_text, -- 2609006976
  CRC32(CAST(JSON_OBJECT('t', CAST('00:00:00' AS TIME)) AS CHAR)) AS via_sql_time;  -- 2560132030

-- Why: MySQL gives a zero TIME the same 6-digit fraction as any other value:
SELECT CAST(JSON_OBJECT('t', CAST('00:00:00' AS TIME)) AS CHAR);
--> {"t": "00:00:00.000000"}     -- go-mysql rendered {"t": "00:00:00"}
```

`decodeTime` and `decodeDateTime` had a `v == 0` shortcut that returned a fraction-free string. Every non-zero value already fell through to the general path and picked up a 6-digit fraction, so zero was the only value rendered inconsistently, and the shortcut disagreed with the server:

| | MySQL | go-mysql before |
|---|---|---|
| `00:00:00` | `"00:00:00.000000"` | `"00:00:00"` |
| `01:02:03` | `"01:02:03.000000"` | `"01:02:03.000000"` |
| `0000-00-00 00:00:00` | `"0000-00-00 00:00:00.000000"` | `"0000-00-00 00:00:00"` |
| `0000-00-00` | `"0000-00-00"` | `"0000-00-00"` |

Deleting the shortcuts is the whole fix - the general formatting paths already produce the server's exact output for `v == 0`.

One thing to flag: the shortcut wasn't behind the `RenderJSONAsMySQLText` flag, so this also changes the legacy render of zero temporals for anyone not using the option (`"00:00:00"` becomes `"00:00:00.000000"`). I think that's the right call, since it's the same string the legacy path already produced for every non-zero value and it's what the server itself returns, but I'm happy to gate it on the flag if you'd rather not touch existing behaviour.

For testing I added `TestJSONTemporalServerParity`, which inserts zero and non-zero temporals into a JSON column, reads the rows back through the binlog, and compares our rendering against the server's own `CAST(c AS CHAR)` for the same row. It fails without this fix -- and can be reproduced on 8.0, 8.4, 9.x.

How we detected this:

We use the go-mysql library to perform schema changes with Spirit. When making changes containing JSON documents we would sometimes see checksum mismatch errors. The checksum process can also isolate the specific rows that mismatch, leading to these discoveries.

After applying the fixes, we've been running without checksum mismatches again.
