### PR TITLE
replication: log rotate to next binlog only when the position changes

### DIFF
--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -937,9 +937,14 @@ func (b *BinlogSyncer) handleEventAndACK(s *BinlogStreamer, e *BinlogEvent, need
 	// Handle event types to update positions and GTID sets
 	switch event := e.Event.(type) {
 	case *RotateEvent:
-		b.nextPos.Name = string(event.NextLogName)
-		b.nextPos.Pos = uint32(event.Position)
-		b.cfg.Logger.Info("rotate to next binlog", slog.String("file", b.nextPos.Name), slog.Uint64("position", uint64(b.nextPos.Pos)))
+		newPos := mysql.Position{Name: string(event.NextLogName), Pos: uint32(event.Position)}
+		// At each rotation the server sends the rotate event from the binlog
+		// followed by an artificial one carrying the same position, so log
+		// only on change to avoid duplicate lines.
+		if b.nextPos != newPos {
+			b.cfg.Logger.Info("rotate to next binlog", slog.String("file", newPos.Name), slog.Uint64("position", uint64(newPos.Pos)))
+		}
+		b.nextPos = newPos
 
 	case *GTIDEvent:
 		if b.prevGset == nil {

--- a/replication/binlogsyncer_test.go
+++ b/replication/binlogsyncer_test.go
@@ -1,8 +1,10 @@
 package replication
 
 import (
+	"bytes"
 	"errors"
 	"io"
+	"log/slog"
 	"net"
 	"os"
 	"strings"
@@ -146,4 +148,33 @@ func TestHandleEventAndACKPayloadInnerGSet(t *testing.T) {
 	require.NoError(t, b.handleEventAndACK(NewBinlogStreamer(), ev, false))
 	require.Equal(t, gset.String(), innerQuery.Event.(*QueryEvent).GSet.String())
 	require.Equal(t, gset.String(), innerXID.Event.(*XIDEvent).GSet.String())
+}
+
+// TestHandleEventAndACKRotateLogDedup verifies the artificial rotate event the
+// server sends right after the real one at each rotation does not produce a
+// second "rotate to next binlog" log line.
+func TestHandleEventAndACKRotateLogDedup(t *testing.T) {
+	var buf bytes.Buffer
+	b := NewBinlogSyncer(BinlogSyncerConfig{
+		ServerID: 1,
+		Logger:   slog.New(slog.NewTextHandler(&buf, nil)),
+	})
+	defer b.Close()
+
+	rotate := func(logPos uint32, flags uint16, name string) *BinlogEvent {
+		return &BinlogEvent{
+			Header: &EventHeader{EventType: ROTATE_EVENT, LogPos: logPos, Flags: flags},
+			Event:  &RotateEvent{NextLogName: []byte(name), Position: 4},
+		}
+	}
+
+	s := NewBinlogStreamer()
+	// Artificial rotate sent at dump start.
+	require.NoError(t, b.handleEventAndACK(s, rotate(0, LOG_EVENT_ARTIFICIAL_F, "mysql-bin.000001"), false))
+	// Real rotate at the end of the old file, then the artificial duplicate.
+	require.NoError(t, b.handleEventAndACK(s, rotate(1234, 0, "mysql-bin.000002"), false))
+	require.NoError(t, b.handleEventAndACK(s, rotate(0, LOG_EVENT_ARTIFICIAL_F, "mysql-bin.000002"), false))
+
+	require.Equal(t, mysql.Position{Name: "mysql-bin.000002", Pos: 4}, b.GetNextPosition())
+	require.Equal(t, 2, strings.Count(buf.String(), "rotate to next binlog"))
 }


### PR DESCRIPTION
At each binlog rotation the server sends the rotate event from the binlog followed by an artificial rotate event carrying the same file and position, producing a duplicate "rotate to next binlog" log line on every rotation.

On a high volume server (with 100MiB binary logs, which is not that uncommon) rotation occurs every 1-2 seconds and accounts for most of our log lines:

```
2026-07-30T17:18:10.138 info finished periodic flush of GTID changeset   total-duration="10.097µs"
2026-07-30T17:18:10.138 info migration status: state=copyRows copy-progress=511839113/913633024 56.02% binlog-deltas=0 total-time=33m30s copier-time=33m30s copier-remaining-time=24m40s (19m from 33m ago) copier-is-throttled=false conns-in-use=38 applier-queue=128/128 applier-pending=9 applier-workers=37 applier-rows-per-chunklet=979 applier-queue-wait-p50=510ms applier-queue-wait-p90=541ms applier-build-p50=8ms applier-write-p50=129ms applier-write-p90=162ms applier-handoff-p50=0s
2026-07-30T17:18:10.884 info rotate to next binlog   file="mysql-bin-changelog.086511" position=0x4
2026-07-30T17:18:10.884 info rotate to next binlog   file="mysql-bin-changelog.086511" position=0x4
2026-07-30T17:18:12.130 info rotate to next binlog   file="mysql-bin-changelog.086512" position=0x4
2026-07-30T17:18:12.130 info rotate to next binlog   file="mysql-bin-changelog.086512" position=0x4
2026-07-30T17:18:13.358 info rotate to next binlog   file="mysql-bin-changelog.086513" position=0x4
2026-07-30T17:18:13.359 info rotate to next binlog   file="mysql-bin-changelog.086513" position=0x4
2026-07-30T17:18:14.617 info rotate to next binlog   file="mysql-bin-changelog.086514" position=0x4
2026-07-30T17:18:14.617 info rotate to next binlog   file="mysql-bin-changelog.086514" position=0x4
2026-07-30T17:18:15.851 info rotate to next binlog   file="mysql-bin-changelog.086515" position=0x4
2026-07-30T17:18:15.851 info rotate to next binlog   file="mysql-bin-changelog.086515" position=0x4
2026-07-30T17:18:17.129 info rotate to next binlog   file="mysql-bin-changelog.086516" position=0x4
2026-07-30T17:18:17.129 info rotate to next binlog   file="mysql-bin-changelog.086516" position=0x4
2026-07-30T17:18:18.391 info rotate to next binlog   file="mysql-bin-changelog.086517" position=0x4
2026-07-30T17:18:18.391 info rotate to next binlog   file="mysql-bin-changelog.086517" position=0x4
2026-07-30T17:18:19.670 info rotate to next binlog   file="mysql-bin-changelog.086518" position=0x4
2026-07-30T17:18:19.670 info rotate to next binlog   file="mysql-bin-changelog.086518" position=0x4
2026-07-30T17:18:20.936 info rotate to next binlog   file="mysql-bin-changelog.086519" position=0x4
2026-07-30T17:18:20.936 info rotate to next binlog   file="mysql-bin-changelog.086519" position=0x4
2026-07-30T17:18:22.154 info rotate to next binlog   file="mysql-bin-changelog.086520" position=0x4
2026-07-30T17:18:22.154 info rotate to next binlog   file="mysql-bin-changelog.086520" position=0x4
2026-07-30T17:18:23.615 info rotate to next binlog   file="mysql-bin-changelog.086521" position=0x4
2026-07-30T17:18:23.615 info rotate to next binlog   file="mysql-bin-changelog.086521" position=0x4
2026-07-30T17:18:24.853 info rotate to next binlog   file="mysql-bin-changelog.086522" position=0x4
2026-07-30T17:18:24.853 info rotate to next binlog   file="mysql-bin-changelog.086522" position=0x4
2026-07-30T17:18:26.064 info rotate to next binlog   file="mysql-bin-changelog.086523" position=0x4
2026-07-30T17:18:26.064 info rotate to next binlog   file="mysql-bin-changelog.086523" position=0x4
2026-07-30T17:18:27.285 info rotate to next binlog   file="mysql-bin-changelog.086524" position=0x4
2026-07-30T17:18:27.285 info rotate to next binlog   file="mysql-bin-changelog.086524" position=0x4
2026-07-30T17:18:28.519 info rotate to next binlog   file="mysql-bin-changelog.086525" position=0x4
2026-07-30T17:18:28.519 info rotate to next binlog   file="mysql-bin-changelog.086525" position=0x4
2026-07-30T17:18:30.008 info rotate to next binlog   file="mysql-bin-changelog.086526" position=0x4
2026-07-30T17:18:30.008 info rotate to next binlog   file="mysql-bin-changelog.086526" position=0x4
2026-07-30T17:18:31.258 info rotate to next binlog   file="mysql-bin-changelog.086527" position=0x4
2026-07-30T17:18:31.258 info rotate to next binlog   file="mysql-bin-changelog.086527" position=0x4
2026-07-30T17:18:32.489 info rotate to next binlog   file="mysql-bin-changelog.086528" position=0x4
2026-07-30T17:18:32.489 info rotate to next binlog   file="mysql-bin-changelog.086528" position=0x4
2026-07-30T17:18:33.719 info rotate to next binlog   file="mysql-bin-changelog.086529" position=0x4
2026-07-30T17:18:33.719 info rotate to next binlog   file="mysql-bin-changelog.086529" position=0x4
2026-07-30T17:18:35.053 info rotate to next binlog   file="mysql-bin-changelog.086530" position=0x4
2026-07-30T17:18:35.053 info rotate to next binlog   file="mysql-bin-changelog.086530" position=0x4
2026-07-30T17:18:36.316 info rotate to next binlog   file="mysql-bin-changelog.086531" position=0x4
2026-07-30T17:18:36.316 info rotate to next binlog   file="mysql-bin-changelog.086531" position=0x4
2026-07-30T17:18:37.568 info rotate to next binlog   file="mysql-bin-changelog.086532" position=0x4
2026-07-30T17:18:37.568 info rotate to next binlog   file="mysql-bin-changelog.086532" position=0x4
2026-07-30T17:18:38.848 info rotate to next binlog   file="mysql-bin-changelog.086533" position=0x4
2026-07-30T17:18:38.848 info rotate to next binlog   file="mysql-bin-changelog.086533" position=0x4
2026-07-30T17:18:40.126 info rotate to next binlog   file="mysql-bin-changelog.086534" position=0x4
2026-07-30T17:18:40.127 info rotate to next binlog   file="mysql-bin-changelog.086534" position=0x4
2026-07-30T17:18:40.138 info finished periodic flush of GTID changeset   total-duration="13.489µs"
2026-07-30T17:18:40.138 info migration status: state=copyRows copy-progress=519628479/913633024 56.87% binlog-deltas=0 total-time=34m0s copier-time=34m0s copier-remaining-time=25m10s (18m from 33m ago) copier-is-throttled=false conns-in-use=39 applier-queue=128/128 applier-pending=9 applier-workers=37 applier-rows-per-chunklet=979 applier-queue-wait-p50=488ms applier-queue-wait-p90=518ms applier-build-p50=5ms applier-write-p50=134ms applier-write-p90=153ms applier-handoff-p50=0s
```

I'm happy to keep the rotate line as `INFO` (it's genuinely useful), if we just remove the duplicates.