### PR TITLE
Server read buffering

### DIFF
--- a/packet/conn.go
+++ b/packet/conn.go
@@ -23,6 +23,9 @@ import (
 const (
 	MinCompressionLength = 50
 	DefaultBufferSize    = 16 * 1024
+	// DefaultReadBufferSize is the bufio.Reader size used by NewConn and
+	// EnableReadBuffering.
+	DefaultReadBufferSize = 64 * 1024
 )
 
 // Conn is the base class to handle MySQL protocol.
@@ -53,7 +56,7 @@ type Conn struct {
 }
 
 func NewConn(conn net.Conn) *Conn {
-	return NewBufferedConn(conn, 65536) // 64kb
+	return NewBufferedConn(conn, DefaultReadBufferSize)
 }
 
 func NewBufferedConn(conn net.Conn, bufferSize int) *Conn {
@@ -91,6 +94,19 @@ func NewTLSConnWithTimeout(conn net.Conn, readTimeout, writeTimeout time.Duratio
 	c.readTimeout = readTimeout
 	c.writeTimeout = writeTimeout
 	return c
+}
+
+// EnableReadBuffering wraps subsequent reads in a bufio.Reader of the given
+// size. Conns created via NewTLSConn start unbuffered because the peer may
+// still upgrade the transport to TLS during the handshake; call this once the
+// handshake completes, and only between packets. No-op if reads are already
+// buffered or bufferSize is not positive.
+func (c *Conn) EnableReadBuffering(bufferSize int) {
+	if c.br != nil || bufferSize <= 0 {
+		return
+	}
+	c.br = bufio.NewReaderSize(c, bufferSize)
+	c.reader = c.br
 }
 
 func (c *Conn) ReadPacket() ([]byte, error) {

--- a/packet/conn_test.go
+++ b/packet/conn_test.go
@@ -1,7 +1,9 @@
 package packet
 
 import (
+	"bufio"
 	"bytes"
+	"net"
 	"testing"
 
 	"github.com/go-mysql-org/go-mysql/compress"
@@ -165,3 +167,54 @@ func TestReadPacketSingleUncompressedFrame(t *testing.T) {
 		t.Fatalf("payload mismatch:\n got  %q\n want %q", got, payload)
 	}
 }
+
+// benchmarkReadPacket measures the read path over loopback TCP: unbuffered is
+// what a conn from NewTLSConn pays without EnableReadBuffering (two read(2)
+// calls per packet), buffered is the same conn after EnableReadBuffering.
+func benchmarkReadPacket(b *testing.B, buffered bool) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer ln.Close()
+
+	const payloadSize = 64
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		w := bufio.NewWriterSize(conn, DefaultBufferSize)
+		frame := make([]byte, 4+payloadSize)
+		frame[0] = payloadSize
+		for seq := byte(0); ; seq++ {
+			frame[3] = seq
+			if _, err := w.Write(frame); err != nil {
+				return
+			}
+		}
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer conn.Close()
+
+	c := NewTLSConn(conn)
+	if buffered {
+		c.EnableReadBuffering(DefaultReadBufferSize)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := c.ReadPacket(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkReadPacketUnbuffered(b *testing.B) { benchmarkReadPacket(b, false) }
+
+func BenchmarkReadPacketBuffered(b *testing.B) { benchmarkReadPacket(b, true) }

--- a/server/conn.go
+++ b/server/conn.go
@@ -92,6 +92,10 @@ func (s *Server) NewCustomizedConn(conn net.Conn, authHandler AuthenticationHand
 		return nil, err
 	}
 
+	// The handshake settled the final transport (the client may have upgraded
+	// to TLS), so reads can be buffered from here on.
+	c.EnableReadBuffering(packet.DefaultReadBufferSize)
+
 	return c, nil
 }
 


### PR DESCRIPTION
Servers constructed with a `tlsConfig` create their `packet.Conn` via `NewTLSConn`, which reads straight from the socket: a buffered reader installed before the handshake could slurp bytes belonging to the TLS handshake when a client upgrades the raw conn after SSLRequest.

The unintended consequence is that every connection to a TLS-capable server — including plaintext connections that never upgrade — pays two `read(2)` syscalls per client packet (4-byte header, then payload), while plaintext-only servers enjoy the 64KB `bufio` added in #422.

Fix: keep the connection phase unbuffered, and install the `bufio.Reader` (new `packet.Conn.EnableReadBuffering`) right after the handshake completes, when the transport can no longer change. For connections that did upgrade to TLS this simply layers the buffer above the `tls.Conn`.

### Performance Numbers

```
Microbenchmark (packet layer, 64-byte payloads over loopback TCP, Apple M4 Max, go1.26):
    BenchmarkReadPacketUnbuffered-16     545.1 ns/op    64 B/op    1 allocs/op
    BenchmarkReadPacketBuffered-16        57.81 ns/op   64 B/op    1 allocs/op
    go test -run '^$' -bench '^BenchmarkReadPacket' -benchmem ./packet/
```

So that's almost 10x.. via syscall elimination.