### PR TITLE
Server write batching

### DIFF
--- a/packet/conn.go
+++ b/packet/conn.go
@@ -40,6 +40,9 @@ type Conn struct {
 	br     *bufio.Reader
 	reader io.Reader
 
+	// Buffered writer, enabled via EnableWriteBuffering.
+	bw *bufio.Writer
+
 	copyNBuf []byte
 
 	header [4]byte
@@ -109,6 +112,39 @@ func (c *Conn) EnableReadBuffering(bufferSize int) {
 	c.reader = c.br
 }
 
+// connWriter adapts the deadline-setting write path to io.Writer so a
+// bufio.Writer can sit on top of it.
+type connWriter struct{ c *Conn }
+
+func (w connWriter) Write(b []byte) (int, error) {
+	return w.c.writeDirect(b)
+}
+
+// EnableWriteBuffering makes WritePacket accumulate packets in a buffer of the
+// given size instead of issuing one write(2) each. Buffered data reaches the
+// wire when the buffer fills, on Flush, or before any ReadPacket* call (so
+// request/response flows cannot deadlock). Callers that stream packets without
+// reading must Flush after each logical unit; Close does not flush. No-op if
+// already enabled or bufferSize is not positive.
+func (c *Conn) EnableWriteBuffering(bufferSize int) {
+	if c.bw != nil || bufferSize <= 0 {
+		return
+	}
+	c.bw = bufio.NewWriterSize(connWriter{c}, bufferSize)
+}
+
+// Flush writes any buffered packets to the underlying connection. It is a
+// no-op when write buffering is not enabled.
+func (c *Conn) Flush() error {
+	if c.bw == nil {
+		return nil
+	}
+	if err := c.bw.Flush(); err != nil {
+		return errors.Wrapf(mysql.ErrBadConn, "Flush failed. err %v", err)
+	}
+	return nil
+}
+
 func (c *Conn) ReadPacket() ([]byte, error) {
 	return c.ReadPacketReuseMem(nil)
 }
@@ -161,6 +197,10 @@ func (c *Conn) ReadPacketReuseMem(dst []byte) ([]byte, error) {
 
 // newCompressedPacketReader creates a new compressed packet reader.
 func (c *Conn) newCompressedPacketReader() (io.Reader, error) {
+	// The peer may be waiting on our buffered output before it sends more.
+	if err := c.Flush(); err != nil {
+		return nil, err
+	}
 	if c.readTimeout != 0 {
 		if err := c.SetReadDeadline(utils.Now().Add(c.readTimeout)); err != nil {
 			return nil, err
@@ -259,6 +299,11 @@ func (c *Conn) copyN(dst io.Writer, n int64) (int64, error) {
 }
 
 func (c *Conn) ReadPacketTo(w io.Writer) error {
+	// The peer may be waiting on our buffered output before it sends more.
+	if err := c.Flush(); err != nil {
+		return err
+	}
+
 	b := utils.BytesBufferGet()
 	defer func() {
 		utils.BytesBufferPut(b)
@@ -361,6 +406,13 @@ func (c *Conn) WritePacket(data []byte) error {
 }
 
 func (c *Conn) writeWithTimeout(b []byte) (n int, err error) {
+	if c.bw != nil {
+		return c.bw.Write(b)
+	}
+	return c.writeDirect(b)
+}
+
+func (c *Conn) writeDirect(b []byte) (n int, err error) {
 	if c.writeTimeout != 0 {
 		if err := c.SetWriteDeadline(utils.Now().Add(c.writeTimeout)); err != nil {
 			return n, err

--- a/packet/conn_test.go
+++ b/packet/conn_test.go
@@ -3,6 +3,7 @@ package packet
 import (
 	"bufio"
 	"bytes"
+	"io"
 	"net"
 	"testing"
 
@@ -218,3 +219,54 @@ func benchmarkReadPacket(b *testing.B, buffered bool) {
 func BenchmarkReadPacketUnbuffered(b *testing.B) { benchmarkReadPacket(b, false) }
 
 func BenchmarkReadPacketBuffered(b *testing.B) { benchmarkReadPacket(b, true) }
+
+// benchmarkWriteResultset measures writing a point-SELECT-shaped response (22
+// packets: column count, 17 column definitions, row, EOF/OK framing) followed
+// by one Flush. Unbuffered issues one write(2) per packet, buffered one per
+// response.
+func benchmarkWriteResultset(b *testing.B, buffered bool) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_, _ = io.Copy(io.Discard, conn)
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer conn.Close()
+
+	c := NewTLSConn(conn)
+	if buffered {
+		c.EnableWriteBuffering(DefaultBufferSize)
+	}
+
+	const packetsPerResponse = 22
+	frame := make([]byte, 4+64)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for range packetsPerResponse {
+			if err := c.WritePacket(frame); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if err := c.Flush(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWriteResultsetUnbuffered(b *testing.B) { benchmarkWriteResultset(b, false) }
+
+func BenchmarkWriteResultsetBuffered(b *testing.B) { benchmarkWriteResultset(b, true) }

--- a/server/command.go
+++ b/server/command.go
@@ -59,6 +59,10 @@ func (c *Conn) HandleCommand() error {
 	v := c.dispatch(data)
 
 	err = c.WriteValue(v)
+	if err == nil && c.Conn != nil {
+		// Push the buffered response out before blocking on the next command.
+		err = c.Flush()
+	}
 
 	if c.Conn != nil {
 		c.ResetSequence()

--- a/server/conn.go
+++ b/server/conn.go
@@ -96,6 +96,10 @@ func (s *Server) NewCustomizedConn(conn net.Conn, authHandler AuthenticationHand
 	// to TLS), so reads can be buffered from here on.
 	c.EnableReadBuffering(packet.DefaultReadBufferSize)
 
+	// Batch response packets into one write(2) per response. HandleCommand
+	// flushes at each response boundary; streaming paths flush per event/row.
+	c.EnableWriteBuffering(packet.DefaultBufferSize)
+
 	return c, nil
 }
 

--- a/server/resp.go
+++ b/server/resp.go
@@ -213,6 +213,10 @@ func (c *Conn) writeStreamTextRows(sr *mysql.StreamResult) error {
 		if err := c.WritePacket(data); err != nil {
 			return err
 		}
+		// Deliver each streamed row immediately; RowsChan may block indefinitely.
+		if err := c.Flush(); err != nil {
+			return err
+		}
 	}
 
 	if err := sr.Err(); err != nil {
@@ -261,6 +265,10 @@ func (c *Conn) writeStreamBinaryRows(sr *mysql.StreamResult) error {
 		copy(data[5:], nullBitmap)
 
 		if err := c.WritePacket(data); err != nil {
+			return err
+		}
+		// Deliver each streamed row immediately; RowsChan may block indefinitely.
+		if err := c.Flush(); err != nil {
 			return err
 		}
 	}
@@ -321,6 +329,11 @@ func (c *Conn) writeBinlogEvents(s *replication.BinlogStreamer) error {
 
 		data = append(data, ev.RawData...)
 		if err := c.WritePacket(data); err != nil {
+			return err
+		}
+		// Deliver each event immediately (heartbeat/semi-sync timing); GetEvent
+		// may block indefinitely.
+		if err := c.Flush(); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Similar to https://github.com/go-mysql-org/go-mysql/pull/1176 which enabled read buffering. This adds write batching.

`WritePacket` previously issued one `write(2)` syscall per protocol packet. A resultset is many small packets — column count, one per column definition, one per row, plus EOF/OK — so a modest 17-column point SELECT cost ~22 syscalls, and syscall overhead dominates the CPU profile of proxy-style servers built on this package.

`packet.Conn` gains opt-in write buffering (`EnableWriteBuffering` / `Flush`), mirroring how MySQL itself buffers responses in its 16KB net buffer:

  - `WritePacket` appends to a `bufio.Writer` once buffering is enabled; bytes reach the wire when the buffer fills, on Flush, or automatically before any ReadPacket* call, so request/response flows cannot deadlock on unflushed output.
  - Write errors surface at flush time; Close does not flush.
  - Nothing changes for connections that do not opt in (client and replication code paths are untouched).

The server package opts in after the handshake completes and flushes at each response boundary in `HandleCommand`. Paths that stream packets and control their own delivery timing — the binlog dump loop and streaming resultsets — flush after every event/row, preserving their existing per-packet delivery semantics.

### Performance Numbers

```
Microbenchmark (writing a 22-packet resultset + flush per op, loopback TCP, Apple M4 Max, go1.26):
    BenchmarkWriteResultsetUnbuffered-16    66350 ns/op    0 B/op    0 allocs/op
    BenchmarkWriteResultsetBuffered-16       2568 ns/op    0 B/op    0 allocs/op
    go test -run '^$' -bench '^BenchmarkWriteResultset' -benchmem ./packet/
```

So about a 25x improvement.