### PR TITLE
server: negotiate CLIENT_DEPRECATE_EOF

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -165,6 +165,14 @@ func (c *Conn) HasCapability(capability uint32) bool {
 	return c.capability&capability > 0
 }
 
+// deprecateEOF reports whether both sides negotiated CLIENT_DEPRECATE_EOF:
+// resultsets are then OK-terminated (with an EOF 0xFE header) and the EOF
+// separator after the column definitions is omitted.
+func (c *Conn) deprecateEOF() bool {
+	return c.capability&mysql.CLIENT_DEPRECATE_EOF > 0 &&
+		c.serverConf.Capability()&mysql.CLIENT_DEPRECATE_EOF > 0
+}
+
 func (c *Conn) Charset() uint8 {
 	return c.charset
 }

--- a/server/resp.go
+++ b/server/resp.go
@@ -69,6 +69,26 @@ func (c *Conn) writeEOF() error {
 	return c.WritePacket(data)
 }
 
+// writeEOFOrOK terminates a packet sequence: a classic EOF packet, or an
+// EOF-headered (0xFE) OK packet when CLIENT_DEPRECATE_EOF is negotiated, as
+// MySQL 5.7.5+ sends. No session-state suffix: the packet must stay under the
+// 9-byte threshold clients use to recognize EOF packets.
+func (c *Conn) writeEOFOrOK() error {
+	if !c.deprecateEOF() {
+		return c.writeEOF()
+	}
+
+	data := make([]byte, 4, 16)
+
+	data = append(data, mysql.EOF_HEADER)
+	data = append(data, mysql.PutLengthEncodedInt(0)...) // affected rows
+	data = append(data, mysql.PutLengthEncodedInt(0)...) // last insert id
+	data = append(data, byte(c.status), byte(c.status>>8))
+	data = append(data, byte(c.warnings), byte(c.warnings>>8))
+
+	return c.WritePacket(data)
+}
+
 // see: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_auth_switch_request.html
 func (c *Conn) writeAuthSwitchRequest(newAuthPluginName string) error {
 	c.authPluginName = newAuthPluginName
@@ -133,7 +153,7 @@ func (c *Conn) writeResultset(r *mysql.Resultset) error {
 		case mysql.StreamingMultiple:
 			return nil
 		case mysql.StreamingSelect:
-			return c.writeEOF()
+			return c.writeEOFOrOK()
 		}
 	}
 
@@ -150,6 +170,13 @@ func (c *Conn) writeResultset(r *mysql.Resultset) error {
 		return err
 	}
 
+	// no separator between column definitions and rows under CLIENT_DEPRECATE_EOF
+	if !c.deprecateEOF() {
+		if err := c.writeEOF(); err != nil {
+			return err
+		}
+	}
+
 	// streaming select resultsets handle rowdata in a separate callback of type
 	// SelectPerRowCallback so we're done here
 	if r.Streaming == mysql.StreamingSelect {
@@ -164,7 +191,7 @@ func (c *Conn) writeResultset(r *mysql.Resultset) error {
 		}
 	}
 
-	if err := c.writeEOF(); err != nil {
+	if err := c.writeEOFOrOK(); err != nil {
 		return err
 	}
 
@@ -186,6 +213,13 @@ func (c *Conn) writeStreamResultset(sr *mysql.StreamResult) error {
 
 	if err := c.writeFieldList(sr.Fields, data); err != nil {
 		return err
+	}
+
+	// no separator between column definitions and rows under CLIENT_DEPRECATE_EOF
+	if !c.deprecateEOF() {
+		if err := c.writeEOF(); err != nil {
+			return err
+		}
 	}
 
 	if sr.Binary {
@@ -223,7 +257,7 @@ func (c *Conn) writeStreamTextRows(sr *mysql.StreamResult) error {
 		return c.writeError(err)
 	}
 
-	return c.writeEOF()
+	return c.writeEOFOrOK()
 }
 
 // writeStreamBinaryRows writes rows using binary protocol.
@@ -277,9 +311,11 @@ func (c *Conn) writeStreamBinaryRows(sr *mysql.StreamResult) error {
 		return c.writeError(err)
 	}
 
-	return c.writeEOF()
+	return c.writeEOFOrOK()
 }
 
+// writeFieldList writes one packet per column definition and no terminator;
+// the caller appends an EOF packet, an EOF-headered OK, or nothing.
 func (c *Conn) writeFieldList(fs []*mysql.Field, data []byte) error {
 	if data == nil {
 		data = make([]byte, 4, 1024)
@@ -293,9 +329,6 @@ func (c *Conn) writeFieldList(fs []*mysql.Field, data []byte) error {
 		}
 	}
 
-	if err := c.writeEOF(); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -349,7 +382,7 @@ func (c *Conn) WriteValue(value any) error {
 	case noResponse:
 		return nil
 	case eofResponse:
-		return c.writeEOF()
+		return c.writeEOFOrOK()
 	case error:
 		return c.writeError(v)
 	case nil:
@@ -362,7 +395,11 @@ func (c *Conn) WriteValue(value any) error {
 		}
 		return c.writeOK(v)
 	case []*mysql.Field:
-		return c.writeFieldList(v, nil)
+		// COM_FIELD_LIST response: column definitions, then a terminator.
+		if err := c.writeFieldList(v, nil); err != nil {
+			return err
+		}
+		return c.writeEOFOrOK()
 	case []mysql.FieldValue:
 		return c.writeFieldValues(v)
 	case *replication.BinlogStreamer:

--- a/server/resp_test.go
+++ b/server/resp_test.go
@@ -264,13 +264,39 @@ func TestConnWriteResultset(t *testing.T) {
 	require.Equal(t, []byte{1, 0, 0, 7, mysql.EOF_HEADER}, clientConn.WriteBuffered[43:])
 }
 
+func TestConnWriteResultsetDeprecateEOF(t *testing.T) {
+	clientConn := &mockconn.MockConn{MultiWrite: true}
+	conn := &Conn{
+		Conn:       packet.NewConn(clientConn),
+		serverConf: &Server{capability: mysql.CLIENT_PROTOCOL_41 | mysql.CLIENT_DEPRECATE_EOF},
+		capability: mysql.CLIENT_PROTOCOL_41 | mysql.CLIENT_DEPRECATE_EOF,
+	}
+
+	r, err := mysql.BuildSimpleTextResultset([]string{"a"}, [][]any{{"b"}})
+	require.NoError(t, err)
+	err = conn.writeResultset(r)
+	require.NoError(t, err)
+
+	// column count
+	require.Equal(t, []byte{1, 0, 0, 0, 1}, clientConn.WriteBuffered[:5])
+	// field packet, with no EOF separator following it
+	require.Equal(t, []byte{23, 0, 0, 1, 3, 100, 101, 102, 0, 0, 0, 1, 'a', 0, 12, 33, 0, 0, 0, 0, 0, 253, 0, 0, 0, 0, 0}, clientConn.WriteBuffered[5:32])
+	// rowdata directly after the fields
+	require.Equal(t, []byte{2, 0, 0, 2, 1, 'b'}, clientConn.WriteBuffered[32:38])
+	// terminating OK packet with an EOF header:
+	// 0xFE, affected rows (0), last insert id (0), status (2), warnings (2)
+	require.Equal(t, []byte{7, 0, 0, 3, mysql.EOF_HEADER, 0, 0, 0, 0, 0, 0}, clientConn.WriteBuffered[38:])
+}
+
 func TestConnWriteFieldList(t *testing.T) {
 	clientConn := &mockconn.MockConn{MultiWrite: true}
 	conn := &Conn{Conn: packet.NewConn(clientConn)}
 
 	r, err := mysql.BuildSimpleTextResultset([]string{"c"}, [][]any{{"d"}})
 	require.NoError(t, err)
-	err = conn.writeFieldList(r.Fields, nil)
+	// COM_FIELD_LIST response path: column definitions followed by a
+	// terminator (writeFieldList itself writes none).
+	err = conn.WriteValue(r.Fields)
 	require.NoError(t, err)
 
 	// column length 1
@@ -289,6 +315,10 @@ func TestConnWriteFieldValues(t *testing.T) {
 
 	require.NoError(t, err)
 	err = conn.writeFieldList(r.Fields, nil)
+	require.NoError(t, err)
+	// writeFieldList writes no terminator anymore; append it as the
+	// resultset path does for pre-DEPRECATE_EOF clients
+	err = conn.writeEOF()
 	require.NoError(t, err)
 
 	// fields and EOF

--- a/server/server_conf.go
+++ b/server/server_conf.go
@@ -15,7 +15,8 @@ import (
 // from server construction and must not be changed independently.
 const userConfigurableServerCapabilities = mysql.CLIENT_LOCAL_FILES |
 	mysql.CLIENT_MULTI_RESULTS |
-	mysql.CLIENT_PS_MULTI_RESULTS
+	mysql.CLIENT_PS_MULTI_RESULTS |
+	mysql.CLIENT_DEPRECATE_EOF
 
 // Defines a basic MySQL server with configs.
 //
@@ -63,7 +64,7 @@ func NewDefaultServer() *Server {
 		capability: mysql.CLIENT_LONG_PASSWORD | mysql.CLIENT_LONG_FLAG | mysql.CLIENT_CONNECT_WITH_DB | mysql.CLIENT_PROTOCOL_41 |
 			mysql.CLIENT_TRANSACTIONS | mysql.CLIENT_SECURE_CONNECTION | mysql.CLIENT_PLUGIN_AUTH | mysql.CLIENT_SSL |
 			mysql.CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA | mysql.CLIENT_CONNECT_ATTRS | mysql.CLIENT_SESSION_TRACK |
-			mysql.CLIENT_MULTI_RESULTS | mysql.CLIENT_PS_MULTI_RESULTS,
+			mysql.CLIENT_MULTI_RESULTS | mysql.CLIENT_PS_MULTI_RESULTS | mysql.CLIENT_DEPRECATE_EOF,
 		collationID:       mysql.DEFAULT_COLLATION_ID,
 		defaultAuthMethod: mysql.AUTH_NATIVE_PASSWORD,
 		rsaPrivateKey:     rsaPrivateKey,
@@ -110,7 +111,7 @@ func NewServerWithAuth(serverVersion string, collationID uint8, defaultAuthMetho
 	capFlag := mysql.CLIENT_LONG_PASSWORD | mysql.CLIENT_LONG_FLAG | mysql.CLIENT_CONNECT_WITH_DB | mysql.CLIENT_PROTOCOL_41 |
 		mysql.CLIENT_TRANSACTIONS | mysql.CLIENT_SECURE_CONNECTION | mysql.CLIENT_PLUGIN_AUTH | mysql.CLIENT_CONNECT_ATTRS |
 		mysql.CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA | mysql.CLIENT_SESSION_TRACK |
-		mysql.CLIENT_MULTI_RESULTS | mysql.CLIENT_PS_MULTI_RESULTS
+		mysql.CLIENT_MULTI_RESULTS | mysql.CLIENT_PS_MULTI_RESULTS | mysql.CLIENT_DEPRECATE_EOF
 	if tlsConfig != nil {
 		capFlag |= mysql.CLIENT_SSL
 	}
@@ -142,8 +143,9 @@ func (s *Server) Capability() uint32 {
 }
 
 // SetCapability enables additional server capabilities advertised in the handshake.
-// Only CLIENT_LOCAL_FILES, CLIENT_MULTI_RESULTS, and CLIENT_PS_MULTI_RESULTS may
-// be set; other flags are managed by server construction (e.g. CLIENT_SSL requires TLS).
+// Only CLIENT_LOCAL_FILES, CLIENT_MULTI_RESULTS, CLIENT_PS_MULTI_RESULTS, and
+// CLIENT_DEPRECATE_EOF may be set; other flags are managed by server construction
+// (e.g. CLIENT_SSL requires TLS).
 func (s *Server) SetCapability(capability uint32) error {
 	if err := validateUserConfigurableCapability(capability); err != nil {
 		return err
@@ -158,8 +160,8 @@ func (s *Server) SetCapability(capability uint32) error {
 }
 
 // UnsetCapability disables server capabilities advertised in the handshake.
-// Only CLIENT_LOCAL_FILES, CLIENT_MULTI_RESULTS, and CLIENT_PS_MULTI_RESULTS may
-// be cleared via this API.
+// Only CLIENT_LOCAL_FILES, CLIENT_MULTI_RESULTS, CLIENT_PS_MULTI_RESULTS, and
+// CLIENT_DEPRECATE_EOF may be cleared via this API.
 func (s *Server) UnsetCapability(capability uint32) error {
 	if err := validateUserConfigurableCapability(capability); err != nil {
 		return err
@@ -178,7 +180,7 @@ func validateUserConfigurableCapability(capability uint32) error {
 		return fmt.Errorf("capability must not be zero")
 	}
 	if invalid := capability &^ userConfigurableServerCapabilities; invalid != 0 {
-		return fmt.Errorf("server capability %#x contains non-user-configurable flags %#x; only CLIENT_LOCAL_FILES, CLIENT_MULTI_RESULTS, and CLIENT_PS_MULTI_RESULTS are supported", capability, invalid)
+		return fmt.Errorf("server capability %#x contains non-user-configurable flags %#x; only CLIENT_LOCAL_FILES, CLIENT_MULTI_RESULTS, CLIENT_PS_MULTI_RESULTS, and CLIENT_DEPRECATE_EOF are supported", capability, invalid)
 	}
 	return nil
 }

--- a/server/stmt.go
+++ b/server/stmt.go
@@ -71,8 +71,12 @@ func (c *Conn) writePrepare(s *Stmt) error {
 			}
 		}
 
-		if err := c.writeEOF(); err != nil {
-			return err
+		// with CLIENT_DEPRECATE_EOF the parameter definitions have no
+		// trailing EOF separator
+		if !c.deprecateEOF() {
+			if err := c.writeEOF(); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -90,8 +94,12 @@ func (c *Conn) writePrepare(s *Stmt) error {
 			}
 		}
 
-		if err := c.writeEOF(); err != nil {
-			return err
+		// with CLIENT_DEPRECATE_EOF the column definitions have no trailing
+		// EOF separator
+		if !c.deprecateEOF() {
+			if err := c.writeEOF(); err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
The client side of this library has requested and parsed CLIENT_DEPRECATE_EOF framing for years, but the server never advertised it, so the flag always negotiated away. Advertise it (and honor it) as MySQL 5.7.5+ does:

  - resultsets: no EOF separator between the column definitions and the rows; rows are terminated by an OK packet carrying the EOF (0xFE) header with affected-rows/insert-id/status/warnings
  - COM_STMT_PREPARE: no EOF after the parameter and column definitions
  - COM_FIELD_LIST and COM_SET_OPTION: EOF-headered OK terminator

This removes two packets from every resultset (and their encode cost; with buffered writes the syscall count is unchanged). The behavior is fully capability-negotiated: clients that do not request the flag get byte-identical classic framing, covered by the existing resultset tests. Operators can opt a server out via UnsetCapability(CLIENT_DEPRECATE_EOF).

writeFieldList no longer writes a terminator; its callers append the right one for their context (EOF, EOF-headered OK, or nothing).