### PR TITLE
packet: report a sequence mismatch as a bad connection

### DIFF
--- a/packet/conn.go
+++ b/packet/conn.go
@@ -323,7 +323,10 @@ func (c *Conn) ReadPacketTo(w io.Writer) error {
 	sequence := c.header[3]
 
 	if sequence != c.Sequence {
-		return errors.Errorf("invalid sequence %d != %d", sequence, c.Sequence)
+		// A mismatched sequence leaves the stream desynced beyond recovery, so the
+		// connection is unusable: report it as bad, like the read failures above, so
+		// callers discard it instead of retrying on it.
+		return errors.Wrapf(mysql.ErrBadConn, "invalid sequence %d != %d", sequence, c.Sequence)
 	}
 
 	c.Sequence++

--- a/packet/conn_test.go
+++ b/packet/conn_test.go
@@ -270,3 +270,21 @@ func benchmarkWriteResultset(b *testing.B, buffered bool) {
 func BenchmarkWriteResultsetUnbuffered(b *testing.B) { benchmarkWriteResultset(b, false) }
 
 func BenchmarkWriteResultsetBuffered(b *testing.B) { benchmarkWriteResultset(b, true) }
+
+// TestReadPacketSequenceMismatchIsBadConn covers a desynced stream: once a packet
+// arrives with an unexpected sequence, nothing after it can be interpreted, so the
+// connection must be reported as bad rather than merely as a failed read. A server
+// closing an idle connection queues its ERR packet outside any command cycle, so it
+// carries sequence 0 and the next command reads it while expecting 1.
+func TestReadPacketSequenceMismatchIsBadConn(t *testing.T) {
+	c := newReadTestConn(mysqlPacket(0, []byte("out of band")), mysql.MYSQL_COMPRESS_NONE)
+	c.Sequence = 1
+
+	_, err := c.ReadPacket()
+	if err == nil {
+		t.Fatal("ReadPacket succeeded on a mismatched sequence, want an error")
+	}
+	if !mysql.ErrorEqual(err, mysql.ErrBadConn) {
+		t.Errorf("err = %v, want an error equal to mysql.ErrBadConn", err)
+	}
+}


### PR DESCRIPTION
Fixes #814.

`ReadPacketTo` reports a packet-sequence mismatch with a plain `errors.Errorf`. But a mismatch means the stream is desynced, and nothing after it can be interpreted — the connection is unusable, exactly like the read failures nine lines above, which are already wrapped in `mysql.ErrBadConn`. This wraps it the same way.

The practical case is a connection the server closed after `wait_timeout`. Since 8.0.24 MySQL queues an ERR 4031 packet before closing; it arrives outside a command cycle, so it carries sequence 0, and the next command reads it while expecting 1. Callers that already discard bad connections then recover on their own — `Canal.Execute` retries on `mysql.ErrBadConn` and reconnects, which turns a fatal error into a transparent retry with no change to canal. The full mechanism and a reproduction are in #814.

The message text is preserved as the prefix (`invalid sequence 0 != 1: connection was bad`), so anything matching on it keeps working.

Tested: new offline test in `packet`; verified failing before the change and passing after. `./packet/ ./replication/ ./mysql/ ./compress/ ./utils/` pass; the server-backed suites (`canal`, `client`, `server`, `dump`, `schema`) were not run locally as they need MySQL on 127.0.0.1:3306 — CI covers them. Also verified end to end against a real MySQL 8.0.43: before the change `ErrorEqual(err, ErrBadConn)` is `false`, after it is `true`.
