### PR TITLE
replication: tag unmarshalable BinlogSyncerConfig fields with json:"-"

### DIFF
--- a/replication/binlogsyncer.go
+++ b/replication/binlogsyncer.go
@@ -53,7 +53,7 @@ type BinlogSyncerConfig struct {
 	RawModeEnabled bool
 
 	// If not nil, use the provided tls.Config to connect to the database using TLS/SSL.
-	TLSConfig *tls.Config
+	TLSConfig *tls.Config `json:"-"`
 
 	// Use replication.Time structure for timestamp and datetime.
 	// We will use Local location for timestamp and UTC location for datetime.
@@ -143,17 +143,17 @@ type BinlogSyncerConfig struct {
 
 	// Option function is used to set outside of BinlogSyncerConfig， between mysql connection and COM_REGISTER_SLAVE
 	// For MariaDB: slave_gtid_ignore_duplicates、skip_replication、slave_until_gtid
-	Option func(*client.Conn) error
+	Option func(*client.Conn) error `json:"-"`
 
 	// Set Logger
 	Logger *slog.Logger
 
 	// Set Dialer
-	Dialer client.Dialer
+	Dialer client.Dialer `json:"-"`
 
-	RowsEventDecodeFunc func(*RowsEvent, []byte) error
+	RowsEventDecodeFunc func(*RowsEvent, []byte) error `json:"-"`
 
-	TableMapOptionalMetaDecodeFunc func([]byte) error
+	TableMapOptionalMetaDecodeFunc func([]byte) error `json:"-"`
 
 	DiscardGTIDSet bool
 
@@ -172,7 +172,7 @@ type BinlogSyncerConfig struct {
 	// SynchronousEventHandler is used for synchronous event handling.
 	// This should not be used together with StartBackupWithHandler.
 	// If this is not nil, GetEvent does not need to be called.
-	SynchronousEventHandler EventHandler
+	SynchronousEventHandler EventHandler `json:"-"`
 }
 
 // EventHandler defines the interface for processing binlog events.

--- a/replication/binlogsyncer_test.go
+++ b/replication/binlogsyncer_test.go
@@ -2,6 +2,7 @@ package replication
 
 import (
 	"bytes"
+	"crypto/tls"
 	"errors"
 	"io"
 	"log/slog"
@@ -177,4 +178,29 @@ func TestHandleEventAndACKRotateLogDedup(t *testing.T) {
 
 	require.Equal(t, mysql.Position{Name: "mysql-bin.000002", Pos: 4}, b.GetNextPosition())
 	require.Equal(t, 2, strings.Count(buf.String(), "rotate to next binlog"))
+}
+
+func TestBinlogSyncerConfigLogsAsJSON(t *testing.T) {
+	var buf bytes.Buffer
+
+	cfg := BinlogSyncerConfig{
+		ServerID:                       100,
+		Host:                           "127.0.0.1",
+		Port:                           3306,
+		User:                           "root",
+		Password:                       "hunter2",
+		Logger:                         slog.New(slog.NewJSONHandler(&buf, nil)),
+		TLSConfig:                      &tls.Config{},
+		Option:                         func(*client.Conn) error { return nil },
+		Dialer:                         (&net.Dialer{}).DialContext,
+		RowsEventDecodeFunc:            func(*RowsEvent, []byte) error { return nil },
+		TableMapOptionalMetaDecodeFunc: func([]byte) error { return nil },
+		SynchronousEventHandler:        NewBackupEventHandler(nil),
+	}
+	NewBinlogSyncer(cfg).Close()
+
+	require.NotContains(t, buf.String(), "!ERROR")
+	require.NotContains(t, buf.String(), "hunter2")
+	require.Contains(t, buf.String(), `"ServerID":100`)
+	require.Contains(t, buf.String(), `"Port":3306`)
 }


### PR DESCRIPTION
Fixes #1180. Uses JSON annotations rather than a `LogValue` method, as @lance6716 asked for in the issue: a tag can't go stale when a new field is added.

`NewBinlogSyncer` logs the whole config with `slog.Any("config", cfg)`. `encoding/json` rejects func-typed fields by type, whether they are nil or not, so under a JSON handler every syncer start printed this and nothing else:

```json
{"level":"INFO","msg":"create BinlogSyncer","config":"!ERROR:json: unsupported type: func(*client.Conn) error"}
```

So no config was logged at all, and the record carried the word `ERROR` at INFO level, which is enough to set off alerting that greps logs for it.

Tagged fields: `Option`, `Dialer`, `RowsEventDecodeFunc`, `TableMapOptionalMetaDecodeFunc`, and two more that fail the same marshal for the same reason. `tls.Config` has func fields of its own, so a non-nil `TLSConfig` fails with `func() time.Time`. `SynchronousEventHandler` is an interface, so whatever the caller passes decides.

One side effect: the `cfg.Password` clear and restore around the log call now does something, because the marshal gets as far as that field.

Note that the record no longer says whether TLS is configured. Tell me if you want a bool for that at the call site.

Tested: the new test calls `NewBinlogSyncer` with all six of those fields set and checks that the record has no `!ERROR` placeholder, no password, and real values. It fails before the change and passes after. `./replication/ ./packet/ ./mysql/ ./compress/ ./utils/` pass. I did not run the suites that need MySQL on 127.0.0.1:3306 (`canal`, `client`, `server`, `dump`, `schema`); CI covers those.
