### PR TITLE
Add mariadb integration test setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,39 @@ jobs:
           go test $(go list ./... | grep -v canal | grep -v dump)
           # go test $(go list ./... | grep canal | grep -v dump)
 
+  mariadbtest:
+    strategy:
+      fail-fast: false
+      matrix:
+        mariadb_version:
+          - 10.11.18
+          - 11.4.12
+          - 11.8.8
+    name: Tests with MariaDB ${{ matrix.mariadb_version }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - name: Install test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make gcc mariadb-client
+          mariadb-dump --version
+      - name: Start MariaDB
+        run: make MARIADB_VERSION=${{ matrix.mariadb_version }} mariadb-start
+      - name: MariaDB version
+        run: mariadb -h 127.0.0.1 -u root -BNe 'SELECT VERSION()'
+      - name: Run tests
+        run: make test-local-mariadb
+      - name: Stop MariaDB
+        if: always()
+        run: make mariadb-stop
+
   golangci:
     name: golangci
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ all: build
 
 GO111MODULE=on
 MYSQL_VERSION ?= 8.0
+MARIADB_VERSION ?= 11.8.8
 GO ?= go
 
 build:
@@ -23,6 +24,53 @@ test-local:
 	docker/resources/waitfor.sh 127.0.0.1 3306 \
 		&& ${GO} test -race -v -timeout 2m ./...
 	docker stop go-mysql-server
+
+MARIADB_CONTAINER ?= go-mariadb-server
+
+mariadb-start:
+	@if docker inspect $(MARIADB_CONTAINER) >/dev/null 2>&1; then \
+		if [ "$$(docker inspect --format '{{.State.Running}}' $(MARIADB_CONTAINER))" = "true" ]; then \
+			echo "MariaDB container $(MARIADB_CONTAINER) is already running"; \
+		else \
+			docker start $(MARIADB_CONTAINER) >/dev/null; \
+		fi; \
+	else \
+		docker run --rm -d -p 3306:3306 --name $(MARIADB_CONTAINER) \
+		-e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 \
+		-e MARIADB_ROOT_HOST=% \
+		-e MARIADB_DATABASE=test \
+		-v "$${PWD}/docker/resources/ca.pem:/etc/mysql/ca.pem:ro" \
+		-v "$${PWD}/docker/resources/server-cert.pem:/etc/mysql/server-cert.pem:ro" \
+		-v "$${PWD}/docker/resources/server-key.pem:/etc/mysql/server-key.pem:ro" \
+		mariadb:$(MARIADB_VERSION) \
+			--server-id=1 --log-bin=mysql --binlog-format=row \
+			--ssl-ca=/etc/mysql/ca.pem \
+			--ssl-cert=/etc/mysql/server-cert.pem \
+			--ssl-key=/etc/mysql/server-key.pem >/dev/null; \
+	fi; \
+	for attempt in $$(seq 1 60); do \
+		if docker exec $(MARIADB_CONTAINER) mariadb-admin ping \
+			-h127.0.0.1 -P3306 -uroot --silent >/dev/null 2>&1; then \
+			echo "MariaDB is ready on 127.0.0.1:3306"; \
+			exit 0; \
+		fi; \
+		sleep 1; \
+	done; \
+	docker logs $(MARIADB_CONTAINER); \
+	exit 1
+
+test-local-mariadb:
+	@docker exec $(MARIADB_CONTAINER) mariadb-admin ping \
+		-h127.0.0.1 -P3306 -uroot --silent >/dev/null 2>&1 || \
+		{ echo "MariaDB is not running; run 'make mariadb-start' first"; exit 1; }
+	MYSQL_FLAVOR=mariadb ${GO} test -race -v -timeout 2m ./...
+
+mariadb-stop:
+	@if docker inspect $(MARIADB_CONTAINER) >/dev/null 2>&1; then \
+		docker stop $(MARIADB_CONTAINER) >/dev/null; \
+	else \
+		echo "MariaDB container $(MARIADB_CONTAINER) does not exist"; \
+	fi
 
 fmt:
 	golangci-lint run --fix

--- a/canal/canal_test.go
+++ b/canal/canal_test.go
@@ -54,6 +54,9 @@ const (
 func (s *canalTestSuite) SetupSuite() {
 	cfg := NewDefaultConfig()
 	cfg.Addr = fmt.Sprintf("%s:%s", *test_util.MysqlHost, *test_util.MysqlPort)
+	if test_util.ServerFlavor != "" {
+		cfg.Flavor = test_util.ServerFlavor
+	}
 	if s.addr != "" {
 		cfg.Addr = s.addr
 	}
@@ -100,7 +103,7 @@ func (s *canalTestSuite) SetupSuite() {
 
 	s.c.SetEventHandler(&testEventHandler{T: s.T()})
 	go func() {
-		set, _ := mysql.ParseGTIDSet("mysql", "")
+		set, _ := mysql.ParseGTIDSet(cfg.Flavor, "")
 		err = s.c.StartFromGTID(set)
 		require.NoError(s.T(), err)
 	}()

--- a/replication/json_mysql_text_test.go
+++ b/replication/json_mysql_text_test.go
@@ -765,6 +765,9 @@ func TestJSONTemporalServerParity(t *testing.T) {
 	require.NoError(t, err)
 	version, err := res.GetString(0, 0)
 	require.NoError(t, err)
+	if strings.Contains(version, "MariaDB") {
+		t.Skip("requires MySQL binary JSON")
+	}
 	logBin, err := res.GetInt(0, 1)
 	require.NoError(t, err)
 	format, err := res.GetString(0, 2)

--- a/replication/replication_test.go
+++ b/replication/replication_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -165,7 +166,6 @@ func (t *testSyncerSuite) testSync(s *BinlogStreamer) {
 			`INSERT INTO test_json_v2 VALUES (7, 'false')`,
 			`INSERT INTO test_json_v2 VALUES (8, 'null')`,
 			`INSERT INTO test_json_v2 VALUES (9, '-1')`,
-			`INSERT INTO test_json_v2 VALUES (10, CAST(CAST(1 AS UNSIGNED) AS JSON))`,
 			`INSERT INTO test_json_v2 VALUES (11, '32767')`,
 			`INSERT INTO test_json_v2 VALUES (12, '32768')`,
 			`INSERT INTO test_json_v2 VALUES (13, '-32768')`,
@@ -179,21 +179,26 @@ func (t *testSyncerSuite) testSync(s *BinlogStreamer) {
 			`INSERT INTO test_json_v2 VALUES (21, '3.14')`,
 			`INSERT INTO test_json_v2 VALUES (22, '{}')`,
 			`INSERT INTO test_json_v2 VALUES (23, '[]')`,
-			`INSERT INTO test_json_v2 VALUES (24, CAST(CAST('2015-01-15 23:24:25' AS DATETIME) AS JSON))`,
-			`INSERT INTO test_json_v2 VALUES (25, CAST(CAST('23:24:25' AS TIME) AS JSON))`,
-			`INSERT INTO test_json_v2 VALUES (125, CAST(CAST('23:24:25.12' AS TIME(3)) AS JSON))`,
-			`INSERT INTO test_json_v2 VALUES (225, CAST(CAST('23:24:25.0237' AS TIME(3)) AS JSON))`,
-			`INSERT INTO test_json_v2 VALUES (26, CAST(CAST('2015-01-15' AS DATE) AS JSON))`,
-			`INSERT INTO test_json_v2 VALUES (27, CAST(TIMESTAMP'2015-01-15 23:24:25' AS JSON))`,
-			`INSERT INTO test_json_v2 VALUES (127, CAST(TIMESTAMP'2015-01-15 23:24:25.12' AS JSON))`,
-			`INSERT INTO test_json_v2 VALUES (227, CAST(TIMESTAMP'2015-01-15 23:24:25.0237' AS JSON))`,
-			`INSERT INTO test_json_v2 VALUES (327, CAST(UNIX_TIMESTAMP('2015-01-15 23:24:25') AS JSON))`,
-			`INSERT INTO test_json_v2 VALUES (28, CAST(ST_GeomFromText('POINT(1 1)') AS JSON))`,
 			`INSERT INTO test_json_v2 VALUES (29, CAST('[]' AS CHAR CHARACTER SET 'ascii'))`,
-			// TODO: 30 and 31 are BIT type from JSON_TYPE, may support later.
-			`INSERT INTO test_json_v2 VALUES (30, CAST(x'cafe' AS JSON))`,
-			`INSERT INTO test_json_v2 VALUES (31, CAST(x'cafebabe' AS JSON))`,
 			`INSERT INTO test_json_v2 VALUES (100, CONCAT('{\"', REPEAT('a', 64 * 1024 - 1), '\":123}'))`,
+		}
+		if t.flavor == mysql.MySQLFlavor {
+			tbls = append(tbls,
+				`INSERT INTO test_json_v2 VALUES (10, CAST(CAST(1 AS UNSIGNED) AS JSON))`,
+				`INSERT INTO test_json_v2 VALUES (24, CAST(CAST('2015-01-15 23:24:25' AS DATETIME) AS JSON))`,
+				`INSERT INTO test_json_v2 VALUES (25, CAST(CAST('23:24:25' AS TIME) AS JSON))`,
+				`INSERT INTO test_json_v2 VALUES (125, CAST(CAST('23:24:25.12' AS TIME(3)) AS JSON))`,
+				`INSERT INTO test_json_v2 VALUES (225, CAST(CAST('23:24:25.0237' AS TIME(3)) AS JSON))`,
+				`INSERT INTO test_json_v2 VALUES (26, CAST(CAST('2015-01-15' AS DATE) AS JSON))`,
+				`INSERT INTO test_json_v2 VALUES (27, CAST(TIMESTAMP'2015-01-15 23:24:25' AS JSON))`,
+				`INSERT INTO test_json_v2 VALUES (127, CAST(TIMESTAMP'2015-01-15 23:24:25.12' AS JSON))`,
+				`INSERT INTO test_json_v2 VALUES (227, CAST(TIMESTAMP'2015-01-15 23:24:25.0237' AS JSON))`,
+				`INSERT INTO test_json_v2 VALUES (327, CAST(UNIX_TIMESTAMP('2015-01-15 23:24:25') AS JSON))`,
+				`INSERT INTO test_json_v2 VALUES (28, CAST(ST_GeomFromText('POINT(1 1)') AS JSON))`,
+				// TODO: 30 and 31 are BIT type from JSON_TYPE, may support later.
+				`INSERT INTO test_json_v2 VALUES (30, CAST(x'cafe' AS JSON))`,
+				`INSERT INTO test_json_v2 VALUES (31, CAST(x'cafebabe' AS JSON))`,
+			)
 		}
 
 		for _, query := range tbls {
@@ -260,8 +265,15 @@ func (t *testSyncerSuite) testSync(s *BinlogStreamer) {
 
 func (t *testSyncerSuite) setupTest(flavor string) {
 	var port uint16 = 3306
-	switch flavor {
-	case mysql.MariaDBFlavor:
+	if test_util.ServerFlavor != "" {
+		if flavor != test_util.ServerFlavor {
+			t.T().Skipf("requires %s server", flavor)
+		}
+
+		configuredPort, err := strconv.ParseUint(*test_util.MysqlPort, 10, 16)
+		require.NoError(t.T(), err)
+		port = uint16(configuredPort)
+	} else if flavor == mysql.MariaDBFlavor {
 		port = 3316
 	}
 
@@ -302,11 +314,19 @@ func (t *testSyncerSuite) setupTest(flavor string) {
 
 func (t *testSyncerSuite) testPositionSync() {
 	// get current master binlog file and position
-	showBinlogStatus := "SHOW BINARY LOG STATUS"
-	showReplicas := "SHOW REPLICAS"
-	if eq, err := t.c.CompareServerVersion("8.4.0"); (err == nil) && (eq < 0) {
+	showBinlogStatus := "SHOW BINLOG STATUS"
+	showReplicas := "SHOW SLAVE HOSTS"
+	if t.flavor == mysql.MySQLFlavor {
+		showBinlogStatus = "SHOW BINARY LOG STATUS"
+		showReplicas = "SHOW REPLICAS"
+	}
+	if t.flavor == mysql.MySQLFlavor {
+		if eq, err := t.c.CompareServerVersion("8.4.0"); (err == nil) && (eq < 0) {
+			showBinlogStatus = "SHOW MASTER STATUS"
+			showReplicas = "SHOW SLAVE HOSTS"
+		}
+	} else if eq, err := t.c.CompareServerVersion("10.5.2"); (err == nil) && (eq < 0) {
 		showBinlogStatus = "SHOW MASTER STATUS"
-		showReplicas = "SHOW SLAVE HOSTS"
 	}
 	r, err := t.c.Execute(showBinlogStatus)
 	require.NoError(t.T(), err)
@@ -322,13 +342,15 @@ func (t *testSyncerSuite) testPositionSync() {
 	// List of replicas must not be empty
 	require.Greater(t.T(), len(r.Values), 0)
 
-	// Slave_UUID is empty for mysql 8.0.28+ (8.0.32 still broken)
-	if eq, err := t.c.CompareServerVersion("8.0.28"); (err == nil) && (eq < 0) {
-		// check we have set Slave_UUID
-		slaveUUID, _ := r.GetString(0, 4)
-		require.Len(t.T(), slaveUUID, 36)
-	} else if err != nil {
-		require.NoError(t.T(), err)
+	if t.flavor == mysql.MySQLFlavor {
+		// Slave_UUID is empty for mysql 8.0.28+ (8.0.32 still broken)
+		if eq, err := t.c.CompareServerVersion("8.0.28"); (err == nil) && (eq < 0) {
+			// check we have set Slave_UUID
+			slaveUUID, _ := r.GetString(0, 4)
+			require.Len(t.T(), slaveUUID, 36)
+		} else if err != nil {
+			require.NoError(t.T(), err)
+		}
 	}
 
 	// Test re-sync.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -152,21 +152,22 @@ func (ta *Table) AddColumn(name string, columnType string, collation string, ext
 		ta.UnsignedColumns = append(ta.UnsignedColumns, index)
 	}
 
-	switch extra {
+	normalizedExtra := strings.ToLower(extra)
+	switch normalizedExtra {
 	case "auto_increment":
 		ta.Columns[index].IsAuto = true
-	case "VIRTUAL GENERATED":
+	case "virtual generated":
 		ta.Columns[index].IsVirtual = true
-	case "STORED GENERATED":
+	case "stored generated":
 		ta.Columns[index].IsStored = true
 	}
 
-	if strings.Contains(extra, "DEFAULT_GENERATED") {
+	if strings.Contains(normalizedExtra, "default_generated") {
 		ta.Columns[index].IsDefaultExpr = true
 	}
 	if ta.Columns[index].Type == TYPE_DATETIME ||
 		ta.Columns[index].Type == TYPE_TIMESTAMP {
-		if strings.Contains(extra, "on update CURRENT_TIMESTAMP") {
+		if strings.Contains(normalizedExtra, "on update current_timestamp") {
 			ta.Columns[index].IsAutoUpdating = true
 		}
 	}
@@ -423,6 +424,8 @@ func (ta *Table) fetchIndexesViaSQLDB(conn *sql.DB) error {
 			case 13:
 				if hasInvisibleIndex {
 					values[i] = &visible
+				} else {
+					values[i] = &unusedVal
 				}
 			default:
 				values[i] = &unusedVal

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/go-mysql-org/go-mysql/client"
@@ -160,7 +161,13 @@ func (s *schemaTestSuite) TestSchemaColumnExtraFlags() {
 
 	exprIdx := ta.FindColumn("expr")
 	if exprIdx >= 0 {
-		require.True(s.T(), ta.Columns[exprIdx].IsDefaultExpr)
+		// MariaDB reports the expression in Default but leaves Extra empty,
+		// whereas MySQL marks it as DEFAULT_GENERATED in Extra.
+		if strings.Contains(s.conn.GetServerVersion(), "MariaDB") {
+			require.False(s.T(), ta.Columns[exprIdx].IsDefaultExpr)
+		} else {
+			require.True(s.T(), ta.Columns[exprIdx].IsDefaultExpr)
+		}
 		require.False(s.T(), ta.Columns[exprIdx].IsAutoUpdating)
 	}
 
@@ -183,6 +190,10 @@ func (s *schemaTestSuite) TestQuoteSchema() {
 }
 
 func (s *schemaTestSuite) TestSchemaWithMultiValueIndex() {
+	if strings.Contains(s.conn.GetServerVersion(), "MariaDB") {
+		s.T().Skip("multi-valued indexes are not supported by MariaDB")
+	}
+
 	_, err := s.conn.Execute(`DROP TABLE IF EXISTS multi_value_idx_test`)
 	require.NoError(s.T(), err)
 

--- a/test_util/flags.go
+++ b/test_util/flags.go
@@ -1,10 +1,14 @@
 package test_util
 
-import "flag"
+import (
+	"flag"
+	"os"
+)
 
 var (
-	MysqlHost = flag.String("host", "127.0.0.1", "MySQL server host")
-	MysqlPort = flag.String("port", "3306", "MySQL server port")
+	MysqlHost    = flag.String("host", "127.0.0.1", "MySQL server host")
+	MysqlPort    = flag.String("port", "3306", "MySQL server port")
+	ServerFlavor = os.Getenv("MYSQL_FLAVOR")
 
 	MysqlFakeHost = flag.String("fake-host", "127.0.0.1", "MySQL fake server host")
 	MysqlFakePort = flag.String("fake-port", "4000", "MySQL fake server port")


### PR DESCRIPTION
- Add make targets to start, test, and stop a MariaDB 11.8.8 container.
- Pass MYSQL_FLAVOR=mariadb to the complete test suite while preserving
  the existing behavior when the variable is not set.
- Configure canal with the selected server flavor so it uses MariaDB GTID
  parsing instead of querying the MySQL-only GTID_EXECUTED variable.
- Run MariaDB replication tests on the configured test port and skip
  scenarios that explicitly require MySQL protocol behavior or GTIDs.
- Use SHOW BINLOG STATUS and SHOW SLAVE HOSTS for MariaDB because its
  status commands differ from recent MySQL versions.
- Skip MySQL-specific CAST(... AS JSON) expressions because MariaDB 11.8
  does not accept JSON as a CAST target and stores JSON as validated text.
- Skip the binary JSON parity test because it verifies MySQL's binary JSON
  representation, which MariaDB does not use.
- Always provide a scan destination for the MariaDB Ignored column
  returned by SHOW INDEX when the MySQL Visible column is absent.
- Normalize SHOW FULL COLUMNS Extra metadata before matching because
  MariaDB returns values such as "on update current_timestamp()" with
  different casing from MySQL.
- Adjust the default-expression expectation because MariaDB reports the
  expression in Default without adding MySQL's DEFAULT_GENERATED marker
  to Extra.
- Skip the multi-valued index test because this index syntax is specific
  to MySQL and is not supported by MariaDB.
- Add MariaDB test matrix to CI