### PR TITLE
mysql: distinguish empty text values from NULL in text resultsets

### DIFF
--- a/mysql/resultset_helper.go
+++ b/mysql/resultset_helper.go
@@ -212,17 +212,17 @@ func BuildSimpleTextResultset(names []string, values [][]any) (*Resultset, error
 					return nil, errors.Errorf("row types aren't consistent")
 				}
 			}
+			if typ == MYSQL_TYPE_NULL {
+				// NULL value is encoded as 0xfb here (without additional info about length)
+				row = append(row, 0xfb)
+				continue
+			}
+
 			b, err = FormatTextValue(value)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-
-			if b == nil {
-				// NULL value is encoded as 0xfb here (without additional info about length)
-				row = append(row, 0xfb)
-			} else {
-				row = append(row, PutLengthEncodedString(b)...)
-			}
+			row = append(row, PutLengthEncodedString(b)...)
 		}
 
 		r.RowDatas = append(r.RowDatas, row)

--- a/mysql/resultset_test.go
+++ b/mysql/resultset_test.go
@@ -22,3 +22,15 @@ func TestGetIntNeg(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(-193), v)
 }
+
+func TestBuildSimpleTextResultsetDistinguishesEmptyValuesFromNull(t *testing.T) {
+	r, err := BuildSimpleTextResultset(
+		[]string{"empty_string", "empty_bytes", "null"},
+		[][]any{{"", []byte{}, nil}},
+	)
+	require.NoError(t, err)
+	require.Equal(t, RowData{0x00, 0x00, 0xfb}, r.RowDatas[0])
+	require.Equal(t, MYSQL_TYPE_VAR_STRING, r.Fields[0].Type)
+	require.Equal(t, MYSQL_TYPE_VAR_STRING, r.Fields[1].Type)
+	require.Equal(t, MYSQL_TYPE_NULL, r.Fields[2].Type)
+}


### PR DESCRIPTION
`BuildSimpleTextResultset` already calls `fieldType(value)` before encoding each cell. This is the semantic classification of the original value: `nil` maps to `MYSQL_TYPE_NULL`, while `string` and `[]byte` map to `MYSQL_TYPE_VAR_STRING`.

The previous implementation checked `b == nil` after calling `FormatTextValue`. At that point, an empty string may also be represented by a nil, zero-length byte slice, so `b == nil` is not sufficient to distinguish it from SQL `NULL`.

| Go value | Inferred MySQL type | Previous encoding | New encoding |
|---|---|---|---|
| `""` | `MYSQL_TYPE_VAR_STRING` | `0xfb` (NULL) | `0x00` (empty string) |
| `[]byte{}` | `MYSQL_TYPE_VAR_STRING` | `0x00` (empty string) | `0x00` (empty string) |
| `nil` | `MYSQL_TYPE_NULL` | `0xfb` (NULL) | `0xfb` (NULL) |

In the MySQL text protocol, `0xfb` is the NULL marker, while `0x00` is a length-encoded string with length zero.

The change therefore uses the already inferred per-value type:

```go
if typ == MYSQL_TYPE_NULL {
    row = append(row, 0xfb)
    continue
}