### PR TITLE
Keep fractional digits for a zero-fraction TIME with fsp

### DIFF
--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -1834,6 +1834,9 @@ func decodeTime2(data []byte, dec uint16) (string, int, error) {
 	}
 
 	if intPart == 0 && frac == 0 {
+		if dec > 0 {
+			return timeFormat(0, dec, n)
+		}
 		return "00:00:00", n, nil
 	}
 
@@ -1855,7 +1858,7 @@ func timeFormat(tmp int64, dec uint16, n int) (string, int, error) {
 	second := hms % (1 << 6)        /* 6 bits starting at 0th   */
 	secPart := tmp % (1 << 24)
 
-	if secPart != 0 {
+	if dec > 0 {
 		s := fmt.Sprintf("%s%02d:%02d:%02d.%06d", sign, hour, minute, second, secPart)
 		return s[0 : len(s)-(6-int(dec))], n, nil
 	}

--- a/replication/row_event_test.go
+++ b/replication/row_event_test.go
@@ -1499,6 +1499,10 @@ func TestDecodeTime2(t *testing.T) {
 		{[]byte("\x7f\xff\xff\xff\xff\xff"), 6, true, "-00:00:00.000001"},
 		{[]byte("\x7f\x0e\xfa\xfe\x1d\xc0"), 6, true, "-15:04:05.123456"},
 		{[]byte("\x4b\x91\x05\xfe\x1d\xc0"), 6, true, "-838:59:58.123456"},
+		// A zero fraction with fsp > 0 must still render the fractional digits.
+		{[]byte("\x80\xf1\x05\x00"), 2, true, "15:04:05.00"},
+		{[]byte("\x80\xf1\x05\x00\x00\x00"), 6, true, "15:04:05.000000"},
+		{[]byte("\x80\x00\x00\x00\x00"), 3, true, "00:00:00.000"},
 	}
 	for _, tc := range testcases {
 		value, _, err := decodeTime2(tc.data, tc.dec)


### PR DESCRIPTION
`decodeTime2`/`timeFormat` gated the fractional output on the fraction being nonzero, so a `TIME(N)` with fsp `N > 0` whose microseconds are exactly 0 rendered without the fractional digits — `TIME(2)` `15:04:05` instead of `15:04:05.00`, and `TIME(3)` zero as `00:00:00` instead of `00:00:00.000`.

MySQL's `my_time_to_str` always appends `dec` fractional digits when `dec > 0` (even when the value is 0), and the sibling `decodeDatetime2` already does this — so `decodeTime2` was inconsistent. Gate the fractional output on `dec > 0` instead, and route the zero-time case through `timeFormat` when `dec > 0`. Added test cases; the existing suite still passes.
