### PR TITLE
Add boolean support to result set formatting

### DIFF
--- a/mysql/resultset_helper.go
+++ b/mysql/resultset_helper.go
@@ -44,6 +44,8 @@ func FormatTextValue(value any) ([]byte, error) {
 		return utils.StringToByteSlice(v), nil
 	case time.Time:
 		return utils.StringToByteSlice(v.Format(time.DateTime)), nil
+	case bool:
+		return utils.BoolToByteSlice(v), nil
 	case nil:
 		return nil, nil
 	default:
@@ -89,6 +91,13 @@ func toBinaryDateTime(t time.Time) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+func toBinaryBool(b bool) ([]byte, error) {
+	if b {
+		return []byte{1}, nil
+	}
+	return []byte{0}, nil
+}
+
 // FormatBinaryValue formats a value for binary protocol.
 func FormatBinaryValue(value any) ([]byte, error) {
 	switch v := value.(type) {
@@ -122,6 +131,8 @@ func FormatBinaryValue(value any) ([]byte, error) {
 		return utils.StringToByteSlice(v), nil
 	case time.Time:
 		return toBinaryDateTime(v)
+	case bool:
+		return toBinaryBool(v)
 	default:
 		return nil, errors.Errorf("invalid type %T", value)
 	}
@@ -139,6 +150,8 @@ func fieldType(value any) (typ uint8, err error) {
 		typ = MYSQL_TYPE_VAR_STRING
 	case time.Time:
 		typ = MYSQL_TYPE_DATETIME
+	case bool:
+		typ = MYSQL_TYPE_TINY
 	case nil:
 		typ = MYSQL_TYPE_NULL
 	default:
@@ -160,6 +173,9 @@ func formatField(field *Field, value any) error {
 		field.Flag = BINARY_FLAG | NOT_NULL_FLAG
 	case string, []byte, time.Time:
 		field.Charset = 33
+	case bool:
+		field.Charset = 63
+		field.Flag = BINARY_FLAG | NOT_NULL_FLAG
 	case nil:
 		field.Charset = 33
 	default:

--- a/mysql/resultset_test.go
+++ b/mysql/resultset_test.go
@@ -25,12 +25,13 @@ func TestGetIntNeg(t *testing.T) {
 
 func TestBuildSimpleTextResultsetDistinguishesEmptyValuesFromNull(t *testing.T) {
 	r, err := BuildSimpleTextResultset(
-		[]string{"empty_string", "empty_bytes", "null"},
-		[][]any{{"", []byte{}, nil}},
+		[]string{"empty_string", "empty_bytes", "null", "bool"},
+		[][]any{{"", []byte{}, nil, false}},
 	)
 	require.NoError(t, err)
-	require.Equal(t, RowData{0x00, 0x00, 0xfb}, r.RowDatas[0])
+	require.Equal(t, RowData{0x00, 0x00, 0xfb, 0x5, 0x66, 0x61, 0x6c, 0x73, 0x65}, r.RowDatas[0])
 	require.Equal(t, MYSQL_TYPE_VAR_STRING, r.Fields[0].Type)
 	require.Equal(t, MYSQL_TYPE_VAR_STRING, r.Fields[1].Type)
 	require.Equal(t, MYSQL_TYPE_NULL, r.Fields[2].Type)
+	require.Equal(t, MYSQL_TYPE_TINY, r.Fields[3].Type)
 }

--- a/utils/zeroalloc.go
+++ b/utils/zeroalloc.go
@@ -34,5 +34,4 @@ func BoolToByteSlice(b bool) []byte {
 		return StringToByteSlice("true")
 	}
 	return StringToByteSlice("false")
-
 }

--- a/utils/zeroalloc.go
+++ b/utils/zeroalloc.go
@@ -28,3 +28,11 @@ func Int64ToUint64(val int64) uint64 {
 func Float64ToUint64(val float64) uint64 {
 	return math.Float64bits(val)
 }
+
+func BoolToByteSlice(b bool) []byte {
+	if b {
+		return StringToByteSlice("true")
+	}
+	return StringToByteSlice("false")
+
+}


### PR DESCRIPTION
Add handling for bool values throughout result set formatting. Text formatting now uses utils.BoolToByteSlice ("true"/"false"). Binary formatting encodes bool as 1/0 via toBinaryBool and FormatBinaryValue. fieldType maps bool to MYSQL_TYPE_TINY and formatField sets appropriate charset/flags. Also add BoolToByteSlice helper in utils/zeroalloc.go.