### PR TITLE
ci: restore stable golangci-lint checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          # Keep the Go toolchain compatible with the pinned linter below.
+          go-version: "1.26"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,9 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          # v2.13.1's goimports and gofumpt disagree on mysql/errname.go when
+          # the linter is built with Go 1.27, so no formatting satisfies both.
+          version: v2.12.2
           args: --timeout=3m
 
   platforms:

--- a/replication/binlogsyncer_test.go
+++ b/replication/binlogsyncer_test.go
@@ -88,6 +88,7 @@ func (c *deadlinelessConn) Close() error {
 func (*deadlinelessConn) LocalAddr() net.Addr         { return &net.TCPAddr{} }
 func (*deadlinelessConn) RemoteAddr() net.Addr        { return &net.TCPAddr{} }
 func (*deadlinelessConn) SetDeadline(time.Time) error { return errors.New("deadline not supported") }
+
 func (*deadlinelessConn) SetReadDeadline(time.Time) error {
 	return errors.New("deadline not supported")
 }


### PR DESCRIPTION
## Summary

- add the blank line required by gofumpt between the one-line and multi-line deadline methods
- pin the golangci job to Go 1.26 and golangci-lint v2.12.2 instead of floating on latest
- avoid the v2.13.1 formatter conflict where goimports and gofumpt require incompatible formatting for mysql/errname.go when the linter is built with Go 1.27

## Verification

- official golangci-lint v2.12.2 release binary with Go 1.26: 0 issues
- go test ./replication