### PR TITLE
server: allow CLIENT_FOUND_ROWS to be enabled via SetCapability

### DIFF
--- a/server/server_conf.go
+++ b/server/server_conf.go
@@ -13,7 +13,8 @@ import (
 // userConfigurableServerCapabilities lists handshake flags that may be toggled
 // via SetCapability / UnsetCapability. Other flags (e.g. CLIENT_SSL) are derived
 // from server construction and must not be changed independently.
-const userConfigurableServerCapabilities = mysql.CLIENT_LOCAL_FILES |
+const userConfigurableServerCapabilities = mysql.CLIENT_FOUND_ROWS |
+	mysql.CLIENT_LOCAL_FILES |
 	mysql.CLIENT_MULTI_RESULTS |
 	mysql.CLIENT_PS_MULTI_RESULTS |
 	mysql.CLIENT_DEPRECATE_EOF
@@ -143,9 +144,15 @@ func (s *Server) Capability() uint32 {
 }
 
 // SetCapability enables additional server capabilities advertised in the handshake.
-// Only CLIENT_LOCAL_FILES, CLIENT_MULTI_RESULTS, CLIENT_PS_MULTI_RESULTS, and
-// CLIENT_DEPRECATE_EOF may be set; other flags are managed by server construction
-// (e.g. CLIENT_SSL requires TLS).
+// Only CLIENT_FOUND_ROWS, CLIENT_LOCAL_FILES, CLIENT_MULTI_RESULTS,
+// CLIENT_PS_MULTI_RESULTS, and CLIENT_DEPRECATE_EOF may be set; other flags are
+// managed by server construction (e.g. CLIENT_SSL requires TLS).
+//
+// Advertising a capability does not implement it. CLIENT_FOUND_ROWS, which makes an
+// UPDATE report rows matched instead of rows changed, is up to the Handler: this
+// package never computes affected rows. A Handler honoring it must check
+// (*Conn).HasCapability(mysql.CLIENT_FOUND_ROWS) and set AffectedRows on the
+// mysql.Result it returns accordingly.
 func (s *Server) SetCapability(capability uint32) error {
 	if err := validateUserConfigurableCapability(capability); err != nil {
 		return err
@@ -160,8 +167,8 @@ func (s *Server) SetCapability(capability uint32) error {
 }
 
 // UnsetCapability disables server capabilities advertised in the handshake.
-// Only CLIENT_LOCAL_FILES, CLIENT_MULTI_RESULTS, CLIENT_PS_MULTI_RESULTS, and
-// CLIENT_DEPRECATE_EOF may be cleared via this API.
+// Only CLIENT_FOUND_ROWS, CLIENT_LOCAL_FILES, CLIENT_MULTI_RESULTS,
+// CLIENT_PS_MULTI_RESULTS, and CLIENT_DEPRECATE_EOF may be cleared via this API.
 func (s *Server) UnsetCapability(capability uint32) error {
 	if err := validateUserConfigurableCapability(capability); err != nil {
 		return err
@@ -180,7 +187,7 @@ func validateUserConfigurableCapability(capability uint32) error {
 		return fmt.Errorf("capability must not be zero")
 	}
 	if invalid := capability &^ userConfigurableServerCapabilities; invalid != 0 {
-		return fmt.Errorf("server capability %#x contains non-user-configurable flags %#x; only CLIENT_LOCAL_FILES, CLIENT_MULTI_RESULTS, CLIENT_PS_MULTI_RESULTS, and CLIENT_DEPRECATE_EOF are supported", capability, invalid)
+		return fmt.Errorf("server capability %#x contains non-user-configurable flags %#x; only CLIENT_FOUND_ROWS, CLIENT_LOCAL_FILES, CLIENT_MULTI_RESULTS, CLIENT_PS_MULTI_RESULTS, and CLIENT_DEPRECATE_EOF are supported", capability, invalid)
 	}
 	return nil
 }

--- a/server/server_conf_test.go
+++ b/server/server_conf_test.go
@@ -192,6 +192,92 @@ func TestLocalFilesCapabilityCanBeDisabled(t *testing.T) {
 		"CLIENT_LOCAL_FILES must not be negotiated when the server does not advertise it, got: %s", negotiated)
 }
 
+// TestFoundRowsCapabilityNegotiated verifies that CLIENT_FOUND_ROWS survives handshake
+// negotiation once the server opts in via SetCapability. Clients that mask their
+// requested capabilities against the server's advertised set are otherwise silently
+// downgraded to changed-row UPDATE counts.
+func TestFoundRowsCapabilityNegotiated(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l.Close()
+
+	svr := NewDefaultServer()
+	require.NoError(t, svr.SetCapability(mysql.CLIENT_FOUND_ROWS))
+	authHandler := NewInMemoryAuthenticationHandler()
+	require.NoError(t, authHandler.AddUser("root", ""))
+
+	go func() {
+		conn, acceptErr := l.Accept()
+		if acceptErr != nil {
+			return
+		}
+		sConn, connErr := svr.NewCustomizedConn(conn, authHandler, EmptyHandler{})
+		if connErr != nil {
+			return
+		}
+		for {
+			if handleErr := sConn.HandleCommand(); handleErr != nil {
+				return
+			}
+		}
+	}()
+
+	c, err := client.Connect(l.Addr().String(), "root", "", "",
+		func(conn *client.Conn) error {
+			return conn.SetCapability(mysql.CLIENT_FOUND_ROWS)
+		},
+	)
+	require.NoError(t, err)
+	defer c.Close()
+
+	negotiated := c.CapabilityString()
+	require.Contains(t, negotiated, "CLIENT_FOUND_ROWS",
+		"CLIENT_FOUND_ROWS must be negotiated for matched-row UPDATE counts, got: %s", negotiated)
+}
+
+// TestFoundRowsCapabilityCanBeDisabled verifies that CLIENT_FOUND_ROWS is not advertised
+// by default and is not negotiated unless explicitly enabled via SetCapability. It stays
+// opt-in because honoring it is the Handler's job.
+func TestFoundRowsCapabilityCanBeDisabled(t *testing.T) {
+	svr := NewDefaultServer()
+	require.False(t, svr.Capability()&mysql.CLIENT_FOUND_ROWS != 0)
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l.Close()
+
+	authHandler := NewInMemoryAuthenticationHandler()
+	require.NoError(t, authHandler.AddUser("root", ""))
+
+	go func() {
+		conn, acceptErr := l.Accept()
+		if acceptErr != nil {
+			return
+		}
+		sConn, connErr := svr.NewCustomizedConn(conn, authHandler, EmptyHandler{})
+		if connErr != nil {
+			return
+		}
+		for {
+			if handleErr := sConn.HandleCommand(); handleErr != nil {
+				return
+			}
+		}
+	}()
+
+	c, err := client.Connect(l.Addr().String(), "root", "", "",
+		func(conn *client.Conn) error {
+			return conn.SetCapability(mysql.CLIENT_FOUND_ROWS)
+		},
+	)
+	require.NoError(t, err)
+	defer c.Close()
+
+	negotiated := c.CapabilityString()
+	require.NotContains(t, negotiated, "CLIENT_FOUND_ROWS",
+		"CLIENT_FOUND_ROWS must not be negotiated when the server does not advertise it, got: %s", negotiated)
+}
+
 func TestSetCapabilityRejectsUnsafeFlags(t *testing.T) {
 	svr := NewServer("8.0.12", mysql.DEFAULT_COLLATION_ID, mysql.AUTH_NATIVE_PASSWORD, nil, nil)
 
@@ -214,4 +300,9 @@ func TestSetCapabilityRejectsUnsafeFlags(t *testing.T) {
 	require.True(t, svr.Capability()&mysql.CLIENT_LOCAL_FILES != 0)
 	require.NoError(t, svr.UnsetCapability(mysql.CLIENT_LOCAL_FILES))
 	require.False(t, svr.Capability()&mysql.CLIENT_LOCAL_FILES != 0)
+
+	require.NoError(t, svr.SetCapability(mysql.CLIENT_FOUND_ROWS))
+	require.True(t, svr.Capability()&mysql.CLIENT_FOUND_ROWS != 0)
+	require.NoError(t, svr.UnsetCapability(mysql.CLIENT_FOUND_ROWS))
+	require.False(t, svr.Capability()&mysql.CLIENT_FOUND_ROWS != 0)
 }


### PR DESCRIPTION
CLIENT_FOUND_ROWS decides what an UPDATE's affected-row count means: with it the server reports rows matched, without it rows changed. A no-op UPDATE is 1 under the flag and 0 without, and ORMs read a zero count as "the row is gone" (Hibernate raises StaleStateException).

The server side could not advertise the flag at all: it is on neither capFlag nor the SetCapability allowlist. (*Conn).HasCapability already reports the client's request, because decodeFirstPart records the client capability word unmasked, so a server can see and honor it -- but only for clients that don't mask their request against the server's advertised set. Connector/J does not mask and works; go-sql-driver/mysql does, so clientFoundRows=true is silently downgraded. Advertising the flag fixes it for both.

It is deliberately not added to the default capFlag. Advertising it promises the Handler returns matched-row counts, and existing handlers do not; the same reasoning as #1163 removing CLIENT_LOCAL_FILES from the defaults.