### PR TITLE
mysql: return nil from AsString for NULL fields

### DIFF
--- a/mysql/field.go
+++ b/mysql/field.go
@@ -203,7 +203,11 @@ func (fv *FieldValue) AsFloat64() float64 {
 	return utils.Uint64ToFloat64(fv.value)
 }
 
+// AsString returns the string value as bytes, or nil for NULL.
 func (fv *FieldValue) AsString() []byte {
+	if fv.Type == FieldValueTypeNull {
+		return nil
+	}
 	return fv.str
 }
 

--- a/mysql/rowdata_test.go
+++ b/mysql/rowdata_test.go
@@ -1,0 +1,54 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRowDataParseNullAfterString(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		binary bool
+		str    RowData
+		null   RowData
+		empty  RowData
+	}{
+		{
+			name:  "text",
+			str:   RowData{2, 'i', 'd'},
+			null:  RowData{0xfb},
+			empty: RowData{0},
+		},
+		{
+			name:   "binary",
+			binary: true,
+			str:    RowData{0, 0, 2, 'i', 'd'},
+			null:   RowData{0, 4}, // The first column uses bit 2 of the NULL bitmap.
+			empty:  RowData{0, 0, 0},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fields := []*Field{{Type: MYSQL_TYPE_VAR_STRING}}
+			row, err := tc.str.Parse(fields, tc.binary, nil)
+			require.NoError(t, err)
+			require.Equal(t, []byte("id"), row[0].AsString())
+
+			// Reuse the destination as the client does for pooled result sets.
+			row, err = tc.null.Parse(fields, tc.binary, row)
+			require.NoError(t, err)
+			require.EqualValues(t, FieldValueTypeNull, row[0].Type)
+			require.Nil(t, row[0].Value())
+			require.Nil(t, row[0].AsString())
+
+			row, err = tc.empty.Parse(fields, tc.binary, row)
+			require.NoError(t, err)
+			require.EqualValues(t, FieldValueTypeString, row[0].Type)
+			require.Equal(t, []byte{}, row[0].AsString())
+
+			row, err = tc.str.Parse(fields, tc.binary, row)
+			require.NoError(t, err)
+			require.Equal(t, []byte("id"), row[0].AsString())
+		})
+	}
+}


### PR DESCRIPTION
`FieldValue.AsString()` can return bytes from a previous row when a result set is reused and the new value is NULL. For example, reading `'id'` followed by NULL can leave `Value()` returning nil while `AsString()` still returns `"id"`.

Return nil from `AsString()` for `FieldValueTypeNull`, while retaining the underlying buffer for reuse. Add regression coverage for text and binary rows, including transitions through NULL and an empty string.

Verified with `go test -race ./mysql -count=1`. Also reproduced the original behavior with v1.16.0 and MariaDB 10.6.28, and verified the fix against both query protocols.

Fixes #1189.
